### PR TITLE
Add missing TS definition for rate limit options

### DIFF
--- a/src/interfaces/queue-options.ts
+++ b/src/interfaces/queue-options.ts
@@ -18,7 +18,9 @@ export interface QueueOptions extends QueueBaseOptions {
   defaultJobOptions?: JobsOptions;
 
   limiter?: {
-    groupKey: string;
+    duration: number,
+    groupKey?: string;
+    max: number,
   };
 
   streams?: {

--- a/src/interfaces/queue-options.ts
+++ b/src/interfaces/queue-options.ts
@@ -18,9 +18,9 @@ export interface QueueOptions extends QueueBaseOptions {
   defaultJobOptions?: JobsOptions;
 
   limiter?: {
-    duration: number,
-    groupKey?: string;
-    max: number,
+    duration?: number,
+    groupKey: string;
+    max?: number,
   };
 
   streams?: {


### PR DESCRIPTION
### Summary

As indicated by tests/test_rate_limiter.ts: https://github.com/taskforcesh/bullmq/blob/3a958dd30d09a049b0d761679d3b8d92709e815e/src/test/test_rate_limiter.ts

There are more limiter options available than are currently included in the Typescript definition.
