### PR TITLE
feat: remove dependence on Bluebird and delay #67

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "@types/ioredis": "^4.0.13",
-    "bluebird": "^3.5.3",
     "cron-parser": "^2.7.3",
     "get-port": "^5.0.0",
     "ioredis": "^4.3.0",
@@ -43,7 +42,6 @@
     "@semantic-release/github": "^5.5.4",
     "@semantic-release/npm": "^5.2.0",
     "@semantic-release/release-notes-generator": "^7.3.0",
-    "@types/bluebird": "^3.5.25",
     "@types/chai": "^4.1.7",
     "@types/lodash": "^4.14.119",
     "@types/mocha": "^5.2.5",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "chai": "^4.2.0",
     "copyfiles": "^2.1.1",
     "coveralls": "^3.0.7",
-    "delay": "^4.3.0",
     "husky": "^3.0.3",
     "istanbul": "^0.4.5",
     "mocha": "^6.1.4",

--- a/src/classes/queue-events.ts
+++ b/src/classes/queue-events.ts
@@ -1,6 +1,5 @@
-import { delay } from 'bluebird';
 import { QueueEventsOptions } from '../interfaces';
-import { array2obj } from '../utils';
+import { array2obj, delay } from '../utils';
 import { QueueBase } from './queue-base';
 
 export class QueueEvents extends QueueBase {

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from 'bluebird';
 import fs from 'fs';
 import IORedis from 'ioredis';
 import path from 'path';
@@ -282,16 +281,8 @@ export class Worker extends QueueBase {
     };
 
     const handleFailed = async (err: Error) => {
-      let error = err;
-      if (
-        error instanceof Bluebird.OperationalError &&
-        (<any>error).cause instanceof Error
-      ) {
-        error = (<any>error).cause; // Handle explicit rejection
-      }
-
       await job.moveToFailed(err, token);
-      this.emit('failed', job, error, 'active');
+      this.emit('failed', job, err, 'active');
     };
 
     // TODO: how to cancel the processing? (null -> job.cancel() => throw CancelError()void)

--- a/src/test/fixtures/delay.js
+++ b/src/test/fixtures/delay.js
@@ -1,0 +1,5 @@
+module.exports = function delay(ms) {
+  return new Promise(function(resolve) {
+    return setTimeout(resolve, ms);
+  });
+};

--- a/src/test/fixtures/fixture_processor.js
+++ b/src/test/fixtures/fixture_processor.js
@@ -4,7 +4,7 @@
  */
 'use strict';
 
-const delay = require('delay');
+const delay = require('./delay');
 
 module.exports = function(/*job*/) {
   return delay(500).then(() => {

--- a/src/test/fixtures/fixture_processor_bar.js
+++ b/src/test/fixtures/fixture_processor_bar.js
@@ -4,7 +4,7 @@
  */
 'use strict';
 
-const delay = require('delay');
+const delay = require('./delay');
 
 module.exports = function(/*job*/) {
   return delay(500).then(() => {

--- a/src/test/fixtures/fixture_processor_exit.js
+++ b/src/test/fixtures/fixture_processor_exit.js
@@ -4,7 +4,7 @@
  */
 'use strict';
 
-const delay = require('delay');
+const delay = require('./delay');
 
 module.exports = function(/*job*/) {
   return delay(500).then(() => {

--- a/src/test/fixtures/fixture_processor_fail.js
+++ b/src/test/fixtures/fixture_processor_fail.js
@@ -4,7 +4,7 @@
  */
 'use strict';
 
-const delay = require('delay');
+const delay = require('./delay');
 
 module.exports = function(/*job*/) {
   return delay(500).then(() => {

--- a/src/test/fixtures/fixture_processor_foo.js
+++ b/src/test/fixtures/fixture_processor_foo.js
@@ -4,7 +4,7 @@
  */
 'use strict';
 
-const delay = require('delay');
+const delay = require('./delay');
 
 module.exports = function(/*job*/) {
   return delay(500).then(() => {

--- a/src/test/fixtures/fixture_processor_progress.js
+++ b/src/test/fixtures/fixture_processor_progress.js
@@ -4,7 +4,7 @@
  */
 'use strict';
 
-const delay = require('delay');
+const delay = require('./delay');
 
 module.exports = function(job) {
   return delay(50)

--- a/src/test/fixtures/fixture_processor_slow.js
+++ b/src/test/fixtures/fixture_processor_slow.js
@@ -4,7 +4,7 @@
  */
 'use strict';
 
-const delay = require('delay');
+const delay = require('./delay');
 
 module.exports = function(/*job*/) {
   return delay(1000).then(() => {

--- a/src/test/test_clean.ts
+++ b/src/test/test_clean.ts
@@ -1,5 +1,5 @@
 import { Queue, QueueEvents, Worker } from '../classes';
-import delay from 'delay';
+import { delay } from '@src/utils';
 import { expect } from 'chai';
 import IORedis from 'ioredis';
 import { after } from 'lodash';

--- a/src/test/test_clean.ts
+++ b/src/test/test_clean.ts
@@ -1,5 +1,5 @@
 import { Queue, QueueEvents, Worker } from '../classes';
-import { delay } from 'bluebird';
+import delay from 'delay';
 import { expect } from 'chai';
 import IORedis from 'ioredis';
 import { after } from 'lodash';

--- a/src/test/test_compat.ts
+++ b/src/test/test_compat.ts
@@ -4,7 +4,7 @@
 
 import { Job, Worker } from '@src/classes';
 import { Queue3 } from '@src/classes/compat';
-import { delay } from 'bluebird';
+import delay from 'delay';
 import { expect } from 'chai';
 import IORedis from 'ioredis';
 import { after } from 'lodash';

--- a/src/test/test_compat.ts
+++ b/src/test/test_compat.ts
@@ -4,7 +4,7 @@
 
 import { Job, Worker } from '@src/classes';
 import { Queue3 } from '@src/classes/compat';
-import delay from 'delay';
+import { delay } from '@src/utils';
 import { expect } from 'chai';
 import IORedis from 'ioredis';
 import { after } from 'lodash';

--- a/src/test/test_job.ts
+++ b/src/test/test_job.ts
@@ -5,7 +5,7 @@ import { Job, Queue, QueueScheduler } from '@src/classes';
 import { QueueEvents } from '@src/classes/queue-events';
 import { Worker } from '@src/classes/worker';
 import { JobsOptions } from '@src/interfaces';
-import delay from 'delay';
+import { delay } from '@src/utils';
 import { expect } from 'chai';
 import IORedis from 'ioredis';
 import { after } from 'lodash';

--- a/src/test/test_job.ts
+++ b/src/test/test_job.ts
@@ -5,7 +5,7 @@ import { Job, Queue, QueueScheduler } from '@src/classes';
 import { QueueEvents } from '@src/classes/queue-events';
 import { Worker } from '@src/classes/worker';
 import { JobsOptions } from '@src/interfaces';
-import { delay } from 'bluebird';
+import delay from 'delay';
 import { expect } from 'chai';
 import IORedis from 'ioredis';
 import { after } from 'lodash';

--- a/src/test/test_pause.ts
+++ b/src/test/test_pause.ts
@@ -5,8 +5,7 @@ import { expect } from 'chai';
 import IORedis from 'ioredis';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
-
-const delay = require('delay');
+import { delay } from '@src/utils';
 
 describe('Pause', function() {
   let queue: Queue;

--- a/src/test/test_sandboxed_process.ts
+++ b/src/test/test_sandboxed_process.ts
@@ -1,12 +1,11 @@
 import { expect } from 'chai';
 import IORedis from 'ioredis';
 import { after } from 'lodash';
-import { Queue, QueueEvents, Worker } from '@src/classes';
+import { Queue, QueueEvents, Worker, pool } from '@src/classes';
 import { beforeEach } from 'mocha';
 import { v4 } from 'uuid';
-const delay = require('delay');
+import { delay } from '@src/utils';
 const pReflect = require('p-reflect');
-const pool = require('../classes/child-pool').pool;
 
 describe('sandboxed process', () => {
   let queue: Queue;

--- a/src/test/test_stalled_jobs.ts
+++ b/src/test/test_stalled_jobs.ts
@@ -1,5 +1,5 @@
 import { Queue, QueueScheduler, Worker, QueueEvents } from '@src/classes';
-import delay from 'delay';
+import { delay } from '@src/utils';
 import IORedis from 'ioredis';
 import { after } from 'lodash';
 import { beforeEach, describe, it } from 'mocha';

--- a/src/test/test_stalled_jobs.ts
+++ b/src/test/test_stalled_jobs.ts
@@ -1,5 +1,5 @@
 import { Queue, QueueScheduler, Worker, QueueEvents } from '@src/classes';
-import { delay } from 'bluebird';
+import delay from 'delay';
 import IORedis from 'ioredis';
 import { after } from 'lodash';
 import { beforeEach, describe, it } from 'mocha';

--- a/src/test/test_worker.ts
+++ b/src/test/test_worker.ts
@@ -3,7 +3,7 @@ import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
 import IORedis from 'ioredis';
 import { v4 } from 'uuid';
-import { delay } from 'bluebird';
+import delay from 'delay';
 import { after, times, once } from 'lodash';
 import { RetryErrors } from '@src/enums';
 import * as sinon from 'sinon';

--- a/src/test/test_worker.ts
+++ b/src/test/test_worker.ts
@@ -3,7 +3,7 @@ import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
 import IORedis from 'ioredis';
 import { v4 } from 'uuid';
-import delay from 'delay';
+import { delay } from '@src/utils';
 import { after, times, once } from 'lodash';
 import { RetryErrors } from '@src/enums';
 import * as sinon from 'sinon';
@@ -685,7 +685,7 @@ describe('workers', function() {
       if (addedJob.id !== job.id) {
         err = new Error('Processed job id does not match that of added job');
       }
-      delay(500);
+      await delay(500);
     });
 
     await worker.waitUntilReady();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,3 +26,9 @@ export function array2obj(arr: string[]) {
   }
   return obj;
 }
+
+export function delay(ms: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(() => resolve(), ms);
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1492,11 +1492,6 @@ define-properties@^1.1.1, define-properties@^1.1.2, define-properties@^1.1.3:
   dependencies:
     object-keys "^1.0.12"
 
-delay@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/delay/-/delay-4.3.0.tgz#efeebfb8f545579cb396b3a722443ec96d14c50e"
-  integrity sha512-Lwaf3zVFDMBop1yDuFZ19F9WyGcZcGacsbdlZtWjQmM50tOcMntm1njF/Nb/Vjij3KaSvCF+sEYGKrrjObu2NA==
-
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"

--- a/yarn.lock
+++ b/yarn.lock
@@ -428,11 +428,6 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@types/bluebird@^3.5.25":
-  version "3.5.28"
-  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.28.tgz#04c1a520ff076649236bc8ca21198542ce2bdb09"
-  integrity sha512-0Vk/kqkukxPKSzP9c8WJgisgGDx5oZDbsLLWIP5t70yThO/YleE+GEm2S1GlRALTaack3O7U5OS5qEm7q2kciA==
-
 "@types/chai@^4.1.7":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.3.tgz#419477a3d5202bad19e14c787940a61dc9ea6407"


### PR DESCRIPTION
This approach uses a simple setTimeout-based delay in the only production
usage (src/classes/queue-events.ts), defined in src/util.ts, and since
there was already a devDependency on a library called
[delay](https://www.npmjs.com/package/delay), this commit uses that in
test contexts. It should be easy to replace that dep with a
`(ms:number) => new Promise(r => setTimeout(r, ms))` as well.

Closes #67