### PR TITLE
feat: add typing for addNextRepeatableJob

### DIFF
--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -53,7 +53,7 @@ export class Queue<
 
   async add(name: N, data: T, opts?: JobsOptions) {
     if (opts && opts.repeat) {
-      return (await this.repeat).addNextRepeatableJob(
+      return (await this.repeat).addNextRepeatableJob<T, R, N>(
         name,
         data,
         { ...this.jobsOpts, ...opts },

--- a/src/classes/repeat.ts
+++ b/src/classes/repeat.ts
@@ -6,9 +6,9 @@ import { Job } from './job';
 const parser = require('cron-parser');
 
 export class Repeat extends QueueBase {
-  async addNextRepeatableJob(
-    name: string,
-    data: any,
+  async addNextRepeatableJob<T = any, R = any, N extends string = string>(
+    name: N,
+    data: T,
     opts: JobsOptions,
     skipCheckExists?: boolean,
   ) {
@@ -50,7 +50,7 @@ export class Repeat extends QueueBase {
 
       // The job could have been deleted since this check
       if (repeatableExists) {
-        return this.createNextJob(
+        return this.createNextJob<T, R, N>(
           name,
           nextMillis,
           repeatJobKey,
@@ -62,12 +62,12 @@ export class Repeat extends QueueBase {
     }
   }
 
-  private async createNextJob(
-    name: string,
+  private async createNextJob<T = any, R = any, N extends string = string>(
+    name: N,
     nextMillis: number,
     repeatJobKey: string,
     opts: JobsOptions,
-    data: any,
+    data: T,
     currentCount: number,
   ) {
     const client = await this.client;
@@ -96,7 +96,7 @@ export class Repeat extends QueueBase {
 
     await client.zadd(this.keys.repeat, nextMillis.toString(), repeatJobKey);
 
-    return Job.create(this, name, data, mergedOpts);
+    return Job.create<T, R, N>(this, name, data, mergedOpts);
   }
 
   async removeRepeatable(name: string, repeat: RepeatOptions, jobId?: string) {


### PR DESCRIPTION
By adding correct typings for the `addNextRepeatableJob` function, `Queue`'s  `add` will have a proper return type (`Promise<Job<T, R, N>>` instead of `Promise<Job<any, any, string>>`).

Based on #472 