### PR TITLE
feat(sandbox): kill child workers gracefully

### DIFF
--- a/src/classes/process-utils.ts
+++ b/src/classes/process-utils.ts
@@ -1,0 +1,41 @@
+'use strict';
+
+import { ChildProcess } from 'child_process';
+
+function onExitOnce(child: ChildProcess): Promise<void> {
+  return new Promise(resolve => {
+    child.once('exit', () => resolve());
+  });
+}
+
+function hasProcessExited(child: ChildProcess): boolean {
+  return !!(child.exitCode !== null || child.signalCode);
+}
+
+/**
+ * Sends a kill signal to a child resolving when the child has exited,
+ * resorting to SIGKILL if the given timeout is reached
+ */
+export async function killAsync(
+  child: ChildProcess,
+  signal: 'SIGTERM' | 'SIGKILL' = 'SIGKILL',
+  timeoutMs: number = undefined,
+): Promise<void> {
+  if (hasProcessExited(child)) {
+    return;
+  }
+
+  const onExit = onExitOnce(child);
+  child.kill(signal);
+
+  if (timeoutMs === 0 || isFinite(timeoutMs)) {
+    const timeoutHandle = setTimeout(() => {
+      if (!hasProcessExited(child)) {
+        child.kill('SIGKILL');
+      }
+    }, timeoutMs);
+    await onExit;
+    clearTimeout(timeoutHandle);
+  }
+  await onExit;
+}

--- a/src/test/test_child-pool.ts
+++ b/src/test/test_child-pool.ts
@@ -8,9 +8,7 @@ describe('Child pool', () => {
     pool = new ChildPool();
   });
 
-  afterEach(() => {
-    pool.clean();
-  });
+  afterEach(() => pool.clean());
 
   it('should return same child if free', async () => {
     const processor = __dirname + '/fixtures/fixture_processor_bar.js';
@@ -48,7 +46,7 @@ describe('Child pool', () => {
     const processor = __dirname + '/fixtures/fixture_processor_bar.js';
     const child = await pool.retain(processor);
     expect(child).to.be.ok;
-    pool.kill(child);
+    await pool.kill(child);
     expect(pool.retained).to.be.empty;
     const newChild = await pool.retain(processor);
     expect(child).to.not.be.eql(newChild);


### PR DESCRIPTION
Properly handle SIGTERM in the child workers by waiting for the current
job to exit, then exiting cleanly.

Worker#close now also kills the workers and waits for them to close

This is the same feature as https://github.com/OptimalBits/bull/pull/1802