### PR TITLE
fix: check of existing redis instance

### DIFF
--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -3,6 +3,7 @@ import IORedis, { Redis } from 'ioredis';
 import * as semver from 'semver';
 import { load } from '../commands';
 import { ConnectionOptions, RedisOptions } from '../interfaces';
+import { isRedisInstance } from '../utils';
 
 export class RedisConnection extends EventEmitter {
   static minimumVersion = '5.0.0';
@@ -13,7 +14,7 @@ export class RedisConnection extends EventEmitter {
   constructor(private opts?: ConnectionOptions) {
     super();
 
-    if (!(opts instanceof IORedis)) {
+    if (!isRedisInstance(opts)) {
       this.opts = {
         port: 6379,
         host: '127.0.0.1',
@@ -23,7 +24,7 @@ export class RedisConnection extends EventEmitter {
         ...opts,
       };
     } else {
-      this._client = opts;
+      this._client = <Redis>opts;
     }
 
     this.initializing = this.init();

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import IORedis from 'ioredis';
+import { Redis } from 'ioredis';
 import path from 'path';
 import { Processor, WorkerOptions } from '../interfaces';
 import { QueueBase, Repeat } from './';
@@ -10,6 +10,7 @@ import sandbox from './sandbox';
 import { Scripts } from './scripts';
 import uuid from 'uuid';
 import { TimerManager } from './timer-manager';
+import { isRedisInstance } from '../utils';
 
 // note: sandboxed processors would also like to define concurrency per process
 // for better resource utilization.
@@ -51,8 +52,8 @@ export class Worker<T = any> extends QueueBase {
       this.opts.lockRenewTime || this.opts.lockDuration / 2;
 
     this.blockingConnection = new RedisConnection(
-      opts instanceof IORedis
-        ? (<IORedis.Redis>opts.connection).duplicate()
+      isRedisInstance(opts.connection)
+        ? (<Redis>opts.connection).duplicate()
         : opts.connection,
     );
     this.blockingConnection.on('error', this.emit.bind(this));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,3 +32,11 @@ export function delay(ms: number): Promise<void> {
     setTimeout(() => resolve(), ms);
   });
 }
+
+export function isRedisInstance(obj: any): boolean {
+  if (!obj) {
+    return false;
+  }
+  const redisApi = ['connect', 'disconnect', 'duplicate'];
+  return redisApi.every(name => typeof obj[name] === 'function');
+}


### PR DESCRIPTION
Should fix #90.


I changed 2 things:
- In worker.ts, the blocking connection was not duplicated because the condition did not use `opts.connection` but `opts`
- In worker.ts and redis-connection.ts, the condition used to check that it was a Redis instance was using `instanceof` which is not totally reliable depending on the environnement (if multiple instance of the package `ioredis` exist through the app, it will not work)
