### PR TITLE
docs: fix clean comment

### DIFF
--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -157,7 +157,7 @@ export class Queue<T = any> extends QueueGetters {
 
   /*@function clean
    *
-   * Cleans jobs from a queue. Similar to remove but keeps jobs within a certain
+   * Cleans jobs from a queue. Similar to drain but keeps jobs within a certain
    * grace period.
    *
    * @param {number} grace - The grace period


### PR DESCRIPTION
The current comment refers to a `remove` function that no longer exists.

Now, clean is similar to drain?