### PR TITLE
Fix moveToWaitingChildren: opts should be optional

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -644,7 +644,7 @@ export class Job<T = any, R = any, N extends string = string> {
    */
   moveToWaitingChildren(
     token: string,
-    opts: MoveToChildrenOpts,
+    opts: MoveToChildrenOpts = {},
   ): Promise<boolean | Error> {
     return Scripts.moveToWaitingChildren(this.queue, this.id, token, opts);
   }

--- a/src/test/test_bulk.ts
+++ b/src/test/test_bulk.ts
@@ -54,7 +54,7 @@ describe('bulk jobs', () => {
 
   it('should allow to pass parent option', async () => {
     const name = 'test';
-    const parentQueueName = 'parent-queue';
+    const parentQueueName = `parent-queue-${v4()}`;
     const parentQueue = new Queue(parentQueueName);
 
     const parentWorker = new Worker(parentQueueName);

--- a/src/test/test_job.ts
+++ b/src/test/test_job.ts
@@ -178,7 +178,7 @@ describe('Job', function() {
       const values = [{ idx: 0, bar: 'something' }];
       const token = 'my-token';
       const token2 = 'my-token2';
-      const parentQueueName = 'parent-queue-' + v4();
+      const parentQueueName = `parent-queue-${v4()}`;
 
       const parentQueue = new Queue(parentQueueName);
       const parentWorker = new Worker(parentQueueName);
@@ -323,7 +323,7 @@ describe('Job', function() {
       ];
       const token = 'my-token';
 
-      const parentQueueName = 'parent-queue';
+      const parentQueueName = `parent-queue-${v4()}`;
 
       const parentQueue = new Queue(parentQueueName);
 

--- a/src/test/test_worker.ts
+++ b/src/test/test_worker.ts
@@ -1776,7 +1776,7 @@ describe('workers', function() {
       const parentToken = 'parent-token';
       const childToken = 'child-token';
 
-      const parentQueueName = 'parent-queue';
+      const parentQueueName = `parent-queue-${v4()}`;
 
       const parentQueue = new Queue(parentQueueName);
       const parentWorker = new Worker(parentQueueName);
@@ -1867,6 +1867,9 @@ describe('workers', function() {
         unprocessed: unprocessed4,
       } = await parent.getDependencies();
       const isWaitingChildren2 = await parent.isWaitingChildren();
+      const movedToWaitingChildren2 = await parent.moveToWaitingChildren(
+        parentToken,
+      );
 
       expect(processed4).to.deep.equal({
         [`bull:${queueName}:${child1.id}`]: `"return value1"`,
@@ -1875,6 +1878,7 @@ describe('workers', function() {
       });
       expect(unprocessed4).to.have.length(0);
       expect(isWaitingChildren2).to.be.false;
+      expect(movedToWaitingChildren2).to.be.false;
 
       await childrenWorker.close();
       await parentWorker.close();


### PR DESCRIPTION
When we want to wait for all the children we could pass no opts to moveToWaitingChildren