### PR TITLE
fix: modified imports to work when esModuleInterop is disabled

### DIFF
--- a/src/classes/child-pool.ts
+++ b/src/classes/child-pool.ts
@@ -1,12 +1,11 @@
-import childProcess, { ChildProcess } from 'child_process';
-import path from 'path';
+import { ChildProcess, fork } from 'child_process';
+import * as path from 'path';
 import { forEach, values, flatten } from 'lodash';
-import getPort from 'get-port';
-import fs from 'fs';
+import * as getPort from 'get-port';
+import * as fs from 'fs';
 import { promisify } from 'util';
 
 const stat = promisify(fs.stat);
-const fork = childProcess.fork;
 
 export interface ChildProcessExt extends ChildProcess {
   processFile?: string;

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -1,4 +1,4 @@
-import * as Redis from 'ioredis';
+import { Redis, Pipeline } from 'ioredis';
 import { debuglog } from 'util';
 import { RetryErrors } from '../enums';
 import { BackoffOptions, JobsOptions, WorkerOptions } from '../interfaces';
@@ -92,7 +92,7 @@ export class Job<T = any, R = any> {
     const multi = client.multi();
 
     for (const job of jobInstances) {
-      job.addJob(<Redis.Redis>(multi as unknown));
+      job.addJob(<Redis>(multi as unknown));
     }
 
     const result = (await multi.exec()) as [null | Error, string][];
@@ -454,7 +454,7 @@ export class Job<T = any, R = any> {
     );
   }
 
-  private addJob(client: Redis.Redis): string {
+  private addJob(client: Redis): string {
     const queue = this.queue;
 
     const jobData = this.asJSON();
@@ -462,7 +462,7 @@ export class Job<T = any, R = any> {
     return Scripts.addJob(client, queue, jobData, this.opts, this.id);
   }
 
-  private saveAttempt(multi: Redis.Pipeline, err: Error) {
+  private saveAttempt(multi: Pipeline, err: Error) {
     this.attemptsMade++;
     this.stacktrace = this.stacktrace || [];
 

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -1,4 +1,4 @@
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 import { debuglog } from 'util';
 import { RetryErrors } from '../enums';
 import { BackoffOptions, JobsOptions, WorkerOptions } from '../interfaces';
@@ -92,7 +92,7 @@ export class Job<T = any, R = any> {
     const multi = client.multi();
 
     for (const job of jobInstances) {
-      job.addJob(<IORedis.Redis>(multi as unknown));
+      job.addJob(<Redis.Redis>(multi as unknown));
     }
 
     const result = (await multi.exec()) as [null | Error, string][];
@@ -454,7 +454,7 @@ export class Job<T = any, R = any> {
     );
   }
 
-  private addJob(client: IORedis.Redis): string {
+  private addJob(client: Redis.Redis): string {
     const queue = this.queue;
 
     const jobData = this.asJSON();
@@ -462,7 +462,7 @@ export class Job<T = any, R = any> {
     return Scripts.addJob(client, queue, jobData, this.opts, this.id);
   }
 
-  private saveAttempt(multi: IORedis.Pipeline, err: Error) {
+  private saveAttempt(multi: Redis.Pipeline, err: Error) {
     this.attemptsMade++;
     this.stacktrace = this.stacktrace || [];
 

--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import * as Redis from 'ioredis';
+import * as IORedis from 'ioredis';
 import * as semver from 'semver';
 import { load } from '../commands';
 import { ConnectionOptions, RedisOptions } from '../interfaces';
@@ -7,8 +7,8 @@ import { isRedisInstance } from '../utils';
 
 export class RedisConnection extends EventEmitter {
   static minimumVersion = '5.0.0';
-  private _client: Redis.Redis;
-  private initializing: Promise<Redis.Redis>;
+  private _client: IORedis.Redis;
+  private initializing: Promise<IORedis.Redis>;
   private closing: boolean;
 
   constructor(private opts?: ConnectionOptions) {
@@ -24,7 +24,7 @@ export class RedisConnection extends EventEmitter {
         ...opts,
       };
     } else {
-      this._client = <Redis.Redis>opts;
+      this._client = <IORedis.Redis>opts;
     }
 
     this.initializing = this.init();
@@ -38,7 +38,7 @@ export class RedisConnection extends EventEmitter {
    * Waits for a redis client to be ready.
    * @param {Redis} redis client
    */
-  static async waitUntilReady(client: Redis.Redis) {
+  static async waitUntilReady(client: IORedis.Redis) {
     return new Promise(function(resolve, reject) {
       if (client.status === 'ready') {
         resolve();
@@ -60,14 +60,14 @@ export class RedisConnection extends EventEmitter {
     });
   }
 
-  get client(): Promise<Redis.Redis> {
+  get client(): Promise<IORedis.Redis> {
     return this.initializing;
   }
 
   private async init() {
     const opts = this.opts as RedisOptions;
     if (!this._client) {
-      this._client = new Redis(opts);
+      this._client = new IORedis(opts);
     }
 
     await RedisConnection.waitUntilReady(this._client);

--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import IORedis, { Redis } from 'ioredis';
+import * as Redis from 'ioredis';
 import * as semver from 'semver';
 import { load } from '../commands';
 import { ConnectionOptions, RedisOptions } from '../interfaces';
@@ -7,8 +7,8 @@ import { isRedisInstance } from '../utils';
 
 export class RedisConnection extends EventEmitter {
   static minimumVersion = '5.0.0';
-  private _client: Redis;
-  private initializing: Promise<Redis>;
+  private _client: Redis.Redis;
+  private initializing: Promise<Redis.Redis>;
   private closing: boolean;
 
   constructor(private opts?: ConnectionOptions) {
@@ -24,7 +24,7 @@ export class RedisConnection extends EventEmitter {
         ...opts,
       };
     } else {
-      this._client = <Redis>opts;
+      this._client = <Redis.Redis>opts;
     }
 
     this.initializing = this.init();
@@ -38,7 +38,7 @@ export class RedisConnection extends EventEmitter {
    * Waits for a redis client to be ready.
    * @param {Redis} redis client
    */
-  static async waitUntilReady(client: IORedis.Redis) {
+  static async waitUntilReady(client: Redis.Redis) {
     return new Promise(function(resolve, reject) {
       if (client.status === 'ready') {
         resolve();
@@ -60,14 +60,14 @@ export class RedisConnection extends EventEmitter {
     });
   }
 
-  get client(): Promise<Redis> {
+  get client(): Promise<Redis.Redis> {
     return this.initializing;
   }
 
   private async init() {
     const opts = this.opts as RedisOptions;
     if (!this._client) {
-      this._client = new IORedis(opts);
+      this._client = new Redis(opts);
     }
 
     await RedisConnection.waitUntilReady(this._client);

--- a/src/classes/timer-manager.ts
+++ b/src/classes/timer-manager.ts
@@ -1,4 +1,4 @@
-import uuid from 'uuid';
+import * as uuid from 'uuid';
 
 /**
  * Keeps track on timers created with setTimeout to help clearTimeout

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import { Redis } from 'ioredis';
-import path from 'path';
+import * as fs from 'fs';
+import * as Redis from 'ioredis';
+import * as path from 'path';
 import { Processor, WorkerOptions } from '../interfaces';
 import { QueueBase, Repeat } from './';
 import { ChildPool, pool } from './child-pool';
@@ -8,7 +8,7 @@ import { Job } from './job';
 import { RedisConnection } from './redis-connection';
 import sandbox from './sandbox';
 import { Scripts } from './scripts';
-import uuid from 'uuid';
+import * as uuid from 'uuid';
 import { TimerManager } from './timer-manager';
 import { isRedisInstance } from '../utils';
 
@@ -53,7 +53,7 @@ export class Worker<T = any> extends QueueBase {
 
     this.blockingConnection = new RedisConnection(
       isRedisInstance(opts.connection)
-        ? (<Redis>opts.connection).duplicate()
+        ? (<Redis.Redis>opts.connection).duplicate()
         : opts.connection,
     );
     this.blockingConnection.on('error', this.emit.bind(this));

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import * as Redis from 'ioredis';
+import { Redis } from 'ioredis';
 import * as path from 'path';
 import { Processor, WorkerOptions } from '../interfaces';
 import { QueueBase, Repeat } from './';
@@ -53,7 +53,7 @@ export class Worker<T = any> extends QueueBase {
 
     this.blockingConnection = new RedisConnection(
       isRedisInstance(opts.connection)
-        ? (<Redis.Redis>opts.connection).duplicate()
+        ? (<Redis>opts.connection).duplicate()
         : opts.connection,
     );
     this.blockingConnection.on('error', this.emit.bind(this));

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -12,7 +12,7 @@
  */
 'use strict';
 
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 
 const path = require('path');
 const util = require('util');
@@ -30,7 +30,7 @@ interface Command {
   };
 }
 
-export const load = async function(client: IORedis.Redis) {
+export const load = async function(client: Redis.Redis) {
   const scripts = await loadScripts(__dirname);
 
   scripts.forEach((command: Command) => {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -12,7 +12,7 @@
  */
 'use strict';
 
-import * as Redis from 'ioredis';
+import { Redis } from 'ioredis';
 
 const path = require('path');
 const util = require('util');
@@ -30,7 +30,7 @@ interface Command {
   };
 }
 
-export const load = async function(client: Redis.Redis) {
+export const load = async function(client: Redis) {
   const scripts = await loadScripts(__dirname);
 
   scripts.forEach((command: Command) => {

--- a/src/interfaces/queue-options.ts
+++ b/src/interfaces/queue-options.ts
@@ -1,6 +1,6 @@
 import { JobsOptions } from '../interfaces';
 
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 import { ConnectionOptions } from './redis-options';
 
 export enum ClientType {
@@ -10,7 +10,7 @@ export enum ClientType {
 
 export interface QueueBaseOptions {
   connection?: ConnectionOptions;
-  client?: IORedis.Redis;
+  client?: Redis.Redis;
   prefix?: string; // prefix for all queue keys.
 }
 

--- a/src/interfaces/queue-options.ts
+++ b/src/interfaces/queue-options.ts
@@ -1,6 +1,6 @@
 import { JobsOptions } from '../interfaces';
 
-import * as Redis from 'ioredis';
+import { Redis } from 'ioredis';
 import { ConnectionOptions } from './redis-options';
 
 export enum ClientType {
@@ -10,7 +10,7 @@ export enum ClientType {
 
 export interface QueueBaseOptions {
   connection?: ConnectionOptions;
-  client?: Redis.Redis;
+  client?: Redis;
   prefix?: string; // prefix for all queue keys.
 }
 

--- a/src/interfaces/redis-options.ts
+++ b/src/interfaces/redis-options.ts
@@ -1,7 +1,7 @@
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 
-export type RedisOptions = IORedis.RedisOptions & {
+export type RedisOptions = Redis.RedisOptions & {
   skipVersionCheck?: boolean;
 };
 
-export type ConnectionOptions = RedisOptions | IORedis.Redis;
+export type ConnectionOptions = RedisOptions | Redis.Redis;

--- a/src/interfaces/redis-options.ts
+++ b/src/interfaces/redis-options.ts
@@ -1,7 +1,7 @@
-import * as Redis from 'ioredis';
+import { Redis, RedisOptions as BaseRedisOptions } from 'ioredis';
 
-export type RedisOptions = Redis.RedisOptions & {
+export type RedisOptions = BaseRedisOptions & {
   skipVersionCheck?: boolean;
 };
 
-export type ConnectionOptions = RedisOptions | Redis.Redis;
+export type ConnectionOptions = RedisOptions | Redis;

--- a/src/test/test_bulk.ts
+++ b/src/test/test_bulk.ts
@@ -1,6 +1,6 @@
 import { Queue, Worker, Job } from '../classes';
 import { expect } from 'chai';
-import * as Redis from 'ioredis';
+import * as IORedis from 'ioredis';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
 import { removeAllQueueData } from '../utils';
@@ -16,7 +16,7 @@ describe('bulk jobs', () => {
 
   afterEach(async function() {
     await queue.close();
-    await removeAllQueueData(new Redis(), queueName);
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should process jobs', async () => {

--- a/src/test/test_bulk.ts
+++ b/src/test/test_bulk.ts
@@ -1,6 +1,6 @@
 import { Queue, Worker, Job } from '../classes';
 import { expect } from 'chai';
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
 import { removeAllQueueData } from '../utils';
@@ -16,7 +16,7 @@ describe('bulk jobs', () => {
 
   afterEach(async function() {
     await queue.close();
-    await removeAllQueueData(new IORedis(), queueName);
+    await removeAllQueueData(new Redis(), queueName);
   });
 
   it('should process jobs', async () => {

--- a/src/test/test_clean.ts
+++ b/src/test/test_clean.ts
@@ -1,7 +1,7 @@
 import { Queue, QueueEvents, Worker } from '../classes';
 import { delay, removeAllQueueData } from '@src/utils';
 import { expect } from 'chai';
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 import { after } from 'lodash';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
@@ -21,7 +21,7 @@ describe('Cleaner', () => {
   afterEach(async function() {
     await queue.close();
     await queueEvents.close();
-    await removeAllQueueData(new IORedis(), queueName);
+    await removeAllQueueData(new Redis(), queueName);
   });
 
   it('should clean an empty queue', async () => {
@@ -127,7 +127,7 @@ describe('Cleaner', () => {
     });
     await worker.waitUntilReady();
 
-    const client = new IORedis();
+    const client = new Redis();
 
     await queue.add('test', { some: 'data' });
     await queue.add('test', { some: 'data' });

--- a/src/test/test_clean.ts
+++ b/src/test/test_clean.ts
@@ -1,7 +1,7 @@
 import { Queue, QueueEvents, Worker } from '../classes';
 import { delay, removeAllQueueData } from '@src/utils';
 import { expect } from 'chai';
-import * as Redis from 'ioredis';
+import * as IORedis from 'ioredis';
 import { after } from 'lodash';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
@@ -21,7 +21,7 @@ describe('Cleaner', () => {
   afterEach(async function() {
     await queue.close();
     await queueEvents.close();
-    await removeAllQueueData(new Redis(), queueName);
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should clean an empty queue', async () => {
@@ -127,7 +127,7 @@ describe('Cleaner', () => {
     });
     await worker.waitUntilReady();
 
-    const client = new Redis();
+    const client = new IORedis();
 
     await queue.add('test', { some: 'data' });
     await queue.add('test', { some: 'data' });

--- a/src/test/test_compat.ts
+++ b/src/test/test_compat.ts
@@ -6,7 +6,7 @@ import { Job, Worker } from '@src/classes';
 import { Queue3 } from '@src/classes/compat';
 import { delay, removeAllQueueData } from '@src/utils';
 import { expect } from 'chai';
-import * as Redis from 'ioredis';
+import * as IORedis from 'ioredis';
 import { after } from 'lodash';
 import { afterEach, beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
@@ -24,7 +24,7 @@ describe('Compat', function() {
 
     afterEach(async function() {
       await queue.close();
-      await removeAllQueueData(new Redis(), queueName);
+      await removeAllQueueData(new IORedis(), queueName);
     });
 
     it('should get waiting jobs', async function() {
@@ -294,7 +294,7 @@ describe('Compat', function() {
 
     afterEach(async function() {
       await queue.close();
-      await removeAllQueueData(new Redis(), queueName);
+      await removeAllQueueData(new IORedis(), queueName);
     });
 
     it('should emit waiting when a job has been added', function(done) {
@@ -403,7 +403,7 @@ describe('Compat', function() {
 
     afterEach(async function() {
       await queue.close();
-      await removeAllQueueData(new Redis(), queueName);
+      await removeAllQueueData(new IORedis(), queueName);
     });
 
     // it('should pause a queue until resumed', async () => {

--- a/src/test/test_compat.ts
+++ b/src/test/test_compat.ts
@@ -6,7 +6,7 @@ import { Job, Worker } from '@src/classes';
 import { Queue3 } from '@src/classes/compat';
 import { delay, removeAllQueueData } from '@src/utils';
 import { expect } from 'chai';
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 import { after } from 'lodash';
 import { afterEach, beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
@@ -24,7 +24,7 @@ describe('Compat', function() {
 
     afterEach(async function() {
       await queue.close();
-      await removeAllQueueData(new IORedis(), queueName);
+      await removeAllQueueData(new Redis(), queueName);
     });
 
     it('should get waiting jobs', async function() {
@@ -294,7 +294,7 @@ describe('Compat', function() {
 
     afterEach(async function() {
       await queue.close();
-      await removeAllQueueData(new IORedis(), queueName);
+      await removeAllQueueData(new Redis(), queueName);
     });
 
     it('should emit waiting when a job has been added', function(done) {
@@ -403,7 +403,7 @@ describe('Compat', function() {
 
     afterEach(async function() {
       await queue.close();
-      await removeAllQueueData(new IORedis(), queueName);
+      await removeAllQueueData(new Redis(), queueName);
     });
 
     // it('should pause a queue until resumed', async () => {

--- a/src/test/test_connection.ts
+++ b/src/test/test_connection.ts
@@ -1,4 +1,4 @@
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 import { Queue, QueueEvents, Job, Worker } from '@src/classes';
 
 import { v4 } from 'uuid';
@@ -16,7 +16,7 @@ describe('connection', () => {
 
   afterEach(async () => {
     await queue.close();
-    await removeAllQueueData(new IORedis(), queueName);
+    await removeAllQueueData(new Redis(), queueName);
   });
 
   it('should recover from a connection loss', async () => {

--- a/src/test/test_connection.ts
+++ b/src/test/test_connection.ts
@@ -1,4 +1,4 @@
-import * as Redis from 'ioredis';
+import * as IORedis from 'ioredis';
 import { Queue, QueueEvents, Job, Worker } from '@src/classes';
 
 import { v4 } from 'uuid';
@@ -16,7 +16,7 @@ describe('connection', () => {
 
   afterEach(async () => {
     await queue.close();
-    await removeAllQueueData(new Redis(), queueName);
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should recover from a connection loss', async () => {

--- a/src/test/test_delay.ts
+++ b/src/test/test_delay.ts
@@ -1,7 +1,7 @@
 import { Queue, Job } from '@src/classes';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 import { v4 } from 'uuid';
 import { Worker } from '@src/classes/worker';
 import { QueueEvents } from '@src/classes/queue-events';
@@ -21,7 +21,7 @@ describe('Delayed jobs', function() {
 
   afterEach(async function() {
     await queue.close();
-    await removeAllQueueData(new IORedis(), queueName);
+    await removeAllQueueData(new Redis(), queueName);
   });
 
   it('should process a delayed job only after delayed time', async function() {

--- a/src/test/test_delay.ts
+++ b/src/test/test_delay.ts
@@ -1,7 +1,7 @@
 import { Queue, Job } from '@src/classes';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import * as Redis from 'ioredis';
+import * as IORedis from 'ioredis';
 import { v4 } from 'uuid';
 import { Worker } from '@src/classes/worker';
 import { QueueEvents } from '@src/classes/queue-events';
@@ -21,7 +21,7 @@ describe('Delayed jobs', function() {
 
   afterEach(async function() {
     await queue.close();
-    await removeAllQueueData(new Redis(), queueName);
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should process a delayed job only after delayed time', async function() {

--- a/src/test/test_events.ts
+++ b/src/test/test_events.ts
@@ -2,7 +2,7 @@ import { Queue } from '@src/classes';
 import { QueueEvents } from '@src/classes/queue-events';
 import { Worker } from '@src/classes/worker';
 import { expect } from 'chai';
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
 import { delay, removeAllQueueData } from '@src/utils';
@@ -23,7 +23,7 @@ describe('events', function() {
   afterEach(async function() {
     await queue.close();
     await queueEvents.close();
-    await removeAllQueueData(new IORedis(), queueName);
+    await removeAllQueueData(new Redis(), queueName);
   });
 
   it('should emit waiting when a job has been added', async function() {
@@ -169,7 +169,7 @@ describe('events', function() {
     expect(eventsLength).to.be.equal(1);
 
     await trimmedQueue.close();
-    await removeAllQueueData(new IORedis(), queueName);
+    await removeAllQueueData(new Redis(), queueName);
   });
 
   it('should trim events manually', async () => {
@@ -194,6 +194,6 @@ describe('events', function() {
     expect(eventsLength).to.be.equal(0);
 
     await trimmedQueue.close();
-    await removeAllQueueData(new IORedis(), queueName);
+    await removeAllQueueData(new Redis(), queueName);
   });
 });

--- a/src/test/test_events.ts
+++ b/src/test/test_events.ts
@@ -2,7 +2,7 @@ import { Queue } from '@src/classes';
 import { QueueEvents } from '@src/classes/queue-events';
 import { Worker } from '@src/classes/worker';
 import { expect } from 'chai';
-import * as Redis from 'ioredis';
+import * as IORedis from 'ioredis';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
 import { delay, removeAllQueueData } from '@src/utils';
@@ -23,7 +23,7 @@ describe('events', function() {
   afterEach(async function() {
     await queue.close();
     await queueEvents.close();
-    await removeAllQueueData(new Redis(), queueName);
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should emit waiting when a job has been added', async function() {
@@ -169,7 +169,7 @@ describe('events', function() {
     expect(eventsLength).to.be.equal(1);
 
     await trimmedQueue.close();
-    await removeAllQueueData(new Redis(), queueName);
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should trim events manually', async () => {
@@ -194,6 +194,6 @@ describe('events', function() {
     expect(eventsLength).to.be.equal(0);
 
     await trimmedQueue.close();
-    await removeAllQueueData(new Redis(), queueName);
+    await removeAllQueueData(new IORedis(), queueName);
   });
 });

--- a/src/test/test_getters.ts
+++ b/src/test/test_getters.ts
@@ -5,7 +5,7 @@
 import { Queue, Job } from '@src/classes';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import * as Redis from 'ioredis';
+import * as IORedis from 'ioredis';
 import { v4 } from 'uuid';
 import { Worker } from '@src/classes/worker';
 import { after } from 'lodash';
@@ -23,7 +23,7 @@ describe('Jobs getters', function() {
 
   afterEach(async function() {
     await queue.close();
-    await removeAllQueueData(new Redis(), queueName);
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should get waiting jobs', async function() {

--- a/src/test/test_getters.ts
+++ b/src/test/test_getters.ts
@@ -5,7 +5,7 @@
 import { Queue, Job } from '@src/classes';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 import { v4 } from 'uuid';
 import { Worker } from '@src/classes/worker';
 import { after } from 'lodash';
@@ -23,7 +23,7 @@ describe('Jobs getters', function() {
 
   afterEach(async function() {
     await queue.close();
-    await removeAllQueueData(new IORedis(), queueName);
+    await removeAllQueueData(new Redis(), queueName);
   });
 
   it('should get waiting jobs', async function() {

--- a/src/test/test_job.ts
+++ b/src/test/test_job.ts
@@ -7,7 +7,7 @@ import { Worker } from '@src/classes/worker';
 import { JobsOptions } from '@src/interfaces';
 import { delay, removeAllQueueData } from '@src/utils';
 import { expect } from 'chai';
-import * as Redis from 'ioredis';
+import * as IORedis from 'ioredis';
 import { after } from 'lodash';
 import { afterEach, beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
@@ -23,7 +23,7 @@ describe('Job', function() {
 
   afterEach(async () => {
     await queue.close();
-    await removeAllQueueData(new Redis(), queueName);
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   describe('.create', function() {

--- a/src/test/test_job.ts
+++ b/src/test/test_job.ts
@@ -7,7 +7,7 @@ import { Worker } from '@src/classes/worker';
 import { JobsOptions } from '@src/interfaces';
 import { delay, removeAllQueueData } from '@src/utils';
 import { expect } from 'chai';
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 import { after } from 'lodash';
 import { afterEach, beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
@@ -23,7 +23,7 @@ describe('Job', function() {
 
   afterEach(async () => {
     await queue.close();
-    await removeAllQueueData(new IORedis(), queueName);
+    await removeAllQueueData(new Redis(), queueName);
   });
 
   describe('.create', function() {

--- a/src/test/test_pause.ts
+++ b/src/test/test_pause.ts
@@ -2,7 +2,7 @@ import { Job, Queue } from '@src/classes';
 import { QueueEvents, QueueScheduler } from '../classes';
 import { Worker } from '@src/classes/worker';
 import { expect } from 'chai';
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
 import { delay, removeAllQueueData } from '@src/utils';
@@ -22,7 +22,7 @@ describe('Pause', function() {
   afterEach(async function() {
     await queue.close();
     await queueEvents.close();
-    await removeAllQueueData(new IORedis(), queueName);
+    await removeAllQueueData(new Redis(), queueName);
   });
 
   // Skipped since some side effect makes this test fail

--- a/src/test/test_pause.ts
+++ b/src/test/test_pause.ts
@@ -2,7 +2,7 @@ import { Job, Queue } from '@src/classes';
 import { QueueEvents, QueueScheduler } from '../classes';
 import { Worker } from '@src/classes/worker';
 import { expect } from 'chai';
-import * as Redis from 'ioredis';
+import * as IORedis from 'ioredis';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
 import { delay, removeAllQueueData } from '@src/utils';
@@ -22,7 +22,7 @@ describe('Pause', function() {
   afterEach(async function() {
     await queue.close();
     await queueEvents.close();
-    await removeAllQueueData(new Redis(), queueName);
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   // Skipped since some side effect makes this test fail

--- a/src/test/test_queue.ts
+++ b/src/test/test_queue.ts
@@ -2,7 +2,7 @@
 import { Queue } from '@src/classes';
 import { describe, beforeEach, it } from 'mocha';
 import { expect, assert } from 'chai';
-import * as Redis from 'ioredis';
+import * as IORedis from 'ioredis';
 import { v4 } from 'uuid';
 import { Worker } from '@src/classes/worker';
 import { after } from 'lodash';
@@ -15,7 +15,7 @@ describe('Queue', function() {
   let queueEvents: QueueEvents;
 
   beforeEach(function() {
-    client = new Redis();
+    client = new IORedis();
   });
 
   beforeEach(async function() {
@@ -28,7 +28,7 @@ describe('Queue', function() {
   afterEach(async function() {
     await queue.close();
     await queueEvents.close();
-    await removeAllQueueData(new Redis(), queueName);
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('creates a queue with default job options', () => {

--- a/src/test/test_queue.ts
+++ b/src/test/test_queue.ts
@@ -2,7 +2,7 @@
 import { Queue } from '@src/classes';
 import { describe, beforeEach, it } from 'mocha';
 import { expect, assert } from 'chai';
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 import { v4 } from 'uuid';
 import { Worker } from '@src/classes/worker';
 import { after } from 'lodash';
@@ -15,7 +15,7 @@ describe('Queue', function() {
   let queueEvents: QueueEvents;
 
   beforeEach(function() {
-    client = new IORedis();
+    client = new Redis();
   });
 
   beforeEach(async function() {
@@ -28,7 +28,7 @@ describe('Queue', function() {
   afterEach(async function() {
     await queue.close();
     await queueEvents.close();
-    await removeAllQueueData(new IORedis(), queueName);
+    await removeAllQueueData(new Redis(), queueName);
   });
 
   it('creates a queue with default job options', () => {

--- a/src/test/test_rate_limiter.ts
+++ b/src/test/test_rate_limiter.ts
@@ -3,7 +3,7 @@ import { QueueEvents } from '@src/classes/queue-events';
 import { QueueScheduler } from '@src/classes/queue-scheduler';
 import { Worker } from '@src/classes/worker';
 import { assert, expect } from 'chai';
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 import { after } from 'lodash';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
@@ -24,7 +24,7 @@ describe('Rate Limiter', function() {
   afterEach(async function() {
     await queue.close();
     await queueEvents.close();
-    await removeAllQueueData(new IORedis(), queueName);
+    await removeAllQueueData(new Redis(), queueName);
   });
 
   it('should put a job into the delayed queue when limit is hit', async () => {

--- a/src/test/test_rate_limiter.ts
+++ b/src/test/test_rate_limiter.ts
@@ -3,7 +3,7 @@ import { QueueEvents } from '@src/classes/queue-events';
 import { QueueScheduler } from '@src/classes/queue-scheduler';
 import { Worker } from '@src/classes/worker';
 import { assert, expect } from 'chai';
-import * as Redis from 'ioredis';
+import * as IORedis from 'ioredis';
 import { after } from 'lodash';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
@@ -24,7 +24,7 @@ describe('Rate Limiter', function() {
   afterEach(async function() {
     await queue.close();
     await queueEvents.close();
-    await removeAllQueueData(new Redis(), queueName);
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should put a job into the delayed queue when limit is hit', async () => {

--- a/src/test/test_repeat.ts
+++ b/src/test/test_repeat.ts
@@ -4,7 +4,7 @@ import { QueueScheduler } from '@src/classes/queue-scheduler';
 import { Repeat } from '@src/classes/repeat';
 import { Worker } from '@src/classes/worker';
 import { expect } from 'chai';
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
 import { defaults } from 'lodash';
@@ -45,7 +45,7 @@ describe('repeat', function() {
     await queue.close();
     await repeat.close();
     await queueEvents.close();
-    await removeAllQueueData(new IORedis(), queueName);
+    await removeAllQueueData(new Redis(), queueName);
   });
 
   it('should create multiple jobs if they have the same cron pattern', async function() {

--- a/src/test/test_repeat.ts
+++ b/src/test/test_repeat.ts
@@ -4,7 +4,7 @@ import { QueueScheduler } from '@src/classes/queue-scheduler';
 import { Repeat } from '@src/classes/repeat';
 import { Worker } from '@src/classes/worker';
 import { expect } from 'chai';
-import * as Redis from 'ioredis';
+import * as IORedis from 'ioredis';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
 import { defaults } from 'lodash';
@@ -45,7 +45,7 @@ describe('repeat', function() {
     await queue.close();
     await repeat.close();
     await queueEvents.close();
-    await removeAllQueueData(new Redis(), queueName);
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should create multiple jobs if they have the same cron pattern', async function() {

--- a/src/test/test_sandboxed_process.ts
+++ b/src/test/test_sandboxed_process.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import * as Redis from 'ioredis';
+import * as IORedis from 'ioredis';
 import { after } from 'lodash';
 import { Queue, QueueEvents, Worker, pool } from '@src/classes';
 import { beforeEach } from 'mocha';
@@ -23,7 +23,7 @@ describe('sandboxed process', () => {
     await queue.close();
     await queueEvents.close();
     pool.clean();
-    await removeAllQueueData(new Redis(), queueName);
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should process and complete', async () => {

--- a/src/test/test_sandboxed_process.ts
+++ b/src/test/test_sandboxed_process.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 import { after } from 'lodash';
 import { Queue, QueueEvents, Worker, pool } from '@src/classes';
 import { beforeEach } from 'mocha';
@@ -23,7 +23,7 @@ describe('sandboxed process', () => {
     await queue.close();
     await queueEvents.close();
     pool.clean();
-    await removeAllQueueData(new IORedis(), queueName);
+    await removeAllQueueData(new Redis(), queueName);
   });
 
   it('should process and complete', async () => {

--- a/src/test/test_stalled_jobs.ts
+++ b/src/test/test_stalled_jobs.ts
@@ -1,6 +1,6 @@
 import { Queue, QueueScheduler, Worker, QueueEvents } from '@src/classes';
 import { delay, removeAllQueueData } from '@src/utils';
-import * as Redis from 'ioredis';
+import * as IORedis from 'ioredis';
 import { after } from 'lodash';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
@@ -17,7 +17,7 @@ describe('stalled jobs', function() {
 
   afterEach(async function() {
     await queue.close();
-    await removeAllQueueData(new Redis(), queueName);
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('process stalled jobs when starting a queue', async function() {

--- a/src/test/test_stalled_jobs.ts
+++ b/src/test/test_stalled_jobs.ts
@@ -1,6 +1,6 @@
 import { Queue, QueueScheduler, Worker, QueueEvents } from '@src/classes';
 import { delay, removeAllQueueData } from '@src/utils';
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 import { after } from 'lodash';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
@@ -17,7 +17,7 @@ describe('stalled jobs', function() {
 
   afterEach(async function() {
     await queue.close();
-    await removeAllQueueData(new IORedis(), queueName);
+    await removeAllQueueData(new Redis(), queueName);
   });
 
   it('process stalled jobs when starting a queue', async function() {

--- a/src/test/test_worker.ts
+++ b/src/test/test_worker.ts
@@ -1,7 +1,7 @@
 import { Queue, QueueEvents, Job, Worker, QueueScheduler } from '@src/classes';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 import { v4 } from 'uuid';
 import { delay, removeAllQueueData } from '@src/utils';
 import { after, times, once } from 'lodash';
@@ -26,7 +26,7 @@ describe('workers', function() {
     sandbox.restore();
     await queue.close();
     await queueEvents.close();
-    await removeAllQueueData(new IORedis(), queueName);
+    await removeAllQueueData(new Redis(), queueName);
   });
 
   it('should get all workers for this queue', async function() {

--- a/src/test/test_worker.ts
+++ b/src/test/test_worker.ts
@@ -1,7 +1,7 @@
 import { Queue, QueueEvents, Job, Worker, QueueScheduler } from '@src/classes';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import * as Redis from 'ioredis';
+import * as IORedis from 'ioredis';
 import { v4 } from 'uuid';
 import { delay, removeAllQueueData } from '@src/utils';
 import { after, times, once } from 'lodash';
@@ -26,7 +26,7 @@ describe('workers', function() {
     sandbox.restore();
     await queue.close();
     await queueEvents.close();
-    await removeAllQueueData(new Redis(), queueName);
+    await removeAllQueueData(new IORedis(), queueName);
   });
 
   it('should get all workers for this queue', async function() {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import IORedis from 'ioredis';
+import * as Redis from 'ioredis';
 
 export const errorObject: { [index: string]: any } = { value: null };
 
@@ -43,7 +43,7 @@ export function isRedisInstance(obj: any): boolean {
 }
 
 export async function removeAllQueueData(
-  client: IORedis.Redis,
+  client: Redis.Redis,
   queueName: string,
   prefix = 'bull',
 ) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import * as Redis from 'ioredis';
+import { Redis } from 'ioredis';
 
 export const errorObject: { [index: string]: any } = { value: null };
 
@@ -43,7 +43,7 @@ export function isRedisInstance(obj: any): boolean {
 }
 
 export async function removeAllQueueData(
-  client: Redis.Redis,
+  client: Redis,
   queueName: string,
   prefix = 'bull',
 ) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,8 @@
     "jsx": "preserve",
     "importHelpers": true,
     "moduleResolution": "node",
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": false,
     "strictNullChecks": false,
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
This change should enable compatibility with top-level projects that have esModuleInterop disabled.

I did not include any tests since I disabled esModuleInterop in BullMQ. This should cover any future issues.

Fixes GH-129.