### PR TITLE
fix: get rid of flushdb/flushall in tests

### DIFF
--- a/src/classes/compat.ts
+++ b/src/classes/compat.ts
@@ -70,6 +70,9 @@ export class Queue3<T = any> extends EventEmitter {
    */
   async isReady(): Promise<this> {
     await this.queue.client;
+    if (this.queueEvents) {
+      await this.queueEvents.client;
+    }
     return this;
   }
 

--- a/src/classes/queue-events.ts
+++ b/src/classes/queue-events.ts
@@ -3,8 +3,6 @@ import { array2obj, delay } from '../utils';
 import { QueueBase } from './queue-base';
 
 export class QueueEvents extends QueueBase {
-  consuming: Promise<void>;
-
   constructor(name: string, opts?: QueueEventsOptions) {
     super(name, opts);
 
@@ -15,8 +13,7 @@ export class QueueEvents extends QueueBase {
       this.opts,
     );
 
-    // tslint:disable: no-floating-promises
-    this.consumeEvents().catch(err => this.emit('error'));
+    this.consumeEvents().catch(err => this.emit('error', err));
   }
 
   private async consumeEvents() {

--- a/src/test/test_bulk.ts
+++ b/src/test/test_bulk.ts
@@ -3,16 +3,11 @@ import { expect } from 'chai';
 import IORedis from 'ioredis';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
+import { removeAllQueueData } from '../utils';
 
 describe('bulk jobs', () => {
   let queue: Queue;
   let queueName: string;
-  let client: IORedis.Redis;
-
-  beforeEach(function() {
-    client = new IORedis();
-    return client.flushdb();
-  });
 
   beforeEach(async function() {
     queueName = 'test-' + v4();
@@ -21,7 +16,7 @@ describe('bulk jobs', () => {
 
   afterEach(async function() {
     await queue.close();
-    return client.quit();
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should process jobs', async () => {

--- a/src/test/test_clean.ts
+++ b/src/test/test_clean.ts
@@ -1,5 +1,5 @@
 import { Queue, QueueEvents, Worker } from '../classes';
-import { delay } from '@src/utils';
+import { delay, removeAllQueueData } from '@src/utils';
 import { expect } from 'chai';
 import IORedis from 'ioredis';
 import { after } from 'lodash';
@@ -10,24 +10,18 @@ describe('Cleaner', () => {
   let queue: Queue;
   let queueEvents: QueueEvents;
   let queueName: string;
-  let client: IORedis.Redis;
-
-  beforeEach(function() {
-    client = new IORedis();
-    return client.flushdb();
-  });
 
   beforeEach(async function() {
     queueName = 'test-' + v4();
     queue = new Queue(queueName);
     queueEvents = new QueueEvents(queueName);
-    return queueEvents.waitUntilReady();
+    await queueEvents.waitUntilReady();
   });
 
   afterEach(async function() {
     await queue.close();
     await queueEvents.close();
-    return client.quit();
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should clean an empty queue', async () => {

--- a/src/test/test_connection.ts
+++ b/src/test/test_connection.ts
@@ -3,27 +3,20 @@ import { Queue, QueueEvents, Job, Worker } from '@src/classes';
 
 import { v4 } from 'uuid';
 import { expect } from 'chai';
+import { removeAllQueueData } from '@src/utils';
 
 describe('connection', () => {
   let queue: Queue;
   let queueName: string;
-  let client: IORedis.Redis;
 
-  beforeEach(function() {
-    client = new IORedis();
-    return client.flushdb();
-  });
-
-  beforeEach(function() {
+  beforeEach(async function() {
     queueName = 'test-' + v4();
-    queue = new Queue(queueName, {
-      connection: { port: 6379, host: '127.0.0.1' },
-    });
+    queue = new Queue(queueName);
   });
 
   afterEach(async () => {
-    await client.quit();
     await queue.close();
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should recover from a connection loss', async () => {

--- a/src/test/test_delay.ts
+++ b/src/test/test_delay.ts
@@ -6,18 +6,13 @@ import { v4 } from 'uuid';
 import { Worker } from '@src/classes/worker';
 import { QueueEvents } from '@src/classes/queue-events';
 import { QueueScheduler } from '@src/classes/queue-scheduler';
+import { removeAllQueueData } from '@src/utils';
 
 describe('Delayed jobs', function() {
   this.timeout(15000);
 
   let queue: Queue;
   let queueName: string;
-  let client: IORedis.Redis;
-
-  beforeEach(function() {
-    client = new IORedis();
-    return client.flushdb();
-  });
 
   beforeEach(async function() {
     queueName = 'test-' + v4();
@@ -26,7 +21,7 @@ describe('Delayed jobs', function() {
 
   afterEach(async function() {
     await queue.close();
-    return client.quit();
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should process a delayed job only after delayed time', async function() {

--- a/src/test/test_getters.ts
+++ b/src/test/test_getters.ts
@@ -9,28 +9,21 @@ import IORedis from 'ioredis';
 import { v4 } from 'uuid';
 import { Worker } from '@src/classes/worker';
 import { after } from 'lodash';
+import { removeAllQueueData } from '@src/utils';
 
 describe('Jobs getters', function() {
   this.timeout(4000);
   let queue: Queue;
   let queueName: string;
-  let client: IORedis.Redis;
-
-  beforeEach(function() {
-    client = new IORedis();
-    return client.flushdb();
-  });
 
   beforeEach(async function() {
     queueName = 'test-' + v4();
-    queue = new Queue(queueName, {
-      connection: { port: 6379, host: '127.0.0.1' },
-    });
+    queue = new Queue(queueName);
   });
 
   afterEach(async function() {
     await queue.close();
-    return client.quit();
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should get waiting jobs', async function() {

--- a/src/test/test_job.ts
+++ b/src/test/test_job.ts
@@ -5,7 +5,7 @@ import { Job, Queue, QueueScheduler } from '@src/classes';
 import { QueueEvents } from '@src/classes/queue-events';
 import { Worker } from '@src/classes/worker';
 import { JobsOptions } from '@src/interfaces';
-import { delay } from '@src/utils';
+import { delay, removeAllQueueData } from '@src/utils';
 import { expect } from 'chai';
 import IORedis from 'ioredis';
 import { after } from 'lodash';
@@ -15,23 +15,15 @@ import { v4 } from 'uuid';
 describe('Job', function() {
   let queue: Queue;
   let queueName: string;
-  let client: IORedis.Redis;
 
-  beforeEach(function() {
-    client = new IORedis();
-    return client.flushdb();
-  });
-
-  beforeEach(function() {
+  beforeEach(async function() {
     queueName = 'test-' + v4();
-    queue = new Queue(queueName, {
-      connection: { port: 6379, host: '127.0.0.1' },
-    });
+    queue = new Queue(queueName);
   });
 
   afterEach(async () => {
     await queue.close();
-    return client.quit();
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   describe('.create', function() {
@@ -457,7 +449,7 @@ describe('Job', function() {
 
     beforeEach(async function() {
       queueEvents = new QueueEvents(queueName);
-      return queueEvents.waitUntilReady();
+      await queueEvents.waitUntilReady();
     });
 
     afterEach(async function() {

--- a/src/test/test_pause.ts
+++ b/src/test/test_pause.ts
@@ -5,18 +5,12 @@ import { expect } from 'chai';
 import IORedis from 'ioredis';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
-import { delay } from '@src/utils';
+import { delay, removeAllQueueData } from '@src/utils';
 
 describe('Pause', function() {
   let queue: Queue;
   let queueName: string;
   let queueEvents: QueueEvents;
-  let client: IORedis.Redis;
-
-  beforeEach(function() {
-    client = new IORedis();
-    return client.flushdb();
-  });
 
   beforeEach(async function() {
     queueName = 'test-' + v4();
@@ -28,7 +22,7 @@ describe('Pause', function() {
   afterEach(async function() {
     await queue.close();
     await queueEvents.close();
-    return client.quit();
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   // Skipped since some side effect makes this test fail

--- a/src/test/test_queue.ts
+++ b/src/test/test_queue.ts
@@ -13,11 +13,9 @@ describe('Queue', function() {
   let queue: Queue;
   let queueName: string;
   let queueEvents: QueueEvents;
-  let client: IORedis.Redis;
 
   beforeEach(function() {
     client = new IORedis();
-    return client.flushdb();
   });
 
   beforeEach(async function() {
@@ -30,7 +28,7 @@ describe('Queue', function() {
   afterEach(async function() {
     await queue.close();
     await queueEvents.close();
-    return client.quit();
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('creates a queue with default job options', () => {

--- a/src/test/test_rate_limiter.ts
+++ b/src/test/test_rate_limiter.ts
@@ -7,17 +7,12 @@ import IORedis from 'ioredis';
 import { after } from 'lodash';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
+import { removeAllQueueData } from '@src/utils';
 
 describe('Rate Limiter', function() {
   let queue: Queue;
   let queueName: string;
   let queueEvents: QueueEvents;
-  let client: IORedis.Redis;
-
-  beforeEach(function() {
-    client = new IORedis();
-    return client.flushdb();
-  });
 
   beforeEach(async function() {
     queueName = 'test-' + v4();
@@ -29,7 +24,7 @@ describe('Rate Limiter', function() {
   afterEach(async function() {
     await queue.close();
     await queueEvents.close();
-    return client.quit();
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should put a job into the delayed queue when limit is hit', async () => {

--- a/src/test/test_repeat.ts
+++ b/src/test/test_repeat.ts
@@ -8,6 +8,7 @@ import IORedis from 'ioredis';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
 import { defaults } from 'lodash';
+import { removeAllQueueData } from '@src/utils';
 
 const sinon = require('sinon');
 const moment = require('moment');
@@ -26,12 +27,9 @@ describe('repeat', function() {
   let queue: Queue;
   let queueEvents: QueueEvents;
   let queueName: string;
-  let client: IORedis.Redis;
 
   beforeEach(function() {
     this.clock = sinon.useFakeTimers();
-    client = new IORedis();
-    return client.flushdb();
   });
 
   beforeEach(async function() {
@@ -39,7 +37,7 @@ describe('repeat', function() {
     queue = new Queue(queueName);
     repeat = new Repeat(queueName);
     queueEvents = new QueueEvents(queueName);
-    return queueEvents.waitUntilReady();
+    await queueEvents.waitUntilReady();
   });
 
   afterEach(async function() {
@@ -47,7 +45,7 @@ describe('repeat', function() {
     await queue.close();
     await repeat.close();
     await queueEvents.close();
-    return client.quit();
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should create multiple jobs if they have the same cron pattern', async function() {

--- a/src/test/test_sandboxed_process.ts
+++ b/src/test/test_sandboxed_process.ts
@@ -4,33 +4,26 @@ import { after } from 'lodash';
 import { Queue, QueueEvents, Worker, pool } from '@src/classes';
 import { beforeEach } from 'mocha';
 import { v4 } from 'uuid';
-import { delay } from '@src/utils';
+import { delay, removeAllQueueData } from '@src/utils';
 const pReflect = require('p-reflect');
 
 describe('sandboxed process', () => {
   let queue: Queue;
   let queueEvents: QueueEvents;
   let queueName: string;
-  let client: IORedis.Redis;
 
-  beforeEach(() => {
-    client = new IORedis();
-    return client.flushdb();
-  });
-
-  beforeEach(async () => {
+  beforeEach(async function() {
     queueName = 'test-' + v4();
     queue = new Queue(queueName);
     queueEvents = new QueueEvents(queueName);
-    return queueEvents.waitUntilReady();
+    await queueEvents.waitUntilReady();
   });
 
   afterEach(async () => {
     await queue.close();
     await queueEvents.close();
-    await client.flushall();
     pool.clean();
-    return client.quit();
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should process and complete', async () => {

--- a/src/test/test_stalled_jobs.ts
+++ b/src/test/test_stalled_jobs.ts
@@ -1,5 +1,5 @@
 import { Queue, QueueScheduler, Worker, QueueEvents } from '@src/classes';
-import { delay } from '@src/utils';
+import { delay, removeAllQueueData } from '@src/utils';
 import IORedis from 'ioredis';
 import { after } from 'lodash';
 import { beforeEach, describe, it } from 'mocha';
@@ -9,12 +9,6 @@ import { expect } from 'chai';
 describe('stalled jobs', function() {
   let queue: Queue;
   let queueName: string;
-  let client: IORedis.Redis;
-
-  beforeEach(function() {
-    client = new IORedis();
-    return client.flushdb();
-  });
 
   beforeEach(async function() {
     queueName = 'test-' + v4();
@@ -23,7 +17,7 @@ describe('stalled jobs', function() {
 
   afterEach(async function() {
     await queue.close();
-    return client.quit();
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('process stalled jobs when starting a queue', async function() {

--- a/src/test/test_worker.ts
+++ b/src/test/test_worker.ts
@@ -3,7 +3,7 @@ import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
 import IORedis from 'ioredis';
 import { v4 } from 'uuid';
-import { delay } from '@src/utils';
+import { delay, removeAllQueueData } from '@src/utils';
 import { after, times, once } from 'lodash';
 import { RetryErrors } from '@src/enums';
 import * as sinon from 'sinon';
@@ -14,25 +14,19 @@ describe('workers', function() {
   let queue: Queue;
   let queueEvents: QueueEvents;
   let queueName: string;
-  let client: IORedis.Redis;
-
-  beforeEach(function() {
-    client = new IORedis();
-    return client.flushdb();
-  });
 
   beforeEach(async function() {
     queueName = 'test-' + v4();
     queue = new Queue(queueName);
     queueEvents = new QueueEvents(queueName);
-    return queueEvents.waitUntilReady();
+    await queueEvents.waitUntilReady();
   });
 
   afterEach(async function() {
     sandbox.restore();
     await queue.close();
     await queueEvents.close();
-    return client.quit();
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should get all workers for this queue', async function() {


### PR DESCRIPTION
Replace flushdb with direct queue keys removal.
Fix unstable test (looks like it started to fail on my env after 3c5b01d1).
Fixes #102 