### PR TITLE
Improve job timeout notification by giving the job name and id in the error message

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -363,7 +363,7 @@ export class Job<T = any, R = any, N extends string = string> {
     return new Promise<any>(async (resolve, reject) => {
       let timeout: NodeJS.Timeout;
       if (ttl) {
-        timeout = setTimeout(() => onFailed('timedout'), ttl);
+        timeout = setTimeout(() => onFailed(`Job wait ${this.name} timed out before finishing, no finish notification arrived after ${ttl}ms (id=${jobId})`), ttl);
       }
 
       function onCompleted(args: any) {


### PR DESCRIPTION
Not a huge change but helps when debugging complicated systems that are talking to multiple different backends to identify which piece exactly timed out. 🤷 