### PR TITLE
fix: remove "client" property of QueueBaseOptions (#324)

### DIFF
--- a/src/interfaces/queue-options.ts
+++ b/src/interfaces/queue-options.ts
@@ -1,6 +1,4 @@
 import { JobsOptions } from '../interfaces';
-
-import { Redis } from 'ioredis';
 import { ConnectionOptions } from './redis-options';
 
 export enum ClientType {
@@ -10,7 +8,6 @@ export enum ClientType {
 
 export interface QueueBaseOptions {
   connection?: ConnectionOptions;
-  client?: Redis;
   /**
    * Prefix for all queue keys.
    */


### PR DESCRIPTION
This PR resolves https://github.com/taskforcesh/bullmq/issues/324.

[QueueBaseOptions](https://github.com/taskforcesh/bullmq/blob/5e6631e7c3f40b7857d2f73b48abfd3f9d072b35/src/interfaces/queue-options.ts#L11) has a `client` property that is not used by the code:
https://github.com/taskforcesh/bullmq/blob/5e6631e7c3f40b7857d2f73b48abfd3f9d072b35/src/interfaces/queue-options.ts#L13

Indeed, instead the `connection` property is used:
https://github.com/taskforcesh/bullmq/blob/5e6631e7c3f40b7857d2f73b48abfd3f9d072b35/src/classes/queue-base.ts#L23

Note that this is not related to the [client getter](https://github.com/taskforcesh/bullmq/blob/7372ef16465fdf7d3c803a9cd9c1a25422d53373/src/classes/queue-base.ts#L57) which also uses the aforementioned `connection` property:
https://github.com/taskforcesh/bullmq/blob/5e6631e7c3f40b7857d2f73b48abfd3f9d072b35/src/classes/queue-base.ts#L59