### PR TITLE
fix: avoid changing Job property types through JSON serialization/deserialization #70

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -144,7 +144,7 @@ export class Job {
     }
   }
 
-  toJSON(): JobJson {
+  asJSON(): JobJson {
     return {
       id: this.id,
       name: this.name,
@@ -452,7 +452,7 @@ export class Job {
   private addJob(client: IORedis.Redis): string {
     const queue = this.queue;
 
-    const jobData = this.toJSON();
+    const jobData = this.asJSON();
 
     return Scripts.addJob(client, queue, jobData, this.opts, this.id);
   }

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -144,6 +144,11 @@ export class Job {
     }
   }
 
+  toJSON() {
+    const { queue, ...withoutQueue } = this;
+    return withoutQueue;
+  }
+
   asJSON(): JobJson {
     return {
       id: this.id,

--- a/src/classes/sandbox.ts
+++ b/src/classes/sandbox.ts
@@ -6,7 +6,7 @@ const sandbox = (processFile: any, childPool: any) => {
 
     child.send({
       cmd: 'start',
-      job: job.toJSON(),
+      job: job.asJSON(),
     });
 
     const done = new Promise((resolve, reject) => {

--- a/src/test/test_job.ts
+++ b/src/test/test_job.ts
@@ -67,14 +67,26 @@ describe('Job', function() {
     });
   });
 
-  describe('JSON.stringify', function() {
-    it("retains the data property's type", async function() {
+  describe('JSON.stringify', () => {
+    it('retains property types', async () => {
       const data = { foo: 'bar' };
       const job = await Job.create(queue, 'test', data);
-      expect(JSON.parse(JSON.stringify(job))).to.have.deep.property(
-        'data',
-        data,
-      );
+      job.returnvalue = 1;
+      job.progress = 20;
+      const json = JSON.stringify(job);
+      const parsed = JSON.parse(json);
+      expect(parsed).to.have.deep.property('data', data);
+      expect(parsed).to.have.property('name', 'test');
+      expect(parsed).to.have.property('returnvalue', 1);
+      expect(parsed).to.have.property('progress', 20);
+    });
+
+    it('omits the queue property to avoid a circular json error on node 8', async () => {
+      const data = { foo: 'bar' };
+      const job = await Job.create(queue, 'test', data);
+      const json = JSON.stringify(job);
+      const parsed = JSON.parse(json);
+      expect(parsed).not.to.have.property('queue');
     });
   });
 

--- a/src/test/test_job.ts
+++ b/src/test/test_job.ts
@@ -67,6 +67,17 @@ describe('Job', function() {
     });
   });
 
+  describe('JSON.stringify', function() {
+    it("retains the data property's type", async function() {
+      const data = { foo: 'bar' };
+      const job = await Job.create(queue, 'test', data);
+      expect(JSON.parse(JSON.stringify(job))).to.have.deep.property(
+        'data',
+        data,
+      );
+    });
+  });
+
   describe('.update', function() {
     it('should allow updating job data', async function() {
       const job = await Job.create(queue, 'test', { foo: 'bar' });


### PR DESCRIPTION
renames Job#toJSON to Job#asJSON and adds a test