### PR TITLE
docs: improve QueueScheduler docs

### DIFF
--- a/docs/gitbook/guide/jobs/stalled.md
+++ b/docs/gitbook/guide/jobs/stalled.md
@@ -1,5 +1,9 @@
 # Stalled
 
+{% hint style="info" %}
+Stalled jobs checks will only work if there is at least one [`QueueScheduler`](../queuescheduler.md) instance configured in the Queue.
+{% endhint %}
+
 When a job is an active state, i.e., it is being processed by a worker, it needs to continuously update the queue to notify that the worker is still working on the job. This mechanism prevents that a worker that crashes or enters an endless loop will keep a job in active state for ever.
 
 When a worker is not able to notify the queue that it is still working on a given job, that job is moved back to the waiting list, or to the failed set. We then said that the job has stalled and the queue will emit the 'stalled' event.

--- a/docs/gitbook/guide/queuescheduler.md
+++ b/docs/gitbook/guide/queuescheduler.md
@@ -1,8 +1,8 @@
 # QueueScheduler
 
-The QueueScheduler is a helper class used to manage stalled and delayed jobs. 
+The QueueScheduler is a helper class used to manage stalled and delayed jobs for a given Queue.
 
 This class automatically moves delayed jobs back to the waiting queue when it is the right time to process them. It also automatically checks for stalled jobs, i.e., detects jobs that are active but where the worker has either crashed or stopped working properly. [Stalled jobs](jobs/stalled.md) are moved back or failed depending on the settings selected when instantiating the class.
 
-The reason for having this functionality in a separate class instead of in the workers \(as in Bull 3.x\) is because whereas you may want to have a large number of workers for parallel processing, for the scheduler you probably only want a couple of instances. One will be enough but you can have more just for redundancy.
+The reason for having this functionality in a separate class instead of in the workers \(as in Bull 3.x\) is because whereas you may want to have a large number of workers for parallel processing, for the scheduler you probably only want a couple of instances for each queue that requires delayed or stalled checks. One will be enough but you can have more just for redundancy.
 


### PR DESCRIPTION
- add hint on the `stalled jobs` page
- updates QueueScheduler description