### PR TITLE
Fix getDependencies defaultOpts

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -594,7 +594,7 @@ export class Job<T = any, R = any, N extends string = string> {
       };
 
       if (opts.processed) {
-        const processedOpts = Object.assign(defaultOpts, opts.processed);
+        const processedOpts = Object.assign({ ...defaultOpts }, opts.processed);
         multi.hscan(
           this.toKey(`${this.id}:processed`),
           processedOpts.cursor,
@@ -604,7 +604,10 @@ export class Job<T = any, R = any, N extends string = string> {
       }
 
       if (opts.unprocessed) {
-        const unprocessedOpts = Object.assign(defaultOpts, opts.unprocessed);
+        const unprocessedOpts = Object.assign(
+          { ...defaultOpts },
+          opts.unprocessed,
+        );
         multi.sscan(
           this.toKey(`${this.id}:dependencies`),
           unprocessedOpts.cursor,


### PR DESCRIPTION
when using Object.assign we are assigning values to the first param, so the defaultOpts are changed the first time that Object.assign is called, so in order to keep the defaultOpts immutable, we should spread its values in a new object when using that method.