### PR TITLE
fix(redis-connection): remove event listeners from shared client

### DIFF
--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -14,6 +14,7 @@ export class RedisConnection extends EventEmitter {
   private initializing: Promise<RedisClient>;
   private closing: boolean;
   private version: string;
+  private handleClientError: (e: Error) => void;
 
   constructor(private readonly opts?: ConnectionOptions) {
     super();
@@ -33,14 +34,14 @@ export class RedisConnection extends EventEmitter {
 
     this.initializing = this.init();
 
+    this.handleClientError = (err: Error): void => {
+      this.emit('error', err);
+    };
+
     this.initializing
       .then(client => client.on('error', this.handleClientError))
       .catch(err => this.emit('error', err));
   }
-
-  handleClientError = (err: Error): void => {
-    this.emit('error', err);
-  };
 
   /**
    * Waits for a redis client to be ready.

--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -38,9 +38,9 @@ export class RedisConnection extends EventEmitter {
       .catch(err => this.emit('error', err));
   }
 
-  handleClientError(err: Error) {
+  handleClientError = (err: Error): void => {
     this.emit('error', err);
-  }
+  };
 
   /**
    * Waits for a redis client to be ready.

--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -34,8 +34,12 @@ export class RedisConnection extends EventEmitter {
     this.initializing = this.init();
 
     this.initializing
-      .then(client => client.on('error', err => this.emit('error', err)))
+      .then(client => client.on('error', this.handleClientError))
       .catch(err => this.emit('error', err));
+  }
+
+  handleClientError(err: Error) {
+    this.emit('error', err);
   }
 
   /**
@@ -122,6 +126,8 @@ export class RedisConnection extends EventEmitter {
       this.closing = true;
       if (this.opts != this._client) {
         await this._client.quit();
+      } else {
+        this._client.off('error', this.handleClientError);
       }
     }
   }


### PR DESCRIPTION
Fixed an issue where event listeners on shared redis connections meant that Workers which had been "closed" were holding onto references to redis-connection in memory.

I believe this will also fix the issue described in #167 