### PR TITLE
Fix disappearing jobs when promoted on paused queue

### DIFF
--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -430,6 +430,7 @@ export class Scripts {
     const keys = [
       queue.keys.delayed,
       queue.keys.wait,
+      queue.keys.paused,
       queue.keys.priority,
       queue.keys.events,
     ];

--- a/src/commands/promote-5.lua
+++ b/src/commands/promote-5.lua
@@ -4,8 +4,9 @@
      Input:
       KEYS[1] 'delayed'
       KEYS[2] 'wait'
-      KEYS[3] 'priority'
-      KEYS[4] 'event stream'
+      KEYS[3] 'paused'
+      KEYS[4] 'priority'
+      KEYS[5] 'event stream'
 
       ARGV[1]  queue.toKey('')
       ARGV[2]  jobId
@@ -21,13 +22,17 @@ if redis.call("ZREM", KEYS[1], jobId) == 1 then
 
   local target = KEYS[2];
 
+  if rcall("EXISTS", KEYS[3]) == 1 then
+    target = KEYS[3]
+  end
+
   if priority == 0 then
     -- LIFO or FIFO
     rcall("LPUSH", target, jobId)
   else
     -- Priority add
-    rcall("ZADD", KEYS[3], priority, jobId)
-    local count = rcall("ZCOUNT", KEYS[3], 0, priority)
+    rcall("ZADD", KEYS[4], priority, jobId)
+    local count = rcall("ZCOUNT", KEYS[4], 0, priority)
 
     local len = rcall("LLEN", target)
     local id = rcall("LINDEX", target, len - (count - 1))
@@ -39,7 +44,7 @@ if redis.call("ZREM", KEYS[1], jobId) == 1 then
   end
 
   -- Emit waiting event (wait..ing@token)
-  rcall("XADD", KEYS[4], "*", "event", "waiting", "jobId", jobId, "prev", "delayed");
+  rcall("XADD", KEYS[5], "*", "event", "waiting", "jobId", jobId, "prev", "delayed");
 
   rcall("HSET", ARGV[1] .. jobId, "delay", 0)
 

--- a/src/test/test_job.ts
+++ b/src/test/test_job.ts
@@ -340,9 +340,8 @@ describe('Job', function() {
     });
 
     it('should promote delayed job to the right queue if queue is paused', async () => {
-      const normalJob = await Job.create(queue, 'normal', { foo: 'bar' });
-      const delayedJob = await Job.create(
-        queue,
+      const normalJob = await queue.add('normal', { foo: 'bar' });
+      const delayedJob = await queue.add(
         'delayed',
         { foo: 'bar' },
         { delay: 1 },

--- a/src/test/test_job.ts
+++ b/src/test/test_job.ts
@@ -338,6 +338,25 @@ describe('Job', function() {
         throw new Error('Job should not be promoted!');
       } catch (err) {}
     });
+
+    it('should promote delayed job to the right queue if queue is paused', async () => {
+      const normalJob = await Job.create(queue, 'normal', { foo: 'bar' });
+      const delayedJob = await Job.create(
+        queue,
+        'delayed',
+        { foo: 'bar' },
+        { delay: 1 },
+      );
+
+      await queue.pause();
+      await delayedJob.promote();
+      await queue.resume();
+
+      const waitingJobsCount = await queue.getWaitingCount();
+      expect(waitingJobsCount).to.be.equal(2);
+      const delayedJobsNewState = await delayedJob.getState();
+      expect(delayedJobsNewState).to.be.equal('waiting');
+    });
   });
 
   // TODO:


### PR DESCRIPTION
Hi,

I believe I found a bug that leads to jobs disappearing from the waiting queue if they where added while the queue was paused. This is the shortest example I could create that reproduces the error, no workers are needed:

```
const Queue = require('bullmq').Queue;
const queue = new Queue('bugtest');

(async () => {
  await queue.drain();
  
  const first = await queue.add('first', null);
  const second = await queue.add('second', null, {delay: 1});

  await queue.pause();
  await second.promote();
  await queue.resume();

  console.log(await queue.getWaitingCount()); // Should output 2, actually 1
  console.log(await second.getState()); // Should output waiting, actually 'unknown'

  queue.close();
})()
```

After some investigation I think the root cause is how the promote Lua script is implemented:
```
--[[
...
      KEYS[2] 'wait'
...
local target = KEYS[2];
```
**It always places promoted jobs to the wait queue even if the queue is paused.**

1. If we have jobs in the wait queue (first job) then pause the queue it is renamed to paused.
2. When calling promote (second job) it moves the job to the wait queue regardless whether the queue is paused or not.
3. Resuming the paused queue renames paused to wait without checking if there were items in the wait queue, so they are gone from all queues.

I implemented a test that follows the above sample code. It in fact failed, so up next I extended the promote Lua script. Now it can detect if the queue is paused and it puts the promoted jobs to the paused queue. The new test as well as all previous ones now pass.

Please take a look at this pull request and if you agree that this is in fact an unwanted behaviour consider accepting my fix for it.
Thanks!