### PR TITLE
feat: add ability to get if queue is paused or not

### DIFF
--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -120,6 +120,12 @@ export class Queue<
     this.emit('resumed');
   }
 
+  async isPaused() {
+    const client = await this.client;
+    const pausedKeyExists = await client.hexists(this.keys.meta, 'paused');
+    return pausedKeyExists === 1;
+  }
+
   async getRepeatableJobs(start?: number, end?: number, asc?: boolean) {
     return (await this.repeat).getRepeatableJobs(start, end, asc);
   }

--- a/src/test/test_pause.ts
+++ b/src/test/test_pause.ts
@@ -302,4 +302,14 @@ describe('Pause', function() {
       });
     });
   });
+
+  it('gets the right response from isPaused', async () => {
+    await queue.pause();
+    const isPausedQueuePaused = await queue.isPaused();
+    expect(isPausedQueuePaused).to.be.true;
+
+    await queue.resume();
+    const isResumedQueuePaused = await queue.isPaused();
+    expect(isResumedQueuePaused).to.be.false;
+  });
 });


### PR DESCRIPTION
Currently it is possible to pause a queue or resume it but there were no way to find out if a queue is paused or not.
Directly using Redis commands would be an anti-pattern in my opinion as the name of the keys and the way how paused state is stored should be an internal detail that the users should not be aware of or interfere with.

I created a public method in the Queue class that exposes if it is paused or not. If the implementation should be renamed or replaced, I'm happy to move it around.