### PR TITLE
docs(interfaces): use block comments; add references and descriptions

### DIFF
--- a/src/interfaces/advanced-options.ts
+++ b/src/interfaces/advanced-options.ts
@@ -1,5 +1,7 @@
 export interface AdvancedOptions {
-  // A set of custom backoff strategies keyed by name.
+  /**
+   * A set of custom backoff strategies keyed by name.
+   */
   backoffStrategies?: {};
 }
 

--- a/src/interfaces/backoff-options.ts
+++ b/src/interfaces/backoff-options.ts
@@ -1,4 +1,15 @@
+/**
+ * Settings for backing off failed jobs.
+ *
+ * @see {@link https://docs.bullmq.io/guide/retrying-failing-jobs}
+ */
 export interface BackoffOptions {
+  /**
+   * Name of the backoff strategy.
+   */
   type: string;
+  /**
+   * Delay in milliseconds.
+   */
   delay?: number;
 }

--- a/src/interfaces/jobs-options.ts
+++ b/src/interfaces/jobs-options.ts
@@ -2,55 +2,86 @@ import { RepeatOptions } from './repeat-options';
 import { BackoffOptions } from './backoff-options';
 
 export interface JobsOptions {
-  //  default Date.now()
+  /**
+   * Defaults to `Date.now()`
+   */
   timestamp?: number;
 
-  // Ranges from 1 (highest priority) to MAX_INT  (lowest priority). Note that
-  // using priorities has a slight impact on performance,
-  // so do not use it if not required.
+  /**
+   * Ranges from 1 (highest priority) to MAX_INT (lowest priority). Note that
+   * using priorities has a slight impact on performance,
+   * so do not use it if not required.
+   */
   priority?: number;
 
-  // An amount of miliseconds to wait until this job can be processed.
-  // Note that for accurate delays, worker and producers
-  // should have their clocks synchronized.
+  /**
+   * An amount of miliseconds to wait until this job can be processed.
+   * Note that for accurate delays, worker and producers
+   * should have their clocks synchronized.
+   */
   delay?: number;
 
-  // The total number of attempts to try the job until it completes.
+  /**
+   * The total number of attempts to try the job until it completes.
+   */
   attempts?: number;
 
-  // Repeat job according to a cron specification.
+  /**
+   * Repeat this job, for example based on a `cron` schedule.
+   */
   repeat?: RepeatOptions;
 
-  // Rate limiter key to use if rate limiter enabled.
+  /**
+   * Rate limiter key to use if rate limiter enabled.
+   *
+   * @see {@link https://docs.bullmq.io/guide/rate-limiting}
+   */
   rateLimiterKey?: string;
 
-  // Backoff setting for automatic retries if the job fails
+  /**
+   * Backoff setting for automatic retries if the job fails
+   */
   backoff?: number | BackoffOptions;
 
-  // if true, adds the job to the right of the queue instead of the left (default false)
+  /**
+   * If true, adds the job to the right of the queue instead of the left (default false)
+   *
+   * @see {@link https://docs.bullmq.io/guide/jobs/lifo}
+   */
   lifo?: boolean;
 
-  // The number of milliseconds after which the job should be
-  // fail with a timeout error [optional]
+  /**
+   * The number of milliseconds after which the job should be
+   * fail with a timeout error.
+   */
   timeout?: number;
 
-  // Override the job ID - by default, the job ID is a unique
-  // integer, but you can use this setting to override it.
-  // If you use this option, it is up to you to ensure the
-  // jobId is unique. If you attempt to add a job with an id that
-  // already exists, it will not be added.
+  /**
+   * Override the job ID - by default, the job ID is a unique
+   * integer, but you can use this setting to override it.
+   * If you use this option, it is up to you to ensure the
+   * jobId is unique. If you attempt to add a job with an id that
+   * already exists, it will not be added.
+   */
   jobId?: string;
 
-  // If true, removes the job when it successfully completes
-  // A number specify the max amount of jobs to keep.
-  // Default behavior is to keep the job in the completed set.
+  /**
+   * If true, removes the job when it successfully completes
+   * When given an number, it specifies the maximum amount of
+   * jobs to keep.
+   * Default behavior is to keep the job in the completed set.
+   */
   removeOnComplete?: boolean | number;
 
-  // If true, removes the job when it fails after all attempts.
-  // A number specify the max amount of jobs to keep.
-  // Default behavior is to keep the job in the failed set.
+  /**
+   * If true, removes the job when it fails after all attempts.
+   * When given an number, it specifies the maximum amount of
+   * jobs to keep.
+   */
   removeOnFail?: boolean | number;
 
-  // Limits the amount of stack trace lines that will be recorded in the stacktrace.
+  /**
+   * Limits the amount of stack trace lines that will be recorded in the stacktrace.
+   */
   stackTraceLimit?: number;
 }

--- a/src/interfaces/queue-options.ts
+++ b/src/interfaces/queue-options.ts
@@ -11,7 +11,10 @@ export enum ClientType {
 export interface QueueBaseOptions {
   connection?: ConnectionOptions;
   client?: Redis;
-  prefix?: string; // prefix for all queue keys.
+  /**
+   * Prefix for all queue keys.
+   */
+  prefix?: string;
 }
 
 export interface QueueOptions extends QueueBaseOptions {
@@ -23,7 +26,10 @@ export interface QueueOptions extends QueueBaseOptions {
 
   streams?: {
     events: {
-      maxLen: number; // Max aproximated length for streams
+      /**
+       * Max aproximated length for streams
+       */
+      maxLen: number;
     };
   };
 }

--- a/src/interfaces/queue-scheduler-options.ts
+++ b/src/interfaces/queue-scheduler-options.ts
@@ -1,6 +1,20 @@
 import { QueueBaseOptions } from '../interfaces';
 
+/**
+ * Options for customizing the behaviour of the scheduler.
+ *
+ * @see {@link https://docs.bullmq.io/guide/jobs/stalled}
+ * @see {@link https://docs.bullmq.io/guide/queuescheduler}
+ */
 export interface QueueSchedulerOptions extends QueueBaseOptions {
+  /**
+   * Amount of times a job can be recovered from a stalled state
+   * to the `wait` state. If this is exceeded, the job is moved
+   * to `failed`.
+   */
   maxStalledCount?: number;
+  /**
+   * Number of milliseconds between stallness checks.
+   */
   stalledInterval?: number;
 }

--- a/src/interfaces/rate-limiter-options.ts
+++ b/src/interfaces/rate-limiter-options.ts
@@ -1,10 +1,22 @@
 export interface RateLimiterOptions {
-  // Max number of jobs processed
+  /**
+   * Max number of jobs to process in the time period
+   * specified in `duration`.
+   */
   max: number;
 
-  // per duration in milliseconds
+  /**
+   * Time in milliseconds. During this time, a maximum
+   * of `max` jobs will be processed.
+   */
   duration: number;
 
-  // grouping path key in job data
+  /**
+   * It is possible to define a rate limiter based on group keys,
+   * for example you may want to have a rate limiter per customer
+   * instead of a global rate limiter for all customers
+   *
+   * @see {@link https://docs.bullmq.io/guide/rate-limiting}
+   */
   groupKey?: string;
 }

--- a/src/interfaces/repeat-options.ts
+++ b/src/interfaces/repeat-options.ts
@@ -1,18 +1,38 @@
+/**
+ * Settings for repeatable jobs
+ *
+ * @see {@link https://docs.bullmq.io/guide/jobs/repeatable}
+ */
 export interface RepeatOptions {
-  // Cron string
+  /**
+   * A cron pattern
+   */
   cron?: string;
-  // Timezone
+  /**
+   * Timezone
+   */
   tz?: string;
-  // Start date when the repeat job should start repeating (only with cron).
+  /**
+   * Start date when the repeat job should start repeating (only with `cron`).
+   */
   startDate?: Date | string | number;
-  // End date when the repeat job should stop repeating.
+  /**
+   * End date when the repeat job should stop repeating.
+   */
   endDate?: Date | string | number;
-  // Number of times the job should repeat at max.
+  /**
+   * Number of times the job should repeat at max.
+   */
   limit?: number;
-  // Repeat every millis (cron setting cannot be used together with this setting.)
+  /**
+   * Repeat after this amount of milliseconds
+   * (`cron` setting cannot be used together with this setting.)
+   */
   every?: number;
 
-  // The start value for the repeat iteration count.
+  /**
+   * The start value for the repeat iteration count.
+   */
   count?: number;
   prevMillis?: number;
   jobId?: string;

--- a/src/interfaces/sandboxed-job-processor.ts
+++ b/src/interfaces/sandboxed-job-processor.ts
@@ -1,5 +1,8 @@
 import { SandboxedJob } from './sandboxed-job';
 
+/**
+ * @see {@link https://docs.bullmq.io/guide/workers/sandboxed-processors}
+ */
 export type SandboxedJobProcessor<T = any, R = any> =
   | ((job: SandboxedJob<T, R>) => R | PromiseLike<R>)
   | ((

--- a/src/interfaces/sandboxed-job.ts
+++ b/src/interfaces/sandboxed-job.ts
@@ -1,6 +1,9 @@
 import { JobJson } from '../classes/job';
 import { JobsOptions } from './jobs-options';
 
+/**
+ * @see {@link https://docs.bullmq.io/guide/workers/sandboxed-processors}
+ */
 export interface SandboxedJob<T = any, R = any>
   extends Omit<JobJson, 'data' | 'opts' | 'progress' | 'log' | 'returnValue'> {
   data: T;

--- a/src/interfaces/worker-options.ts
+++ b/src/interfaces/worker-options.ts
@@ -1,12 +1,24 @@
 import { Job } from '../classes';
 import { AdvancedOptions, QueueBaseOptions, RateLimiterOptions } from './';
 
+/**
+ * An async function that receives `Job`s and handles them.
+ */
 export type Processor<T = any, R = any, N extends string = string> = (
   job: Job<T, R, N>,
 ) => Promise<R>;
 
 export interface WorkerOptions extends QueueBaseOptions {
+  /**
+   * Amount of jobs that a single worker is allowed to work on
+   * in parallel.
+   *
+   * @see {@link https://docs.bullmq.io/guide/workers/concurrency}
+   */
   concurrency?: number;
+  /**
+   * @see {@link https://docs.bullmq.io/guide/rate-limiting}
+   */
   limiter?: RateLimiterOptions;
   skipDelayCheck?: boolean;
   drainDelay?: number;


### PR DESCRIPTION
- Block comments for IDE support / "intellisense"
- Add links to the docs for further reading
- For links, I used the format described at https://tsdoc.org/pages/tags/see/