### PR TITLE
fix(sandbox): If the child process is killed, remove it from the pool.

### DIFF
--- a/src/classes/sandbox.ts
+++ b/src/classes/sandbox.ts
@@ -48,7 +48,7 @@ const sandbox = (processFile: any, childPool: any) => {
       child.removeListener('message', msgHandler);
       child.removeListener('exit', exitHandler);
 
-      if (child.exitCode !== null) {
+      if (child.exitCode !== null || /SIG.*/.test(child.signalCode)) {
         childPool.remove(child);
       } else {
         childPool.release(child);


### PR DESCRIPTION
This fix comes from bull.

Reference: 
https://github.com/OptimalBits/bull/issues/1460
https://github.com/OptimalBits/bull/pull/1461