### PR TITLE
Just publish dist files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
   "source": "src/index.ts",
   "author": "Taskforce.sh Inc.",
   "license": "MIT",
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "dry-run": "npm publish --dry-run",
     "build": "tsc && yarn copylua",
     "copylua": "copyfiles -f ./src/commands/*.lua ./dist/commands",
     "coverage": "nyc --reporter=text npm run test",

--- a/src/test/test_connection.ts
+++ b/src/test/test_connection.ts
@@ -1,9 +1,9 @@
 import * as IORedis from 'ioredis';
-import { Queue, QueueEvents, Job, Worker } from '@src/classes';
+import { Queue, QueueEvents, Job, Worker } from '../classes';
 
 import { v4 } from 'uuid';
 import { expect } from 'chai';
-import { removeAllQueueData } from '@src/utils';
+import { removeAllQueueData } from '../utils';
 
 describe('connection', () => {
   let queue: Queue;

--- a/src/test/test_job.ts
+++ b/src/test/test_job.ts
@@ -1,11 +1,11 @@
 /*eslint-env node */
 'use strict';
 
-import { Job, Queue, QueueScheduler } from '@src/classes';
-import { QueueEvents } from '@src/classes/queue-events';
-import { Worker } from '@src/classes/worker';
-import { JobsOptions } from '@src/interfaces';
-import { delay, removeAllQueueData } from '@src/utils';
+import { Job, Queue, QueueScheduler } from '../classes';
+import { QueueEvents } from '../classes/queue-events';
+import { Worker } from '../classes/worker';
+import { JobsOptions } from '../interfaces';
+import { delay, removeAllQueueData } from '../utils';
 import { expect } from 'chai';
 import * as IORedis from 'ioredis';
 import { after } from 'lodash';

--- a/src/test/test_sandboxed_process.ts
+++ b/src/test/test_sandboxed_process.ts
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 import * as IORedis from 'ioredis';
 import { after } from 'lodash';
-import { Queue, QueueEvents, Worker } from '@src/classes';
+import { Queue, QueueEvents, Worker } from '../classes';
 import { beforeEach } from 'mocha';
 import { v4 } from 'uuid';
-import { delay, removeAllQueueData } from '@src/utils';
+import { delay, removeAllQueueData } from '../utils';
 const pReflect = require('p-reflect');
 
 describe('sandboxed process', () => {

--- a/src/test/test_worker.ts
+++ b/src/test/test_worker.ts
@@ -1,11 +1,11 @@
-import { Queue, QueueEvents, Job, Worker, QueueScheduler } from '@src/classes';
+import { Queue, QueueEvents, Job, Worker, QueueScheduler } from '../classes';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
 import * as IORedis from 'ioredis';
 import { v4 } from 'uuid';
-import { delay, removeAllQueueData } from '@src/utils';
+import { delay, removeAllQueueData } from '../utils';
 import { after, times, once } from 'lodash';
-import { RetryErrors } from '@src/enums';
+import { RetryErrors } from '../enums';
 import * as sinon from 'sinon';
 
 describe('workers', function() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
     },
     "lib": ["esnext"]
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/test/*"]
 }


### PR DESCRIPTION
Currently, a lot of files are published, docs, dist, src, ... etc. We can just publish the ones that are in dist since these files are built. you can now use yarn dry-run to see which files are going to be published to verified this, also with this change we are going to decrease the size of this package a lot.