### PR TITLE
Fix a bug where waiting for a job to complete can timeout if the job finished faster than the listeners can be registered

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -392,7 +392,9 @@ export class Job<T = any, R = any, N extends string = string> {
 
       // Poll once right now to see if the job has already finished. The job may have been completed before we were able
       // to register the event handlers on the QueueEvents, so we check here to make sure we're not waiting for an event
-      // that has already happened.
+      // that has already happened. We block checking the job until the queue events object is actually listening to
+      // Redis so there's no chance that it will miss events.
+      await queueEvents.waitUntilReady();
       const status = await Scripts.isFinished(this.queue, jobId);
       const finished = status > 0;
       if (finished) {

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -360,47 +360,50 @@ export class Job<T = any, R = any, N extends string = string> {
     await this.queue.waitUntilReady();
 
     const jobId = this.id;
-    const status = await Scripts.isFinished(this.queue, jobId);
-    const finished = status > 0;
-    if (finished) {
-      const job = await Job.fromId(this.queue, this.id);
-      if (status == 2) {
-        throw new Error(job.failedReason);
-      } else {
-        return job.returnvalue;
+    return new Promise<any>(async (resolve, reject) => {
+      let timeout: NodeJS.Timeout;
+      if (ttl) {
+        timeout = setTimeout(() => onFailed('timedout'), ttl);
       }
-    } else {
-      return new Promise((resolve, reject) => {
-        let timeout: NodeJS.Timeout;
-        if (ttl) {
-          timeout = setTimeout(() => onFailed('timedout'), ttl);
+
+      function onCompleted(args: any) {
+        removeListeners();
+        resolve(args.returnvalue);
+      }
+
+      function onFailed(args: any) {
+        removeListeners();
+        reject(new Error(args.failedReason || args));
+      }
+
+      const completedEvent = `completed:${jobId}`;
+      const failedEvent = `failed:${jobId}`;
+
+      queueEvents.on(completedEvent, onCompleted);
+      queueEvents.on(failedEvent, onFailed);
+      this.queue.on('closing', onFailed);
+
+      const removeListeners = () => {
+        clearInterval(timeout);
+        queueEvents.removeListener(completedEvent, onCompleted);
+        queueEvents.removeListener(failedEvent, onFailed);
+        this.queue.removeListener('closing', onFailed);
+      };
+
+      // Poll once right now to see if the job has already finished. The job may have been completed before we were able
+      // to register the event handlers on the QueueEvents, so we check here to make sure we're not waiting for an event
+      // that has already happened.
+      const status = await Scripts.isFinished(this.queue, jobId);
+      const finished = status > 0;
+      if (finished) {
+        const job = await Job.fromId(this.queue, this.id);
+        if (status == 2) {
+          onFailed(job);
+        } else {
+          onCompleted(job);
         }
-
-        function onCompleted(args: any) {
-          removeListeners();
-          resolve(args.returnvalue);
-        }
-
-        function onFailed(args: any) {
-          removeListeners();
-          reject(new Error(args.failedReason || args));
-        }
-
-        const completedEvent = `completed:${jobId}`;
-        const failedEvent = `failed:${jobId}`;
-
-        queueEvents.on(completedEvent, onCompleted);
-        queueEvents.on(failedEvent, onFailed);
-        this.queue.on('closing', onFailed);
-
-        const removeListeners = () => {
-          clearInterval(timeout);
-          queueEvents.removeListener(completedEvent, onCompleted);
-          queueEvents.removeListener(failedEvent, onFailed);
-          this.queue.removeListener('closing', onFailed);
-        };
-      });
-    }
+      }
+    });
   }
 
   moveToDelayed(timestamp: number) {


### PR DESCRIPTION
Before this change, `job.waitUntilFinished` did a smart check at the start to see if the job had already been completed. This makes sense -- the QueueEvents object is never going to send another `completed` event for a job that has already been completed, so we need to make sure that we're not listening for an event that never comes.

The problem is that there's a finite amount of time between when we make this first check and when we start listening to the queue events. There is a window after we make the check and before we are listening for the completed event. For very quick to process jobs, they can emit their completed event in this window, so the listeners never find it. The `waitUntilFinished` will fail with a timeout, but the job did actually complete.

This switches the order in which we do things to eliminate this window: we add the completed event listeners first, and then poll once. That way, the jobs that finish very quickly will either hit the event listener if it's already been added, or be noticed by the check at the end. Jobs that have already been completed will be noticed by the check at the end. `Promise`es can only resolve once, so even if both checks fire the function will only return once.

The downside of this approach is that for jobs that have already been completed before the function is even called, we add some extra listeners to the QueueEvents that didn't strictly need to be added. Since these are just in memory doodads, I think this is ok. An alternative would be to run `Scripts.isFinished` at the start and end of the function, but I think that's worse and causes more redis load, whereas extra EventEmitter listeners don't.

Also notable is that the `QueueEvents` instance that you pass to `waitUntilFinished` needs to be connected for `waitUntilFinished` to work. If you just do `.waitUntilFinished(new QueueEvents())`, the `QueueEvents` may not connect to redis and start reading the stream in time to see the event. I think it might make sense to discourage the use of the QueueEvents constructor for this reason, and instead have an async static method that creates one and then `waitUntilReady`s, or even better, waits until the `BLOCK` call has actually been issued. 

I'm also not sure really how to test this because it is a race condition and requires a very specific ordering of events to arise. Are there other tests that do the careful sequencing necessary to test this kind of thing? 