### PR TITLE
fix(redis-connection): run the load command for reused redis client

### DIFF
--- a/docs/gitbook/guide/connections.md
+++ b/docs/gitbook/guide/connections.md
@@ -15,7 +15,7 @@ const myQueue = new Queue('myqueue', { connection: {
   port: 32856
 }});
 
-const myWorker = new Worker('myworker', { connection: {
+const myWorker = new Worker('myworker', async (job)=>{}, { connection: {
   host: myredis.taskforce.run,
   port: 32856
 }});

--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -45,7 +45,6 @@ export class RedisConnection extends EventEmitter {
       } else {
         async function handleReady() {
           client.removeListener('error', handleError);
-          await load(client);
           resolve();
         }
 
@@ -71,6 +70,7 @@ export class RedisConnection extends EventEmitter {
     }
 
     await RedisConnection.waitUntilReady(this._client);
+    await load(this._client);
 
     if (opts && opts.skipVersionCheck !== true && !this.closing) {
       const version = await this.getRedisVersion();

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -34,7 +34,10 @@ export const load = async function(client: Redis) {
   const scripts = await loadScripts(__dirname);
 
   scripts.forEach((command: Command) => {
-    client.defineCommand(command.name, command.options);
+    // Only define the command if not already defined
+    if (!(client as any)[command.name]) {
+      client.defineCommand(command.name, command.options);
+    }
   });
 };
 


### PR DESCRIPTION
resolves #108, resolves #79, resolves #59 

I think all the different initialization cases are fixed by this change. When re-using a redis client, the ready event is not triggered so the `load` function was not being called in this case.