### PR TITLE
docs: fix typo in flows.md

### DIFF
--- a/docs/gitbook/guide/jobs/flows.md
+++ b/docs/gitbook/guide/jobs/flows.md
@@ -34,7 +34,7 @@ import { FlowProducer } from 'bullmq';
 // object otherwise it connects to a local redis instance.
 const flowProducer = new FlowProducer();
 
-const flow = await flow.add({
+const flow = await flowProducer.add({
   name: 'renovate-interior',
   queueName: 'renovate',
   children: [


### PR DESCRIPTION
Fixed a typo in the code snippet inside `flows.md` file.

Also, the same typo exists in the `parent-child-jobs.md`, but I didn't include it into this PR, as this file seems to be unused. Maybe we could simply remove that file.