### PR TITLE
Fix job types

### DIFF
--- a/src/classes/compat.ts
+++ b/src/classes/compat.ts
@@ -94,7 +94,7 @@ export class Queue3<T = any> extends EventEmitter {
    * If the promise is rejected, the error will be passed as a second argument to the "failed" event.
    * If it is resolved, its value will be the "completed" event's second argument.
    */
-  async process(processor: string | Processor) {
+  async process(processor: string | Processor<T>) {
     if (this.worker) {
       throw new Error('Queue3.process() cannot be called twice');
     }

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -23,7 +23,7 @@ export interface JobJson {
   returnvalue: string;
 }
 
-export class Job<T = any, R = any> {
+export class Job<T = any, R = any, N extends string = string> {
   progress: number | object = 0;
   returnvalue: R = null;
   stacktrace: string[] = null;
@@ -40,7 +40,7 @@ export class Job<T = any, R = any> {
 
   constructor(
     private queue: QueueBase,
-    public name: string,
+    public name: N,
     public data: T,
     public opts: JobsOptions = {},
     public id?: string,
@@ -60,25 +60,25 @@ export class Job<T = any, R = any> {
     this.toKey = queue.toKey.bind(queue);
   }
 
-  static async create<T = any, R = any>(
+  static async create<T = any, R = any, N extends string = string>(
     queue: QueueBase,
-    name: string,
+    name: N,
     data: T,
     opts?: JobsOptions,
   ) {
     const client = await queue.client;
 
-    const job = new Job<T, R>(queue, name, data, opts, opts && opts.jobId);
+    const job = new Job<T, R, N>(queue, name, data, opts, opts && opts.jobId);
 
     job.id = await job.addJob(client);
 
     return job;
   }
 
-  static async createBulk<T = any, R = any>(
+  static async createBulk<T = any, R = any, N extends string = string>(
     queue: QueueBase,
     jobs: {
-      name: string;
+      name: N;
       data: T;
       opts?: JobsOptions;
     }[],
@@ -86,7 +86,7 @@ export class Job<T = any, R = any> {
     const client = await queue.client;
 
     const jobInstances = jobs.map(
-      job => new Job<T, R>(queue, job.name, job.data, job.opts),
+      job => new Job<T, R, N>(queue, job.name, job.data, job.opts),
     );
 
     const multi = client.multi();

--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -4,7 +4,11 @@ import { JobsOptions, QueueOptions, RepeatOptions } from '../interfaces';
 import { Job, QueueGetters, Repeat } from './';
 import { Scripts } from './scripts';
 
-export class Queue<T = any> extends QueueGetters {
+export class Queue<
+  T = any,
+  R = any,
+  N extends string = string
+> extends QueueGetters {
   token = v4();
   jobsOpts: JobsOptions;
   limiter: {
@@ -44,7 +48,7 @@ export class Queue<T = any> extends QueueGetters {
     });
   }
 
-  async add(name: string, data: T, opts?: JobsOptions) {
+  async add(name: N, data: T, opts?: JobsOptions) {
     if (opts && opts.repeat) {
       return (await this.repeat).addNextRepeatableJob(
         name,
@@ -55,7 +59,7 @@ export class Queue<T = any> extends QueueGetters {
     } else {
       const jobId = this.jobIdForGroup(opts, data);
 
-      const job = await Job.create(this, name, data, {
+      const job = await Job.create<T, R, N>(this, name, data, {
         ...this.jobsOpts,
         ...opts,
         jobId,
@@ -80,7 +84,7 @@ export class Queue<T = any> extends QueueGetters {
    * @param jobs: [] The array of jobs to add to the queue. Each job is defined by 3
    * properties, 'name', 'data' and 'opts'. They follow the same signature as 'Queue.add'.
    */
-  async addBulk(jobs: { name: string; data: T; opts?: JobsOptions }[]) {
+  async addBulk(jobs: { name: N; data: T; opts?: JobsOptions }[]) {
     return Job.createBulk(
       this,
       jobs.map(job => ({
@@ -120,11 +124,7 @@ export class Queue<T = any> extends QueueGetters {
     return (await this.repeat).getRepeatableJobs(start, end, asc);
   }
 
-  async removeRepeatable(
-    name: string,
-    repeatOpts: RepeatOptions,
-    jobId?: string,
-  ) {
+  async removeRepeatable(name: N, repeatOpts: RepeatOptions, jobId?: string) {
     return (await this.repeat).removeRepeatable(name, repeatOpts, jobId);
   }
 

--- a/src/classes/sandbox.ts
+++ b/src/classes/sandbox.ts
@@ -1,5 +1,7 @@
-const sandbox = (processFile: any, childPool: any) => {
-  return async function process(job: any) {
+import { Job } from './job';
+
+const sandbox = <T, R, N extends string>(processFile: any, childPool: any) => {
+  return async function process(job: Job<T, R, N>): Promise<R> {
     const child = await childPool.retain(processFile);
     let msgHandler: any;
     let exitHandler: any;
@@ -9,8 +11,8 @@ const sandbox = (processFile: any, childPool: any) => {
       job: job.asJSON(),
     });
 
-    const done = new Promise((resolve, reject) => {
-      msgHandler = (msg: any) => {
+    const done: Promise<R> = new Promise((resolve, reject) => {
+      msgHandler = async (msg: any) => {
         switch (msg.cmd) {
           case 'completed':
             resolve(msg.value);
@@ -23,10 +25,10 @@ const sandbox = (processFile: any, childPool: any) => {
             break;
           }
           case 'progress':
-            job.updateProgress(msg.value);
+            await job.updateProgress(msg.value);
             break;
           case 'log':
-            job.log(msg.value);
+            await job.log(msg.value);
             break;
         }
       };

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -91,7 +91,11 @@ export class Scripts {
     return (<any>client).removeJob(keys.concat([queue.keys.events, jobId]));
   }
 
-  static async extendLock(worker: Worker, jobId: string, token: string) {
+  static async extendLock<T, R, N extends string>(
+    worker: Worker<T, R, N>,
+    jobId: string,
+    token: string,
+  ) {
     const client = await worker.client;
     const opts: WorkerOptions = worker.opts;
     const args = [
@@ -362,7 +366,11 @@ export class Scripts {
     return (<any>client).reprocessJob(keys.concat(args));
   }
 
-  static async moveToActive(worker: Worker, token: string, jobId?: string) {
+  static async moveToActive<T, R, N extends string>(
+    worker: Worker<T, R, N>,
+    token: string,
+    jobId?: string,
+  ) {
     const client = await worker.client;
     const opts = worker.opts;
 

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -22,7 +22,7 @@ export class Worker<T = any> extends QueueBase {
 
   private drained: boolean;
   private waiting = false;
-  private processFn: Processor;
+  private processFn: Processor<T>;
 
   private resumeWorker: () => void;
   private paused: Promise<void>;
@@ -35,7 +35,7 @@ export class Worker<T = any> extends QueueBase {
   private processing: Map<Promise<Job<T> | string>, string>; // { [index: number]: Promise<Job | void> } = {};
   constructor(
     name: string,
-    processor: string | Processor,
+    processor: string | Processor<T>,
     opts: WorkerOptions = {},
   ) {
     super(name, opts);

--- a/src/interfaces/worker-options.ts
+++ b/src/interfaces/worker-options.ts
@@ -1,7 +1,9 @@
 import { Job } from '../classes';
 import { AdvancedOptions, QueueBaseOptions, RateLimiterOptions } from './';
 
-export type Processor<T> = (job: Job<T>) => Promise<any>;
+export type Processor<T = any, R = any, N extends string = string> = (
+  job: Job<T, R, N>,
+) => Promise<R>;
 
 export interface WorkerOptions extends QueueBaseOptions {
   concurrency?: number;

--- a/src/interfaces/worker-options.ts
+++ b/src/interfaces/worker-options.ts
@@ -1,7 +1,7 @@
 import { Job } from '../classes';
 import { AdvancedOptions, QueueBaseOptions, RateLimiterOptions } from './';
 
-export type Processor = (job: Job) => Promise<any>;
+export type Processor<T> = (job: Job<T>) => Promise<any>;
 
 export interface WorkerOptions extends QueueBaseOptions {
   concurrency?: number;


### PR DESCRIPTION
Was looking into how I could setup BullMQ with typed job names (to ensure no unhandled jobs are added to queues). Ended up adding a few new generics to support those new types. Big ones are adding two new generics to Queue and Worker: job return values and job names, as well as augmenting the Processor with the same Queue and Worker generics.

Didnt change any actual code other than a small fix in `src/classes/sandbox.ts`. With new types, tslint didn’t like the unhandled promises in the msgHandler.

Been using BullMQ for some time now but not super familiar with the codebase itself, let me know if there’s anything you’d like me to change with this! 

Side note: I'm a huge fan of Bull, amazing piece of technology!
