### PR TITLE
fix: add return type for job.waitUntilFinished()

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -445,7 +445,7 @@ export class Job<T = any, R = any, N extends string = string> {
   /**
    * Returns a promise the resolves when the job has finished. (completed or failed).
    */
-  async waitUntilFinished(queueEvents: QueueEvents, ttl?: number) {
+  async waitUntilFinished(queueEvents: QueueEvents, ttl?: number): Promise<R> {
     await this.queue.waitUntilReady();
 
     const jobId = this.id;


### PR DESCRIPTION
Hi

Method `job.waitUntilFinished()` returns the job's returnvalue when resolving but its return type is not specified (resulting in `Promise<any>`)

This PR fixes this typing issue.