### PR TITLE
fix export of FlowJob interface

### DIFF
--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,5 +1,6 @@
 export * from './advanced-options';
 export * from './backoff-options';
+export * from './flow-job';
 export * from './jobs-options';
 export * from './queue-options';
 export * from './queue-scheduler-options';


### PR DESCRIPTION
this allows to do `import { FlowJob } from "bullmq";` instead of `import { FlowJob } from "bullmq/dist/interfaces/flow-job";`