### PR TITLE
Feat getFlow method

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -530,7 +530,7 @@ export class Job<T = any, R = any, N extends string = string> {
    * @returns {string} Returns one of these values:
    * 'completed', 'failed', 'delayed', 'active', 'waiting', 'waiting-children', 'unknown'.
    */
-  getState() {
+  getState(): Promise<string> {
     return Scripts.getState(this.queue, this.id);
   }
 

--- a/src/test/test_flow.ts
+++ b/src/test/test_flow.ts
@@ -10,7 +10,7 @@ describe('flows', () => {
   let queueName: string;
 
   beforeEach(async function() {
-    queueName = 'test-' + v4();
+    queueName = `test-${v4()}`;
     queue = new Queue(queueName);
   });
 
@@ -163,6 +163,72 @@ describe('flows', () => {
 
     expect(children[0].children[0].children[0].job.id).to.be.ok;
     expect(children[0].children[0].children[0].job.data.foo).to.be.eql('qux');
+
+    await flow.close();
+
+    await removeAllQueueData(new IORedis(), topQueueName);
+  });
+
+  it('should get part of flow tree', async () => {
+    const name = 'child-job';
+
+    const topQueueName = `parent-queue-${v4()}`;
+
+    const flow = new FlowProducer();
+    const originalTree = await flow.add({
+      name: 'root-job',
+      queueName: topQueueName,
+      data: {},
+      children: [
+        {
+          name,
+          data: { idx: 0, foo: 'bar' },
+          queueName,
+          children: [
+            {
+              name,
+              data: { idx: 1, foo: 'baz' },
+              queueName,
+              children: [{ name, data: { idx: 2, foo: 'qux' }, queueName }],
+            },
+          ],
+        },
+        {
+          name,
+          data: { idx: 3, foo: 'bax' },
+          queueName,
+        },
+        {
+          name,
+          data: { idx: 4, foo: 'baz' },
+          queueName,
+        },
+      ],
+    });
+
+    const { job: topJob } = originalTree;
+
+    const tree = await flow.getFlow({
+      id: topJob.id,
+      queueName: topQueueName,
+      depth: 2,
+      maxChildren: 2,
+    });
+
+    expect(tree).to.have.property('job');
+    expect(tree).to.have.property('children');
+
+    const { children, job } = tree;
+    const isWaitingChildren = await job.isWaitingChildren();
+
+    expect(isWaitingChildren).to.be.true;
+    expect(children.length).to.be.greaterThanOrEqual(2);
+
+    expect(children[0].job.id).to.be.ok;
+    expect(children[0].children).to.be.undefined;
+
+    expect(children[1].job.id).to.be.ok;
+    expect(children[1].children).to.be.undefined;
 
     await flow.close();
 

--- a/src/test/test_flow.ts
+++ b/src/test/test_flow.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
 import { removeAllQueueData, delay } from '../utils';
 
-describe.only('flows', () => {
+describe('flows', () => {
   let queue: Queue;
   let queueName: string;
 


### PR DESCRIPTION
This method tries to help in getting and entire flow from a parent reference. Also as we can have a lot of children for a job I think is a good idea to limit this method by a max children and depth level, so we don't too much information