### PR TITLE
Feat expose queueName in job

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -524,6 +524,10 @@ export class Job<T = any, R = any, N extends string = string> {
     return (await this.isInList('wait')) || (await this.isInList('paused'));
   }
 
+  get queueName(): string {
+    return this.queue.name;
+  }
+
   /**
    * @method getState
    * Get current state.

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -22,6 +22,7 @@ import { RedisClient } from './redis-connection';
 
 export type MinimalQueue = Pick<
   QueueBase,
+  | 'name'
   | 'client'
   | 'toKey'
   | 'keys'

--- a/src/test/test_flow.ts
+++ b/src/test/test_flow.ts
@@ -243,9 +243,11 @@ describe('flows', () => {
 
     expect(children[0].job.id).to.be.ok;
     expect(children[0].job.data.foo).to.be.eql('bar');
+    expect(children[0].job.queueName).to.be.eql(queueName);
     expect(children[0].children).to.have.length(1);
 
     expect(children[0].children[0].job.id).to.be.ok;
+    expect(children[0].children[0].job.queueName).to.be.eql(queueName);
     expect(children[0].children[0].job.data.foo).to.be.eql('baz');
 
     expect(children[0].children[0].children[0].job.id).to.be.ok;


### PR DESCRIPTION
As we have getFlow method, we can get a tree for an specific parent node, but in order to know from which queue the children and grand children belong, it would be nice to expose the name of the queue from the job instance.