### PR TITLE
Fix missing event typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,13 @@
   "source": "src/index.ts",
   "author": "Taskforce.sh Inc.",
   "license": "MIT",
+  "keywords": [
+    "bull",
+    "bullmq",
+    "queues",
+    "jobs",
+    "redis"
+  ],
   "files": [
     "dist"
   ],

--- a/src/classes/queue-events.ts
+++ b/src/classes/queue-events.ts
@@ -6,7 +6,7 @@ import { StreamReadRaw } from '../interfaces/redis-streams';
 export declare interface QueueEvents {
   on(
     event: 'active',
-    listener: (args: { jobId: string }, prev?: string) => void,
+    listener: (args: { jobId: string; prev?: string }, id: string) => void,
   ): this;
   on(
     event: 'waiting',
@@ -99,8 +99,14 @@ export class QueueEvents extends QueueBase {
                 break;
             }
 
-            this.emit(args.event, args, id);
-            this.emit(`${args.event}:${args.jobId}`, args, id);
+            const { event, ...restArgs } = args;
+
+            if (event === 'drained') {
+              this.emit(event, id);
+            } else {
+              this.emit(event, restArgs, id);
+              this.emit(`${event}:${restArgs.jobId}`, restArgs, id);
+            }
           }
         }
       } catch (err) {

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -18,6 +18,10 @@ import { isRedisInstance, delay } from '../utils';
 export const clientCommandMessageReg = /ERR unknown command ['`]\s*client\s*['`]/;
 
 export declare interface Worker {
+  on(
+    event: 'active',
+    listener: (job: Job, result: null, prev: string) => void,
+  ): this;
   on(event: 'completed', listener: (job: Job) => void): this;
   on(event: 'drained', listener: () => void): this;
   on(event: 'error', listener: (failedReason: Error) => void): this;

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -18,9 +18,13 @@ import { isRedisInstance, delay } from '../utils';
 export const clientCommandMessageReg = /ERR unknown command ['`]\s*client\s*['`]/;
 
 export declare interface Worker {
-  on(event: 'drained', listener: () => void): this;
   on(event: 'completed', listener: (job: Job) => void): this;
+  on(event: 'drained', listener: () => void): this;
   on(event: 'error', listener: (failedReason: Error) => void): this;
+  on(
+    event: 'progress',
+    listener: (job: Job, progress: number | object) => void,
+  ): this;
   on(event: string, listener: Function): this;
 }
 

--- a/src/test/test_events.ts
+++ b/src/test/test_events.ts
@@ -14,7 +14,7 @@ describe('events', function() {
   let queueName: string;
 
   beforeEach(async function() {
-    queueName = 'test-' + v4();
+    queueName = `test-${v4()}`;
     queue = new Queue(queueName);
     queueEvents = new QueueEvents(queueName);
     await queueEvents.waitUntilReady();
@@ -52,7 +52,10 @@ describe('events', function() {
     });
 
     const drained = new Promise(resolve => {
-      queueEvents.once('drained', resolve);
+      queueEvents.once('drained', id => {
+        expect(id).to.be.string;
+        resolve();
+      });
     });
 
     await queue.add('test', { foo: 'bar' });


### PR DESCRIPTION
The actual drained event does not contain other args apart of event name, the typing was expecting that the event id is passing so I updated the logic here, also the active typing was wrong so it's updated now. I noticed that there are not keywords, so I added some what do you think https://docs.npmjs.com/cli/v7/configuring-npm/package-json#keywords?