### PR TITLE
fix(worker): catch errors from created Repeat

### DIFF
--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -43,6 +43,7 @@ export class Queue<
           ...this.opts,
           connection: await this.client,
         });
+        this._repeat.on('error', e => this.emit.bind(this, e));
       }
       resolve(this._repeat);
     });

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -102,6 +102,7 @@ export class Worker<
           ...this.opts,
           connection,
         });
+        this._repeat.on('error', e => this.emit.bind(this, e));
       }
       resolve(this._repeat);
     });


### PR DESCRIPTION
Fixes a bug where the `Repeat` created in the worker for repeat jobs does not have an error handler installed, which causes an uncaught exception even if an error handler is installed on the worker in the event of a Redis network error, for example.