### PR TITLE
Node process not exiting cleanly

### DIFF
--- a/src/classes/queue-base.ts
+++ b/src/classes/queue-base.ts
@@ -72,7 +72,15 @@ export class QueueBase extends EventEmitter {
   }
 
   close() {
-    return (this.closing = this.connection.close());
+    if (!this.closing) {
+      this.emit('closing');
+
+      this.closing = this.connection.close().then(() => {
+        this.emit('closed');
+      });
+    }
+
+    return this.closing;
   }
 
   disconnect() {

--- a/src/classes/queue-scheduler.ts
+++ b/src/classes/queue-scheduler.ts
@@ -160,11 +160,17 @@ export class QueueScheduler extends QueueBase {
   }
 
   async close() {
-    if (this.isBlocked) {
-      this.closing = this.disconnect();
-    } else {
-      super.close();
+    if (!this.closing) {
+      this.emit('closing');
+
+      this.closing = (this.isBlocked
+        ? this.disconnect()
+        : this.connection.close()
+      ).then(() => {
+        this.emit('closed');
+      });
     }
+
     return this.closing;
   }
 }

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -374,11 +374,9 @@ export class Worker<T = any> extends QueueBase {
           await this.resume();
           if (!force) {
             await this.whenCurrentJobsFinished(false);
-          } else {
-            await client.disconnect();
           }
-          // await this.disconnect();
-          await super.close();
+          await client.disconnect();
+          await this.connection.close();
         } catch (err) {
           reject(err);
         } finally {
@@ -389,5 +387,7 @@ export class Worker<T = any> extends QueueBase {
         resolve();
       });
     }
+
+    return this.closing;
   }
 }


### PR DESCRIPTION
Having lots of issues trying to cleanly shut down a worker + scheduler process (similar to #119)  

The changes in this PR fix all of the issues I was having.

1) Change to Worker queue is the same as in PR #153 whereby nothing was being awaited. 

2) If Worker.close is called without the force flag, the blocking client connection is never getting closed, which prevents the Node event loop from exiting.

https://github.com/taskforcesh/bullmq/blob/b96f5ba3e9c36182174300af629b34fe43c62ecd/src/classes/worker.ts#L378

3) QueueBase.close and QueueScheduler.close, if called multiple times, causes trouble.  I added the same check you are doing in Worker.close

4) Added "closing" and "closed" events to QueueBase and QueueScheduler.   This achieves functional parity with the Worker class.
