### PR TITLE
Fix moveToComplete, should not move to complete before children

### DIFF
--- a/src/classes/flow-producer.ts
+++ b/src/classes/flow-producer.ts
@@ -213,7 +213,7 @@ export class FlowProducer extends EventEmitter {
   }
 }
 
-function getParentKey(opts: { id: string; queue: string }) {
+export function getParentKey(opts: { id: string; queue: string }) {
   if (opts) {
     return `${opts.queue}:${opts.id}`;
   }

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -241,6 +241,8 @@ export class Scripts {
         return new Error(`Missing lock for job ${jobId} ${command}`);
       case -3:
         return new Error(`Job is not in the active list ${jobId} ${command}`);
+      case -4:
+        return new Error(`Job ${jobId} has pending dependencies ${command}`);
     }
   }
 

--- a/src/commands/moveToFinished-7.lua
+++ b/src/commands/moveToFinished-7.lua
@@ -33,6 +33,7 @@
       -1 Missing key.
       -2 Missing lock.
       -3 Job not in active set
+      -4 Job has pending dependencies
 
      Events:
       'completed/failed'
@@ -41,6 +42,10 @@ local rcall = redis.call
 
 local jobIdKey = KEYS[3]
 if rcall("EXISTS",jobIdKey) == 1 then -- // Make sure job exists
+
+    if rcall("SCARD", jobIdKey .. ":dependencies") ~= 0 then -- // Make sure it does not have pending dependencies
+      return -4
+    end
 
     if ARGV[10] ~= "0" then
       local lockKey = jobIdKey .. ':lock'

--- a/src/test/test_job.ts
+++ b/src/test/test_job.ts
@@ -91,6 +91,9 @@ describe('Job', function() {
       })
 
       const job = (await parentWorker.getNextJob(token)) as Job;
+      const { unprocessed } = await parent.getDependencies();
+
+      expect(unprocessed).to.have.length(1);
 
       const isActive = await job.isActive();
       expect(isActive).to.be.equal(true);

--- a/src/test/test_job.ts
+++ b/src/test/test_job.ts
@@ -61,59 +61,6 @@ describe('Job', function() {
       });
       expect(createdJob.id).to.be.equal(customJobId);
     });
-
-    it('should not complete a parent job before its children', async () => {
-      const values = [
-        { idx: 0, bar: 'something' },
-      ];
-      const token = 'my-token';
-  
-      const parentQueueName = 'parent-queue';
-      
-      const parentQueue = new Queue(parentQueueName);
-  
-      const parentWorker = new Worker(parentQueueName);
-      const childrenWorker = new Worker(queueName);
-      await parentWorker.waitUntilReady();
-      await childrenWorker.waitUntilReady();
-  
-      const data = { foo: 'bar' };
-      const parent = await Job.create(parentQueue, 'testParent', data);
-      const parentKey = getParentKey({
-        id: parent.id,
-        queue: 'bull:' + parentQueueName
-      });
-      const client = await queue.client;
-      const child1 = new Job(queue, 'testJob1', values[0]);
-      await child1.addJob(client, {
-        parentKey,
-        parentDependenciesKey: `${parentKey}:dependencies`,
-      })
-
-      const job = (await parentWorker.getNextJob(token)) as Job;
-      const { unprocessed } = await parent.getDependencies();
-
-      expect(unprocessed).to.have.length(1);
-
-      const isActive = await job.isActive();
-      expect(isActive).to.be.equal(true);
-
-      const inspection = await pReflect(
-        Promise.resolve(job.moveToCompleted('return value', token)),
-      );
-
-      expect(inspection.isRejected).to.be.eql(true);
-      expect(inspection.reason.message).to.be.eql(`Job ${job.id} has pending dependencies finished`);
-
-      const isCompleted = await job.isCompleted();
-
-      expect(isCompleted).to.be.false;
-  
-      await childrenWorker.close();
-      await parentWorker.close();
-      await parentQueue.close();
-      await removeAllQueueData(new IORedis(), parentQueueName);
-    });
   });
 
   describe('JSON.stringify', () => {
@@ -261,6 +208,59 @@ describe('Job', function() {
       const state = await job.getState();
       expect(state).to.be.equal('completed');
       await worker.close();
+    });
+
+    it('should not complete a parent job before its children', async () => {
+      const values = [
+        { idx: 0, bar: 'something' },
+      ];
+      const token = 'my-token';
+  
+      const parentQueueName = 'parent-queue';
+      
+      const parentQueue = new Queue(parentQueueName);
+  
+      const parentWorker = new Worker(parentQueueName);
+      const childrenWorker = new Worker(queueName);
+      await parentWorker.waitUntilReady();
+      await childrenWorker.waitUntilReady();
+  
+      const data = { foo: 'bar' };
+      const parent = await Job.create(parentQueue, 'testParent', data);
+      const parentKey = getParentKey({
+        id: parent.id,
+        queue: 'bull:' + parentQueueName
+      });
+      const client = await queue.client;
+      const child1 = new Job(queue, 'testJob1', values[0]);
+      await child1.addJob(client, {
+        parentKey,
+        parentDependenciesKey: `${parentKey}:dependencies`,
+      })
+
+      const job = (await parentWorker.getNextJob(token)) as Job;
+      const { unprocessed } = await parent.getDependencies();
+
+      expect(unprocessed).to.have.length(1);
+
+      const isActive = await job.isActive();
+      expect(isActive).to.be.equal(true);
+
+      const inspection = await pReflect(
+        Promise.resolve(job.moveToCompleted('return value', token)),
+      );
+
+      expect(inspection.isRejected).to.be.eql(true);
+      expect(inspection.reason.message).to.be.eql(`Job ${job.id} has pending dependencies finished`);
+
+      const isCompleted = await job.isCompleted();
+
+      expect(isCompleted).to.be.false;
+  
+      await childrenWorker.close();
+      await parentWorker.close();
+      await parentQueue.close();
+      await removeAllQueueData(new IORedis(), parentQueueName);
     });
   });
 

--- a/src/test/test_job.ts
+++ b/src/test/test_job.ts
@@ -4,6 +4,7 @@
 import { Job, Queue, QueueScheduler } from '../classes';
 import { QueueEvents } from '../classes/queue-events';
 import { Worker } from '../classes/worker';
+import { getParentKey } from '../classes/flow-producer';
 import { JobsOptions } from '../interfaces';
 import { delay, removeAllQueueData } from '../utils';
 import { expect } from 'chai';
@@ -11,6 +12,7 @@ import * as IORedis from 'ioredis';
 import { after } from 'lodash';
 import { afterEach, beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
+const pReflect = require('p-reflect');
 
 const sinon = require('sinon');
 
@@ -58,6 +60,56 @@ describe('Job', function() {
         jobId: customJobId,
       });
       expect(createdJob.id).to.be.equal(customJobId);
+    });
+
+    it('should not complete a parent job before its children', async () => {
+      const values = [
+        { idx: 0, bar: 'something' },
+      ];
+      const token = 'my-token';
+  
+      const parentQueueName = 'parent-queue';
+      
+      const parentQueue = new Queue(parentQueueName);
+  
+      const parentWorker = new Worker(parentQueueName);
+      const childrenWorker = new Worker(queueName);
+      await parentWorker.waitUntilReady();
+      await childrenWorker.waitUntilReady();
+  
+      const data = { foo: 'bar' };
+      const parent = await Job.create(parentQueue, 'testParent', data);
+      const parentKey = getParentKey({
+        id: parent.id,
+        queue: 'bull:' + parentQueueName
+      });
+      const client = await queue.client;
+      const child1 = new Job(queue, 'testJob1', values[0]);
+      await child1.addJob(client, {
+        parentKey,
+        parentDependenciesKey: `${parentKey}:dependencies`,
+      })
+
+      const job = (await parentWorker.getNextJob(token)) as Job;
+
+      const isActive = await job.isActive();
+      expect(isActive).to.be.equal(true);
+
+      const inspection = await pReflect(
+        Promise.resolve(job.moveToCompleted('return value', token)),
+      );
+
+      expect(inspection.isRejected).to.be.eql(true);
+      expect(inspection.reason.message).to.be.eql(`Job ${job.id} has pending dependencies finished`);
+
+      const isCompleted = await job.isCompleted();
+
+      expect(isCompleted).to.be.false;
+  
+      await childrenWorker.close();
+      await parentWorker.close();
+      await parentQueue.close();
+      await removeAllQueueData(new IORedis(), parentQueueName);
     });
   });
 

--- a/src/test/test_repeat.ts
+++ b/src/test/test_repeat.ts
@@ -1,13 +1,13 @@
-import { Job, Queue } from '@src/classes';
-import { QueueEvents } from '@src/classes/queue-events';
-import { QueueScheduler } from '@src/classes/queue-scheduler';
-import { Repeat } from '@src/classes/repeat';
-import { Worker } from '@src/classes/worker';
+import { Job, Queue } from '../classes';
+import { QueueEvents } from '../classes/queue-events';
+import { QueueScheduler } from '../classes/queue-scheduler';
+import { Repeat } from '../classes/repeat';
+import { Worker } from '../classes/worker';
 import { expect } from 'chai';
 import * as IORedis from 'ioredis';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
-import { removeAllQueueData } from '@src/utils';
+import { removeAllQueueData } from '../utils';
 
 const sinon = require('sinon');
 const moment = require('moment');


### PR DESCRIPTION
Currently we can manually move parent to complete, even if it has children. We should verify that this job does not have pending children first, if not throw an error