### PR TITLE
[fix] Remove duplicate active entry

### DIFF
--- a/src/classes/queue-base.ts
+++ b/src/classes/queue-base.ts
@@ -27,7 +27,6 @@ export class QueueBase extends EventEmitter {
       'waiting',
       'paused',
       'resumed',
-      'active',
       'id',
       'delayed',
       'priority',


### PR DESCRIPTION
Noticed that `active` was in the keys list twice for events. I understand that functionally this does not affect anything but figured it was still good to clean up.