### PR TITLE
Fix flaky test related to getDependencies

### DIFF
--- a/src/test/test_worker.ts
+++ b/src/test/test_worker.ts
@@ -1902,30 +1902,33 @@ describe('workers', function() {
 
       expect(currentState).to.be.equal('active');
 
-      await times(25, async (index: number) =>
-        Job.create(
-          queue,
-          `child${index}`,
-          { idx: index, ...value },
-          {
-            parent: {
-              id: parent.id,
-              queue: 'bull:' + parentQueueName,
+      await Promise.all(
+        Array.from(Array(65).keys()).map((index: number) => {
+          return Job.create(
+            queue,
+            `child${index}`,
+            { idx: index, ...value },
+            {
+              parent: {
+                id: parent.id,
+                queue: 'bull:' + parentQueueName,
+              },
             },
-          },
-        ),
+          );
+        }),
       );
+
       const {
         nextUnprocessedCursor: nextCursor1,
         unprocessed: unprocessed1,
       } = await parent.getDependencies({
         unprocessed: {
           cursor: 0,
-          count: 20,
+          count: 50,
         },
       });
 
-      expect(unprocessed1.length).to.be.greaterThanOrEqual(20);
+      expect(unprocessed1.length).to.be.greaterThanOrEqual(50);
 
       const {
         nextUnprocessedCursor: nextCursor2,
@@ -1933,11 +1936,11 @@ describe('workers', function() {
       } = await parent.getDependencies({
         unprocessed: {
           cursor: nextCursor1,
-          count: 20,
+          count: 50,
         },
       });
 
-      expect(unprocessed2.length).to.be.greaterThanOrEqual(0);
+      expect(unprocessed2.length).to.be.lessThanOrEqual(15);
       expect(nextCursor2).to.be.equal(0);
 
       await childrenWorker.close();

--- a/src/test/test_worker.ts
+++ b/src/test/test_worker.ts
@@ -1902,7 +1902,7 @@ describe('workers', function() {
 
       expect(currentState).to.be.equal('active');
 
-      await times(15, async (index: number) =>
+      await times(25, async (index: number) =>
         Job.create(
           queue,
           `child${index}`,
@@ -1921,11 +1921,11 @@ describe('workers', function() {
       } = await parent.getDependencies({
         unprocessed: {
           cursor: 0,
-          count: 10,
+          count: 20,
         },
       });
 
-      expect(unprocessed1.length).to.be.greaterThanOrEqual(10);
+      expect(unprocessed1.length).to.be.greaterThanOrEqual(20);
 
       const {
         nextUnprocessedCursor: nextCursor2,
@@ -1933,11 +1933,11 @@ describe('workers', function() {
       } = await parent.getDependencies({
         unprocessed: {
           cursor: nextCursor1,
-          count: 10,
+          count: 20,
         },
       });
 
-      expect(unprocessed2.length).to.be.lessThanOrEqual(5);
+      expect(unprocessed2.length).to.be.greaterThanOrEqual(0);
       expect(nextCursor2).to.be.equal(0);
 
       await childrenWorker.close();


### PR DESCRIPTION
There is one comment to be aware when using sscan and hscan, here is explained in the documentation https://redis.io/commands/scan#why-scan-may-return-all-the-items-of-an-aggregate-data-type-in-a-single-call