### PR TITLE
fix: job.createBulk() did not set custom job id

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -86,7 +86,14 @@ export class Job<T = any, R = any> {
     const client = await queue.client;
 
     const jobInstances = jobs.map(
-      job => new Job<T, R>(queue, job.name, job.data, job.opts),
+      job =>
+        new Job<T, R>(
+          queue,
+          job.name,
+          job.data,
+          job.opts,
+          job.opts && job.opts.jobId,
+        ),
     );
 
     const multi = client.multi();


### PR DESCRIPTION
job id argument was not passed into the job ctor

#189 