### PR TITLE
fix: fixed exit code 12 when using inspect with child process

### DIFF
--- a/src/classes/child-pool.ts
+++ b/src/classes/child-pool.ts
@@ -63,7 +63,7 @@ export class ChildPool {
       }
     }
 
-    child = fork(masterFile, execArgv);
+    child = fork(masterFile, [], { execArgv });
     child.processFile = processFile;
 
     _this.retained[child.pid] = child;


### PR DESCRIPTION
Hi,

My child processes are crashing if I start Node with the inspect flag. I see that there is already some code in place to handle this, but it doesn't seem to be working.

`Starting inspector on 0.0.0.0:5858 failed: address already in use`

> {"job":{"id":"9","name":"test2","data":"{\"objectType\":\"users\",\"objectId\":\"52786\",\"delete\":false}","opts":"{\"attempts\":0,\"delay\":0,\"removeOnComplete\":true,\"removeOnFail\":true}","progress":0,"attemptsMade":1,"processedOn":1581530442512,"timestamp":1581530442516,"failedReason":"\"Unexpected exit code: 12 signal: null\"","stacktrace":"[\"Error: Unexpected exit code: 12 signal: null\\n    at ChildProcess.exitHandler (/application/node_modules/bullmq/dist/classes/sandbox.js:34:24)\\n  at ChildProcess.emit (events.js:228:7)\\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:272:12)\"]","returnvalue":"null"},"errorMessage":"Unexpected exit code: 12 signal: null","errorStack":"Error: Unexpected exit code: 12 signal: null\n    at ChildProcess.exitHandler (/application/node_modules/bullmq/dist/classes/sandbox.js:34:24)\n    at ChildProcess.emit (events.js:228:7)\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:272:12)","level":"error","message":"Job failed.","timestamp":"2020-02-12T18:00:42.544Z"}

I see that v3 correctly passes `execArgv` as part of the `options` object argument.

https://github.com/OptimalBits/bull/blob/30791047bffd1f5714fae82bbd247bfe4cc2009e/lib/process/child-pool.js#L49

The curly brackets were dropped in v4. I think this is causing `fork()` to interpret this as the string array `args` argument.

I'm not entirely sure how to write a test for this issue. It's sort of weird to modify the global state of the process inside the test. Additionally, simply adding the inspect flag to master process does not open the debug listener (I think?). Any ideas?