### PR TITLE
build: sort script targets, rename prepublish target to prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,19 +8,19 @@
   "author": "Taskforce.sh Inc.",
   "license": "MIT",
   "scripts": {
-    "docs": "typedoc --out docs src",
     "build": "tsc && yarn copylua",
     "copylua": "copyfiles -f ./src/commands/*.lua ./dist/commands",
-    "lint": "tslint --project tsconfig.json -c tslint.json 'src/**/*.ts'",
-    "test": "yarn lint && tsc && ts-mocha --paths 'src/**/test_*.ts' --exit",
-    "test:watch": "yarn lint  && ts-mocha --paths 'src/**/test_*.ts' -w --watch-extensions ts",
     "coverage": "nyc --reporter=text npm run test",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
+    "docs": "typedoc --out docs src",
+    "lint": "tslint --project tsconfig.json -c tslint.json 'src/**/*.ts'",
     "precommit": "yarn lint",
-    "semantic-release": "semantic-release",
+    "prepare": "yarn build",
     "prettier": "prettier --config package.json src/**/*.ts",
+    "semantic-release": "semantic-release",
     "semantic-release-prepare": "ts-node tools/semantic-release-prepare",
-    "prepublish": "yarn build"
+    "test": "yarn lint && tsc && ts-mocha --paths 'src/**/test_*.ts' --exit",
+    "test:watch": "yarn lint  && ts-mocha --paths 'src/**/test_*.ts' -w --watch-extensions ts"
   },
   "dependencies": {
     "@types/ioredis": "^4.16.3",


### PR DESCRIPTION
If a user wishes to pull in a version of bullmq via the git/github syntax as supported by npm, the resulting code will not work before this change.  This is because npm will not invoke the `prepublish` target to compile the TS code.  However it will invoke the `prepare` target which is a superset of the `prepublish` target.  Thus it makes sense to rename the `prepublish` taret to `prepare` as that is a more desirable behavior.  More can be read on it at https://docs.npmjs.com/files/package.json. 

This change also sorts the targets because sorting is good.