### PR TITLE
Upgrade ioredis

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "test:watch": "yarn lint  && ts-mocha --paths 'src/**/test_*.ts' -w --watch-extensions ts"
   },
   "dependencies": {
-    "@types/ioredis": "^4.16.3",
+    "@types/ioredis": "^4.18.0",
     "cron-parser": "^2.7.3",
     "get-port": "^5.0.0",
-    "ioredis": "^4.17.3",
+    "ioredis": "^4.18.0",
     "lodash": "^4.17.11",
     "semver": "^6.3.0",
     "tslib": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "test:watch": "yarn lint  && ts-mocha --paths 'src/**/test_*.ts' -w --watch-extensions ts"
   },
   "dependencies": {
-    "@types/ioredis": "^4.18.0",
+    "@types/ioredis": "^4.22.2",
     "cron-parser": "^2.7.3",
     "get-port": "^5.0.0",
-    "ioredis": "^4.18.0",
+    "ioredis": "^4.25.0",
     "lodash": "^4.17.11",
     "semver": "^6.3.0",
     "tslib": "^1.10.0",

--- a/src/test/test_repeat.ts
+++ b/src/test/test_repeat.ts
@@ -142,7 +142,7 @@ describe('repeat', function() {
     const worker = new Worker(queueName, async job => {});
 
     const date = new Date('2017-02-07 9:24:00');
-    this.clock.tick(date.getTime());
+    this.clock.setSystemTime(date);
 
     const nextTick = 2 * ONE_SECOND + 100;
 
@@ -157,7 +157,7 @@ describe('repeat', function() {
     let prev: any;
     var counter = 0;
 
-    const completting = new Promise<void>(resolve => {
+    const completing = new Promise<void>(resolve => {
       worker.on('completed', async job => {
         this.clock.tick(nextTick);
         if (prev) {
@@ -172,7 +172,7 @@ describe('repeat', function() {
       });
     });
 
-    await completting;
+    await completing;
     await worker.close();
     await queueScheduler.close();
   });
@@ -183,7 +183,7 @@ describe('repeat', function() {
     await queueScheduler.waitUntilReady();
 
     const date = new Date('2017-02-07 9:24:00');
-    this.clock.tick(date.getTime());
+    this.clock.setSystemTime(date);
     const nextTick = 2 * ONE_SECOND + 500;
     const delay = 5 * ONE_SECOND + 500;
 
@@ -205,7 +205,7 @@ describe('repeat', function() {
     let prev: Job;
     let counter = 0;
 
-    const completting = new Promise<void>((resolve, reject) => {
+    const completing = new Promise<void>((resolve, reject) => {
       worker.on('completed', async job => {
         this.clock.tick(nextTick);
         if (prev) {
@@ -220,7 +220,7 @@ describe('repeat', function() {
       });
     });
 
-    await completting;
+    await completing;
 
     await queueScheduler.close();
     await worker.close();
@@ -232,7 +232,7 @@ describe('repeat', function() {
     await queueScheduler.waitUntilReady();
 
     const date = new Date('2017-02-07 9:24:00');
-    this.clock.tick(date.getTime());
+    this.clock.setSystemTime(date);
     const nextTick = 2 * ONE_SECOND + 500;
     const delay = 5 * ONE_SECOND + 500;
 
@@ -254,7 +254,7 @@ describe('repeat', function() {
     let prev: Job;
     let counter = 0;
 
-    const completting = new Promise<void>((resolve, reject) => {
+    const completing = new Promise<void>((resolve, reject) => {
       worker.on('completed', async job => {
         this.clock.tick(nextTick);
         if (prev) {
@@ -269,7 +269,7 @@ describe('repeat', function() {
       });
     });
 
-    await completting;
+    await completing;
     await queueScheduler.close();
     await worker.close();
   });
@@ -299,7 +299,7 @@ describe('repeat', function() {
 
     let prev: Job;
     let counter = 0;
-    const completting = new Promise<void>((resolve, reject) => {
+    const completing = new Promise<void>((resolve, reject) => {
       queue.on('completed', async job => {
         this.clock.tick(nextTick);
         if (prev) {
@@ -319,7 +319,7 @@ describe('repeat', function() {
       });
     });
 
-    await completting;
+    await completing;
     await queueScheduler.close();
     await worker.close();
   });
@@ -393,7 +393,7 @@ describe('repeat', function() {
     let prev: Job;
     let counter = 0;
 
-    this.clock.tick(date.getTime());
+    this.clock.setSystemTime(date);
 
     const nextTick = ONE_SECOND + 1;
     const repeat = { cron: '*/1 * * * * *' };
@@ -455,7 +455,7 @@ describe('repeat', function() {
     let processor;
     const jobId = 'xxxx';
 
-    this.clock.tick(date.getTime());
+    this.clock.setSystemTime(date);
 
     const nextTick = 2 * ONE_SECOND + 10;
     const repeat = { cron: '*/2 * * * * *' };
@@ -590,7 +590,7 @@ describe('repeat', function() {
     await queueScheduler.waitUntilReady();
 
     const date = new Date('2017-02-07 9:24:00');
-    this.clock.tick(date.getTime());
+    this.clock.setSystemTime(date);
     const nextTick = ONE_SECOND + 500;
 
     const worker = new Worker(queueName, NoopProc);
@@ -604,7 +604,7 @@ describe('repeat', function() {
 
     var counter = 0;
 
-    const completting = new Promise<void>((resolve, reject) => {
+    const completing = new Promise<void>((resolve, reject) => {
       worker.on('completed', () => {
         this.clock.tick(nextTick);
         counter++;
@@ -616,7 +616,7 @@ describe('repeat', function() {
       });
     });
 
-    await completting;
+    await completing;
     await worker.close();
     await queueScheduler.close();
   });
@@ -669,9 +669,7 @@ describe('repeat', function() {
     const interval = ONE_SECOND * 2;
     const date = new Date('2017-02-07 9:24:00');
 
-    // Quantize time
-    const time = Math.floor(date.getTime() / interval) * interval;
-    this.clock.tick(time);
+    this.clock.setSystemTime(date);
 
     const nextTick = ONE_SECOND * 2 + 500;
 
@@ -685,7 +683,7 @@ describe('repeat', function() {
     let prevType: string;
     let counter = 0;
 
-    const completting = new Promise<void>(resolve => {
+    const completing = new Promise<void>(resolve => {
       worker.on('completed', job => {
         this.clock.tick(nextTick);
         if (prevType) {
@@ -699,7 +697,7 @@ describe('repeat', function() {
       });
     });
 
-    await completting;
+    await completing;
     await worker.close();
     await queueScheduler.close();
   });
@@ -724,7 +722,7 @@ describe('repeat', function() {
     await queueScheduler.waitUntilReady();
 
     const date = new Date('2017-02-07 9:24:00');
-    this.clock.tick(date.getTime());
+    this.clock.setSystemTime(date);
     const nextTick = 1 * ONE_SECOND + 500;
 
     const worker = new Worker(queueName, async job => {});

--- a/yarn.lock
+++ b/yarn.lock
@@ -615,10 +615,10 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.14.tgz#44d2dd0b5de6185089375d976b4ec5caf6861193"
   integrity sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==
 
-"@types/ioredis@^4.16.3":
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/@types/ioredis/-/ioredis-4.17.5.tgz#9c8c6f08b98fd0f9e2dd40217434db607668ed21"
-  integrity sha512-MkG9WEGozGBDL869a0WJUBfDKodOFSfRfR4zSfq610MrdL9l+ToyHPyNqa4oSvAAAmldo06Gq1V+EzFRrNByfQ==
+"@types/ioredis@^4.18.0":
+  version "4.22.2"
+  resolved "https://registry.yarnpkg.com/@types/ioredis/-/ioredis-4.22.2.tgz#a4fddabd6032dc31f243498a6ac6d920eca12ba9"
+  integrity sha512-32nEh2Eq20xlgtIqVx1kkJkpqh5V1wqMsumK8Y9Izma/vW9k8Ro7sD+y4G6SyCqz8u9+HcssZ6+E83Modta38w==
   dependencies:
     "@types/node" "*"
 
@@ -1675,6 +1675,13 @@ debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
   integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
+  dependencies:
+    ms "2.1.2"
+
+debug@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
   dependencies:
     ms "2.1.2"
 
@@ -2843,20 +2850,21 @@ invert-kv@^1.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
-ioredis@^4.17.3:
-  version "4.17.3"
-  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.17.3.tgz#9938c60e4ca685f75326337177bdc2e73ae9c9dc"
-  integrity sha512-iRvq4BOYzNFkDnSyhx7cmJNOi1x/HWYe+A4VXHBu4qpwJaGT1Mp+D2bVGJntH9K/Z/GeOM/Nprb8gB3bmitz1Q==
+ioredis@^4.18.0:
+  version "4.25.0"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.25.0.tgz#bc78d1fcda9d2b6f120f47c5764672734810b369"
+  integrity sha512-UoeqXpZB05aerGD3gB9NiigMsAyph+N+GWH8+3lX1+26caVV03GkL6JoLxS2HCxyvqCWbNsVSZTAp5W12qe23A==
   dependencies:
     cluster-key-slot "^1.1.0"
-    debug "^4.1.1"
+    debug "^4.3.1"
     denque "^1.1.0"
     lodash.defaults "^4.2.0"
     lodash.flatten "^4.4.0"
-    redis-commands "1.5.0"
+    p-map "^2.1.0"
+    redis-commands "1.7.0"
     redis-errors "^1.2.0"
     redis-parser "^3.0.0"
-    standard-as-callback "^2.0.1"
+    standard-as-callback "^2.1.0"
 
 ip-regex@^2.1.0:
   version "2.1.0"
@@ -4590,7 +4598,7 @@ p-locate@^4.1.0:
   dependencies:
     p-limit "^2.2.0"
 
-p-map@^2.0.0:
+p-map@^2.0.0, p-map@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
@@ -5176,10 +5184,10 @@ redeyed@~2.1.0:
   dependencies:
     esprima "~4.0.0"
 
-redis-commands@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.5.0.tgz#80d2e20698fe688f227127ff9e5164a7dd17e785"
-  integrity sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg==
+redis-commands@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.7.0.tgz#15a6fea2d58281e27b1cd1acfb4b293e278c3a89"
+  integrity sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==
 
 redis-errors@^1.0.0, redis-errors@^1.2.0:
   version "1.2.0"
@@ -5676,10 +5684,10 @@ ssri@^6.0.0, ssri@^6.0.1:
   dependencies:
     figgy-pudding "^3.5.1"
 
-standard-as-callback@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.0.1.tgz#ed8bb25648e15831759b6023bdb87e6b60b38126"
-  integrity sha512-NQOxSeB8gOI5WjSaxjBgog2QFw55FV8TkS6Y07BiB3VJ8xNTvUYm0wl0s8ObgQ5NhdpnNfigMIKjgPESzgr4tg==
+standard-as-callback@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
+  integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
 
 stream-combiner2@~1.1.1:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -615,7 +615,7 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.14.tgz#44d2dd0b5de6185089375d976b4ec5caf6861193"
   integrity sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==
 
-"@types/ioredis@^4.18.0":
+"@types/ioredis@^4.22.2":
   version "4.22.2"
   resolved "https://registry.yarnpkg.com/@types/ioredis/-/ioredis-4.22.2.tgz#a4fddabd6032dc31f243498a6ac6d920eca12ba9"
   integrity sha512-32nEh2Eq20xlgtIqVx1kkJkpqh5V1wqMsumK8Y9Izma/vW9k8Ro7sD+y4G6SyCqz8u9+HcssZ6+E83Modta38w==
@@ -2850,7 +2850,7 @@ invert-kv@^1.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
-ioredis@^4.18.0:
+ioredis@^4.25.0:
   version "4.25.0"
   resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.25.0.tgz#bc78d1fcda9d2b6f120f47c5764672734810b369"
   integrity sha512-UoeqXpZB05aerGD3gB9NiigMsAyph+N+GWH8+3lX1+26caVV03GkL6JoLxS2HCxyvqCWbNsVSZTAp5W12qe23A==


### PR DESCRIPTION
This upgrade is in order to support the new methods in redis client, since now we cannot use lpos directly for example. After this PR is approved I could update #445