### PR TITLE
fix(options): add typing to backoffStrategies

### DIFF
--- a/src/interfaces/advanced-options.ts
+++ b/src/interfaces/advanced-options.ts
@@ -1,8 +1,10 @@
+import { BackoffFunction } from '../classes/backoffs';
+
 export interface AdvancedOptions {
   /**
    * A set of custom backoff strategies keyed by name.
    */
-  backoffStrategies?: {};
+  backoffStrategies?: Record<string, BackoffFunction>;
 }
 
 export const AdvancedOptionsDefaults: AdvancedOptions = {


### PR DESCRIPTION
## Commit description

```
Before, `AdvancedOptions.backoffStrategies` was a plain object (`{}`).
This induced no intellisense in code editors and also weaker typing.
With this commit, we get autocomplete when creating custom backoff strategies.

BREAKING CHANGE: Invalid backoff strategies will not be compiled anymore.
```

## Why ? 

This allow for better discoverability. I had to read BullMQ's code to understand that backoff can be computed from the error message and Job data.

## Before/After

### Before

![image](https://user-images.githubusercontent.com/13921610/124352461-8ab28c80-dc00-11eb-870d-fc61df8860bd.png)

(no autocompletion)

### After

![image](https://user-images.githubusercontent.com/13921610/124352474-93a35e00-dc00-11eb-845d-d0471b860cf9.png)

(nice autocompletion and type checking)