### PR TITLE
fix: rename Flow to FlowProducer class

### DIFF
--- a/src/classes/flow-producer.ts
+++ b/src/classes/flow-producer.ts
@@ -8,7 +8,6 @@ import { RedisConnection } from './redis-connection';
 import { KeysMap, QueueKeys } from './queue-keys';
 import { FlowJob } from '../interfaces/flow-job';
 import { Job } from './job';
-import { ParentOpts } from './scripts';
 
 export interface JobNode {
   job: Job;
@@ -20,7 +19,7 @@ export interface JobNode {
  * with dependencies between them in such a way that it is possible
  * to build complex flows.
  */
-export class Flow extends EventEmitter {
+export class FlowProducer extends EventEmitter {
   toKey: (name: string, type: string) => string;
   keys: KeysMap;
   closing: Promise<void>;

--- a/src/classes/index.ts
+++ b/src/classes/index.ts
@@ -11,4 +11,4 @@ export * from './scripts';
 export * from './worker';
 export * from './child-pool';
 export * from './sandbox';
-export * from './flow';
+export * from './flow-producer';

--- a/src/test/test_flow.ts
+++ b/src/test/test_flow.ts
@@ -1,4 +1,4 @@
-import { Queue, Worker, Job, Flow, JobNode } from '../classes';
+import { Queue, Worker, Job, FlowProducer, JobNode } from '../classes';
 import { expect } from 'chai';
 import * as IORedis from 'ioredis';
 import { beforeEach, describe, it } from 'mocha';
@@ -65,7 +65,7 @@ describe('flows', () => {
     const parentWorker = new Worker(parentQueueName, parentProcessor);
     const childrenWorker = new Worker(queueName, childrenProcessor);
 
-    const flow = new Flow();
+    const flow = new FlowProducer();
     const tree = await flow.add({
       name: 'parent-job',
       queueName: parentQueueName,
@@ -172,7 +172,7 @@ describe('flows', () => {
     const parentWorker = new Worker(topQueueName, parentProcessor);
     const childrenWorker = new Worker(queueName, childrenProcessor);
 
-    const flow = new Flow();
+    const flow = new FlowProducer();
     const tree = await flow.add({
       name: 'root-job',
       queueName: topQueueName,
@@ -239,7 +239,7 @@ describe('flows', () => {
 
     const childrenWorker = new Worker(queueName, childrenProcessor);
 
-    const flow = new Flow();
+    const flow = new FlowProducer();
     const tree = await flow.add({
       name: 'parent-job',
       queueName: parentQueueName,
@@ -291,7 +291,7 @@ describe('flows', () => {
     const parentQueue = new Queue(parentQueueName);
     await parentQueue.pause();
 
-    const flow = new Flow();
+    const flow = new FlowProducer();
     const tree = await flow.add({
       name: 'parent-job',
       queueName: parentQueueName,
@@ -333,7 +333,7 @@ describe('flows', () => {
       const parentQueueName = 'parent-queue';
       const name = 'child-job';
 
-      const flow = new Flow();
+      const flow = new FlowProducer();
       const tree = await flow.add({
         name: 'parent-job',
         queueName: parentQueueName,
@@ -387,7 +387,7 @@ describe('flows', () => {
 
       const worker = new Worker(queueName);
 
-      const flow = new Flow();
+      const flow = new FlowProducer();
       const tree = await flow.add({
         name: 'parent-job',
         queueName: parentQueueName,
@@ -421,7 +421,7 @@ describe('flows', () => {
       const parentQueueName = 'parent-queue';
       const name = 'child-job';
 
-      const flow = new Flow();
+      const flow = new FlowProducer();
       const tree = await flow.add({
         name: 'root-job',
         queueName: parentQueueName,
@@ -468,7 +468,7 @@ describe('flows', () => {
       const parentQueueName = 'parent-queue';
       const name = 'child-job';
 
-      const flow = new Flow();
+      const flow = new FlowProducer();
       const tree = await flow.add({
         name: 'parent-job',
         queueName: parentQueueName,


### PR DESCRIPTION
This is actually a breaking change, but I took the freedom to release it as a fix since flows are a pretty new feature and I do not expect anybody to actually use it it production yet.