### PR TITLE
fix: restore the Job timestamp when deserializing JSON data (#138)

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -113,7 +113,7 @@ export class Job<T = any, R = any> {
     job.progress = JSON.parse(json.progress || 0);
 
     // job.delay = parseInt(json.delay);
-    // job.timestamp = parseInt(json.timestamp);
+    job.timestamp = parseInt(json.timestamp);
 
     if (json.finishedOn) {
       job.finishedOn = parseInt(json.finishedOn);


### PR DESCRIPTION
Uncommented out line of code that sets/restores the job timestamp from the job's JSON data.

#138 