### PR TITLE
feat(types): add sandboxed job processor types

### DIFF
--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -6,4 +6,6 @@ export * from './queue-scheduler-options';
 export * from './rate-limiter-options';
 export * from './redis-options';
 export * from './repeat-options';
+export * from './sandboxed-job-processor';
+export * from './sandboxed-job';
 export * from './worker-options';

--- a/src/interfaces/sandboxed-job-processor.ts
+++ b/src/interfaces/sandboxed-job-processor.ts
@@ -1,0 +1,8 @@
+import { SandboxedJob } from './sandboxed-job';
+
+export type SandboxedJobProcessor<T = any, R = any> =
+  | ((job: SandboxedJob<T, R>) => R | PromiseLike<R>)
+  | ((
+      job: SandboxedJob<T, R>,
+      callback: (error: unknown, result: R) => void,
+    ) => void);

--- a/src/interfaces/sandboxed-job.ts
+++ b/src/interfaces/sandboxed-job.ts
@@ -1,0 +1,13 @@
+import { JobJson } from '../classes/job';
+import { JobsOptions } from './jobs-options';
+
+export interface SandboxedJob<T = any, R = any>
+  extends Omit<JobJson, 'data' | 'opts' | 'progress' | 'log' | 'returnValue'> {
+  data: T;
+  opts: JobsOptions;
+  progress:
+    | (() => object | number)
+    | ((value: object | number) => Promise<void>);
+  log: (row: any) => void;
+  returnValue: R;
+}


### PR DESCRIPTION
At first: I don't know what's the PR format, I just wanted to make working with this library a little less frustrating by adding processor types.

So with this change you can write your processors like:
```typescript
const processor: SandboxedJobProcessor<string> = async (job) => {
    job.progress(0);
    // do some stuff with `job.data` or smth...
    job.progress(100);
    return 'done';
};
export default processor;
```