### PR TITLE
Fix RedisClient type

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -456,7 +456,9 @@ export class Job<T = any, R = any, N extends string = string> {
         timeout = setTimeout(
           () =>
             onFailed(
+              /* eslint-disable max-len */
               `Job wait ${this.name} timed out before finishing, no finish notification arrived after ${ttl}ms (id=${jobId})`,
+              /* eslint-enable max-len */
             ),
           ttl,
         );

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -5,7 +5,7 @@ import { Processor, WorkerOptions, GetNextJobOptions } from '../interfaces';
 import { QueueBase, Repeat } from './';
 import { ChildPool } from './child-pool';
 import { Job, JobJsonRaw } from './job';
-import { RedisConnection } from './redis-connection';
+import { RedisConnection, RedisClient } from './redis-connection';
 import sandbox from './sandbox';
 import { Scripts } from './scripts';
 import { v4 } from 'uuid';
@@ -91,7 +91,7 @@ export class Worker<
     this.on('error', err => console.error(err));
   }
 
-  async waitUntilReady() {
+  async waitUntilReady(): Promise<RedisClient> {
     await super.waitUntilReady();
     return this.blockingConnection.client;
   }
@@ -363,7 +363,7 @@ export class Worker<
   async pause(doNotWaitActive?: boolean) {
     if (!this.paused) {
       this.paused = new Promise(resolve => {
-        this.resumeWorker = function () {
+        this.resumeWorker = function() {
           resolve();
           this.paused = null; // Allow pause to be checked externally for paused state.
           this.resumeWorker = null;


### PR DESCRIPTION
This PR tries to fix the release failure generated by this pr #514, what I did is change how RedisClient was constructed, previously it was transpiled with an import declaration, now it is build without it, also I run yarn docs locally and the error is gone