### PR TITLE
feat: Retrieve Jobs by ID pattern

### DIFF
--- a/docs/gitbook/guide/fetching-jobs.md
+++ b/docs/gitbook/guide/fetching-jobs.md
@@ -1,0 +1,58 @@
+# Fetching Jobs
+
+BullMQ allows you to iterate through existing jobs using the methods `.getJobsFromIdPattern` and `.getJobsByName`.
+
+## `.getJobsFromIdPattern`
+
+Returns all jobs with IDs matching a specific pattern.
+
+```typescript
+import { Queue } from "bullmq";
+
+const queue = new Queue('painter');
+
+await queue.add("default", ... ,{ jobId: "foo.1" })
+await queue.add("default", ..., { jobId: "foo.2" })
+await queue.add("default", ..., { jobId: "bar.1" })
+
+const result = await queue.fromIdPattern(
+    "foo.*", // pattern to search for
+    0 // cursor, initially 0
+)
+
+result.jobs // includes `foo.1` and `foo.2`, but not `bar.1`
+result.newCursor // cursor to use for next iteration, `null` if scan is finished
+```
+
+{% hint style="info" %}
+Uses Redis' `SCAN` internally and thus
+will perform badly on big instances.
+{% endhint %}
+
+## `.getJobsByName`
+
+Returns all jobs with a specific name.
+
+```typescript
+import { Queue } from "bullmq";
+
+const queue = new Queue('painter');
+
+await queue.add("foo", ...)
+await queue.add("foo", ...)
+await queue.add("bar", ...)
+
+const result = await queue.getJobsByName(
+    "foo",
+    0 // cursor, initially 0
+)
+
+result.jobs // includes the first two jobs
+result.newCursor // cursor to use for next iteration, `null` if scan is finished
+```
+
+{% hint style="info" %}
+Uses Redis' `SSCAN` internally, which performs a lot better than `SCAN`.
+Prefer this over `.getJobsFromIdPattern`, if possible.
+{% endhint %}
+

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -147,6 +147,29 @@ export class Job<T = any, R = any> {
     }
   }
 
+  static async fromIdPattern(
+    queue: QueueBase,
+    idPattern: string,
+    cursor = 0,
+    count = 100,
+  ) {
+    const { jobJSONs, newCursor } = await Scripts.getJobByIdPattern(
+      queue,
+      idPattern,
+      cursor,
+      count,
+    );
+
+    const jobs = Object.entries(jobJSONs).map(([key, json]) =>
+      Job.fromJSON(queue, json, queue.fromKey(key)),
+    );
+
+    return {
+      jobs,
+      newCursor,
+    };
+  }
+
   toJSON() {
     const { queue, ...withoutQueue } = this;
     return withoutQueue;

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -147,6 +147,29 @@ export class Job<T = any, R = any> {
     }
   }
 
+  static async fromName(
+    queue: QueueBase,
+    name: string,
+    cursor = 0,
+    count = 100,
+  ) {
+    const { jobJSONs, newCursor } = await Scripts.getJobsByName(
+      queue,
+      name,
+      cursor,
+      count,
+    );
+
+    const jobs = Object.entries(jobJSONs).map(([key, json]) =>
+      Job.fromJSON(queue, json, queue.fromKey(key)),
+    );
+
+    return {
+      jobs,
+      newCursor,
+    };
+  }
+
   static async fromIdPattern(
     queue: QueueBase,
     idPattern: string,

--- a/src/classes/queue-base.ts
+++ b/src/classes/queue-base.ts
@@ -54,6 +54,15 @@ export class QueueBase extends EventEmitter {
     return `${this.opts.prefix}:${this.name}:${type}`;
   }
 
+  /**
+   * If passed `bull:myQueueName:job1`,
+   * it will return `job1`.
+   */
+  fromKey(key: string) {
+    const prefixLength = this.toKey('').length;
+    return key.slice(prefixLength);
+  }
+
   get client() {
     return this.connection.client;
   }

--- a/src/classes/queue-base.ts
+++ b/src/classes/queue-base.ts
@@ -44,6 +44,7 @@ export class QueueBase extends EventEmitter {
       'meta',
       'events',
       'delay',
+      'by-name',
     ].forEach(key => {
       keys[key] = this.toKey(key);
     });
@@ -52,6 +53,10 @@ export class QueueBase extends EventEmitter {
 
   toKey(type: string) {
     return `${this.opts.prefix}:${this.name}:${type}`;
+  }
+
+  byNameKey(name: string) {
+    return `${this.keys['by-name']}:${name}`;
   }
 
   /**

--- a/src/classes/queue-getters.ts
+++ b/src/classes/queue-getters.ts
@@ -10,11 +10,11 @@ export class QueueGetters extends QueueBase {
     return Job.fromId(this, jobId);
   }
 
-  getJobsByName(name: string, cursor = 0, count = 100) {
+  getJobsByName(name: string, cursor: number, count = 100) {
     return Job.fromName(this, name, cursor, count);
   }
 
-  getJobFromIdPattern(jobId: string, cursor = 0, count = 100) {
+  getJobsFromIdPattern(jobId: string, cursor: number, count = 100) {
     return Job.fromIdPattern(this, jobId, cursor, count);
   }
 

--- a/src/classes/queue-getters.ts
+++ b/src/classes/queue-getters.ts
@@ -10,6 +10,10 @@ export class QueueGetters extends QueueBase {
     return Job.fromId(this, jobId);
   }
 
+  getJobFromIdPattern(jobId: string, cursor = 0, count = 100) {
+    return Job.fromIdPattern(this, jobId, cursor, count);
+  }
+
   private commandByType(
     types: string[],
     count: boolean,

--- a/src/classes/queue-getters.ts
+++ b/src/classes/queue-getters.ts
@@ -10,6 +10,10 @@ export class QueueGetters extends QueueBase {
     return Job.fromId(this, jobId);
   }
 
+  getJobsByName(name: string, cursor = 0, count = 100) {
+    return Job.fromName(this, name, cursor, count);
+  }
+
   getJobFromIdPattern(jobId: string, cursor = 0, count = 100) {
     return Job.fromIdPattern(this, jobId, cursor, count);
   }

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -142,6 +142,7 @@ export class Scripts {
       queueKeys.priority,
       queueKeys.events,
       queueKeys.meta,
+      queue.byNameKey(job.name),
     ];
 
     let remove;

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -90,7 +90,7 @@ export class Scripts {
       `${jobId}:logs`,
     ].map(name => queue.toKey(name));
     return (<any>client).removeJob(
-      keys.concat([queue.keys.events, queue.byNameKey(''), jobId]),
+      keys.concat([queue.keys.events, queue.keys['by-name'], jobId]),
     );
   }
 

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -307,7 +307,7 @@ export class Scripts {
     return [queue.toKey(idPattern), cursor, count];
   }
 
-  static async getJobByIdPattern<T>(
+  static async getJobByIdPattern(
     queue: QueueBase,
     idPattern: string,
     cursor: number,
@@ -318,7 +318,7 @@ export class Scripts {
     const args = this.getJobByIdPatternArgs(queue, idPattern, cursor, count);
     const response = await (client as any).getJobsByIdPattern(args);
 
-    const newCursor = Number(response[0]);
+    const newCursor = response[0] === '0' ? null : Number(response[0]);
 
     const jobJSONs: Record<string, any> = {};
 

--- a/src/commands/addJob-9.lua
+++ b/src/commands/addJob-9.lua
@@ -23,6 +23,7 @@
       KEYS[6] 'priority'
       KEYS[7] events stream key
       KEYS[8] delay stream key
+      KEYS[9] by name set key
 
       ARGV[1]  key prefix,
       ARGV[2]  custom id (will not generate one automatically)
@@ -55,6 +56,9 @@ end
 -- Store the job.
 rcall("HMSET", jobIdKey, "name", ARGV[3], "data", ARGV[4], "opts", ARGV[5],
       "timestamp", ARGV[6], "delay", ARGV[7], "priority", ARGV[9])
+
+-- Add to queue/name set
+rcall("SADD", KEYS[9], jobId)
 
 -- Check if job is delayed
 local delayedTimestamp = tonumber(ARGV[8])

--- a/src/commands/getJobsByIdPattern-0.lua
+++ b/src/commands/getJobsByIdPattern-0.lua
@@ -13,11 +13,11 @@ local scannedJobIds = scanResult[2]
 
 local result = { newCursor }
 
-for index, jobId in pairs(scannedJobIds) do
-  table.insert(result, "id")
-  table.insert(result, jobId)
+for index, jobIdKey in pairs(scannedJobIds) do
+  table.insert(result, "jobIdKey")
+  table.insert(result, jobIdKey)
 
-  local jobHash = redis.call("HGETALL", jobId)
+  local jobHash = redis.call("HGETALL", jobIdKey)
 
   for key, value in pairs(jobHash) do
     table.insert(result, value)

--- a/src/commands/getJobsByIdPattern-0.lua
+++ b/src/commands/getJobsByIdPattern-0.lua
@@ -1,0 +1,27 @@
+--[[
+  Get Jobs by ID pattern
+
+     Input:
+        ARGV[1] ID pattern
+        ARGV[2] cursor
+        ARGV[3] count
+]]
+local scanResult = redis.call("SCAN", ARGV[2], "COUNT", ARGV[3], "MATCH", ARGV[1], "TYPE", "hash")
+
+local newCursor = scanResult[1]
+local scannedJobIds = scanResult[2]
+
+local result = { newCursor }
+
+for index, jobId in pairs(scannedJobIds) do
+  table.insert(result, "id")
+  table.insert(result, jobId)
+
+  local jobHash = redis.call("HGETALL", jobId)
+
+  for key, value in pairs(jobHash) do
+    table.insert(result, value)
+  end
+end
+
+return result

--- a/src/commands/getJobsByName-1.lua
+++ b/src/commands/getJobsByName-1.lua
@@ -1,0 +1,30 @@
+--[[
+  Get Jobs by ID pattern
+
+     Input:
+        KEYS[1] Queue / Name Set Key
+        ARGV[1] Key Prefix
+        ARGV[2] cursor
+        ARGV[3] count
+]]
+local scanResult = redis.call("SSCAN", KEYS[1], ARGV[2], "COUNT", ARGV[3])
+
+local newCursor = scanResult[1]
+local scannedJobIds = scanResult[2]
+
+local result = { newCursor }
+
+for index, jobId in pairs(scannedJobIds) do
+  table.insert(result, "id")
+  table.insert(result, jobId)
+
+  local jobIdKey = ARGV[1] .. jobId
+
+  local jobHash = redis.call("HGETALL", jobIdKey)
+
+  for key, value in pairs(jobHash) do
+    table.insert(result, value)
+  end
+end
+
+return result

--- a/src/commands/getJobsByName-1.lua
+++ b/src/commands/getJobsByName-1.lua
@@ -15,10 +15,10 @@ local scannedJobIds = scanResult[2]
 local result = { newCursor }
 
 for index, jobId in pairs(scannedJobIds) do
-  table.insert(result, "id")
-  table.insert(result, jobId)
-
   local jobIdKey = ARGV[1] .. jobId
+
+  table.insert(result, "jobIdKey")
+  table.insert(result, jobIdKey)
 
   local jobHash = redis.call("HGETALL", jobIdKey)
 

--- a/src/commands/moveToFinished-8.lua
+++ b/src/commands/moveToFinished-8.lua
@@ -13,6 +13,7 @@
       KEYS[5] priority key
       KEYS[6] event stream key
       KEYS[7] meta key
+      KEYS[8] queue/name set key
 
       ARGV[1]  jobId
       ARGV[2]  timestamp
@@ -75,6 +76,7 @@ if rcall("EXISTS", KEYS[3]) == 1 then -- // Make sure job exists
     else
         local jobLogKey = KEYS[3] .. ':logs'
         rcall("DEL", KEYS[3], jobLogKey)
+        rcall("SREM", KEYS[8], ARGV[1])
     end
 
     rcall("XADD", KEYS[6], "*", "event", ARGV[5], "jobId", ARGV[1], ARGV[3],

--- a/src/commands/removeJob-11.lua
+++ b/src/commands/removeJob-11.lua
@@ -13,6 +13,7 @@
       KEYS[8] jobId
       KEYS[9] job logs
       KEYS[10] events stream
+      KEYS[11] queue prefix
 
       ARGV[1]  jobId
 
@@ -22,6 +23,11 @@
 
 local rcall = redis.call
 local jobId = ARGV[1]
+
+local jobName = rcall("HGET", KEYS[8], "name")
+
+local queueNameSet = KEYS[11] .. jobName
+
 rcall("LREM", KEYS[1], 0, jobId)
 rcall("LREM", KEYS[2], 0, jobId)
 rcall("ZREM", KEYS[3], jobId)
@@ -31,6 +37,7 @@ rcall("ZREM", KEYS[6], jobId)
 rcall("ZREM", KEYS[7], jobId)
 rcall("DEL", KEYS[8])
 rcall("DEL", KEYS[9])
+rcall("SREM", KEYS[11], queueNameSet)
 
 rcall("XADD", KEYS[10], "*", "event", "removed", "jobId", jobId, "prev", "TBD");
 

--- a/src/commands/removeJob-11.lua
+++ b/src/commands/removeJob-11.lua
@@ -35,7 +35,7 @@ rcall("ZREM", KEYS[6], jobId)
 rcall("ZREM", KEYS[7], jobId)
 rcall("DEL", KEYS[8])
 rcall("DEL", KEYS[9])
-rcall("SREM", KEYS[11], jobId)
+rcall("SREM", KEYS[11] .. ":" .. jobName, jobId)
 
 rcall("XADD", KEYS[10], "*", "event", "removed", "jobId", jobId, "prev", "TBD");
 

--- a/src/commands/removeJob-11.lua
+++ b/src/commands/removeJob-11.lua
@@ -26,8 +26,6 @@ local jobId = ARGV[1]
 
 local jobName = rcall("HGET", KEYS[8], "name")
 
-local queueNameSet = KEYS[11] .. jobName
-
 rcall("LREM", KEYS[1], 0, jobId)
 rcall("LREM", KEYS[2], 0, jobId)
 rcall("ZREM", KEYS[3], jobId)
@@ -37,7 +35,7 @@ rcall("ZREM", KEYS[6], jobId)
 rcall("ZREM", KEYS[7], jobId)
 rcall("DEL", KEYS[8])
 rcall("DEL", KEYS[9])
-rcall("SREM", KEYS[11], queueNameSet)
+rcall("SREM", KEYS[11], jobId)
 
 rcall("XADD", KEYS[10], "*", "event", "removed", "jobId", jobId, "prev", "TBD");
 

--- a/src/test/test_job.ts
+++ b/src/test/test_job.ts
@@ -592,12 +592,65 @@ describe('Job', function() {
 
       await delay(500);
 
-      const { jobs, newCursor } = await Job.fromIdPattern(queue, 'customer1:*');
-      expect(jobs).to.have.length(2);
+      const { jobs, newCursor } = await Job.fromIdPattern(
+        queue,
+        'customer1:*',
+        0,
+        1000,
+      );
+      expect(newCursor).to.equal(null);
 
       const jobIds = jobs.map(j => j.id);
       expect(jobIds).to.have.members(['customer1:job1', 'customer1:job2']);
-      expect(newCursor).to.equal(0);
+      expect(jobIds).to.have.length(2);
+    });
+  });
+
+  describe('.fromName', () => {
+    it('should return all jobs with name', async function() {
+      await queue.add(
+        'foo',
+        { c: 1, j: 1 },
+        {
+          delay: 5000,
+          jobId: '1',
+        },
+      );
+
+      await queue.add(
+        'foo',
+        { c: 1, j: 2 },
+        {
+          delay: 5000,
+          jobId: '2',
+        },
+      );
+
+      await queue.add(
+        'bar',
+        { c: 2, j: 1 },
+        {
+          delay: 5000,
+          jobId: '3',
+        },
+      );
+
+      await delay(500);
+
+      const { jobs: fooJobs, newCursor } = await Job.fromName(
+        queue,
+        'foo',
+        0,
+        1000,
+      );
+      expect(newCursor).to.equal(null);
+
+      const fooJobIds = fooJobs.map(j => j.id);
+      expect(fooJobIds).to.have.members(['1', '2']);
+      expect(fooJobIds).to.have.length(2);
+
+      const { jobs: barJobs } = await Job.fromName(queue, 'bar');
+      expect(barJobs).to.have.length(1);
     });
   });
 });

--- a/src/test/test_job.ts
+++ b/src/test/test_job.ts
@@ -632,6 +632,7 @@ describe('Job', function() {
         {
           delay: 5000,
           jobId: '3',
+          removeOnComplete: true,
         },
       );
 
@@ -651,6 +652,11 @@ describe('Job', function() {
 
       const { jobs: barJobs } = await Job.fromName(queue, 'bar');
       expect(barJobs).to.have.length(1);
+
+      await barJobs[0].remove();
+
+      const { jobs: emptyBarJobs } = await Job.fromName(queue, 'bar');
+      expect(emptyBarJobs).to.eql([]);
     });
   });
 });

--- a/src/test/test_job.ts
+++ b/src/test/test_job.ts
@@ -560,4 +560,44 @@ describe('Job', function() {
       await worker.close();
     });
   });
+
+  describe('.fromIdPattern', () => {
+    it('should return all matching jobs', async function() {
+      await queue.add(
+        'test',
+        { c: 1, j: 1 },
+        {
+          delay: 5000,
+          jobId: 'customer1:job1',
+        },
+      );
+
+      await queue.add(
+        'test',
+        { c: 1, j: 2 },
+        {
+          delay: 5000,
+          jobId: 'customer1:job2',
+        },
+      );
+
+      await queue.add(
+        'test',
+        { c: 2, j: 1 },
+        {
+          delay: 5000,
+          jobId: 'customer2:job1',
+        },
+      );
+
+      await delay(500);
+
+      const { jobs, newCursor } = await Job.fromIdPattern(queue, 'customer1:*');
+      expect(jobs).to.have.length(2);
+
+      const jobIds = jobs.map(j => j.id);
+      expect(jobIds).to.have.members(['customer1:job1', 'customer1:job2']);
+      expect(newCursor).to.equal(0);
+    });
+  });
 });


### PR DESCRIPTION
I'm using bullmq for [Quirrel](https://quirrel.dev) and need a way to fetch pending jobs. This PR adds a new function `getJobByIdPattern` that can be used like the following:

```ts
const { newCursor, jobs: jobsByCustomer1 } = await queue.getJobByIdPattern("customer1:*")

// later on ...

const { jobs: nextBatchOfJobsByCustomer1 } = await queue.getJobByIdPattern("customer1:*", newCursor)
```
