### PR TITLE
Ensure connection reconnects when pausing.

### DIFF
--- a/src/test/test_pause.ts
+++ b/src/test/test_pause.ts
@@ -311,4 +311,21 @@ describe('Pause', function() {
     const isResumedQueuePaused = await queue.isPaused();
     expect(isResumedQueuePaused).to.be.false;
   });
+
+  it('should pause and resume worker without error', async function() {
+    const worker = new Worker(queueName, async job => {
+      await delay(100);
+    });
+
+    await worker.waitUntilReady();
+    await delay(10);
+    await worker.pause();
+    await delay(10);
+    worker.resume();
+    await delay(10);
+    await worker.pause();
+    await delay(10);
+
+    return worker.close();
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/taskforcesh/bullmq/issues/160

Currently, if we pause a worker while waiting to pop off the next job, we disconnect. The issue is that `this.waiting` can change to `false` before we try to reconnect, preventing us from reconnecting, even if it was requested (which is it, when pausing). Once we resume, the connection is closed, causing the `run` loop to throw `Client is disconnected` (since we're neither paused nor closing).

We fix this by _only_ checking the `reconnect` argument. To handle the case where we didn't disconnect, we just set reconnect to `false` so that we don't try to reconnect.

**For reviewers**
I believe it's clear that this can happen, and I've observed it in a flaky test suite in my company's CI, but I'm struggling to write a test for it. Maybe you all would have ideas on how I could test this? 🙇 