### PR TITLE
Second Argument for worker is missing

### DIFF
--- a/docs/gitbook/guide/connections.md
+++ b/docs/gitbook/guide/connections.md
@@ -29,7 +29,7 @@ const connection = new IORedis();
 
 // Reuse the ioredis instance
 const myQueue = new Queue('myqueue', { connection });
-const myWorker = new Worker('myworker', { connection });
+const myWorker = new Worker('myworker', async (job)=>{}, { connection });
 ```
 
 Note that in the second example, even though the ioredis instance is being reused, the worker will create a duplicated connection that it needs internally to make blocking connections.


### PR DESCRIPTION
I am not sure exactly the options here, but definitely this will work.  It also appears that some sort of resolution might occur if a string is passed, but I can't figure that one out.