### PR TITLE
Fix clientCommandMessageReg

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -15,7 +15,7 @@ import { isRedisInstance } from '../utils';
 // note: sandboxed processors would also like to define concurrency per process
 // for better resource utilization.
 
-export const clientCommandMessageReg = /ERR unknown command '\s*client\s*'/;
+export const clientCommandMessageReg = /ERR unknown command ['\`]\s*client\s*['\`]/;
 
 export class Worker<
   T = any,

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -15,7 +15,7 @@ import { isRedisInstance } from '../utils';
 // note: sandboxed processors would also like to define concurrency per process
 // for better resource utilization.
 
-export const clientCommandMessageReg = /ERR unknown command ['\`]\s*client\s*['\`]/;
+export const clientCommandMessageReg = /ERR unknown command ['`]\s*client\s*['`]/;
 
 export class Worker<
   T = any,


### PR DESCRIPTION
In Google Cloud memorystorage redis v5 the error that throw when you use client is:
```bash
root@tortilla2-8649d75859-nbmmh:/usr/src/app# netcat redis-memorystore 6379
client id
-ERR unknown command `client`, with args beginning with: `id`,
```
I update regex to get this error too