### PR TITLE
Feat parent opts in root job for a flow

### DIFF
--- a/src/classes/flow-producer.ts
+++ b/src/classes/flow-producer.ts
@@ -7,7 +7,6 @@ import {
   FlowQueuesOpts,
   FlowOpts,
   QueueBaseOptions,
-  QueueOptions,
   RedisClient,
 } from '../interfaces';
 import { getParentKey, jobIdForGroup } from '../utils';
@@ -125,28 +124,17 @@ export class FlowProducer extends EventEmitter {
       ? `${parentKey}:dependencies`
       : undefined;
 
-    const jobsTree = this.addNode(multi, flow, {
-      parentOpts,
-      parentDependenciesKey,
+    const jobsTree = this.addNode({
+      multi,
+      node: flow,
+      queuesOpts: opts?.queuesOptions,
+      parent: {
+        parentOpts,
+        parentDependenciesKey,
+      },
     });
 
     const result = await multi.exec();
-
-    const updateJobIds = (
-      jobsTree: JobNode,
-      result: [Error, string][],
-      index: number,
-    ) => {
-      // TODO: Can we safely ignore result errors? how could they happen in the
-      // first place?
-      jobsTree.job.id = result[index][1];
-      const children = jobsTree.children;
-      if (children) {
-        for (let i = 0; i < children.length; i++) {
-          updateJobIds(children[i], result, index + i + 1);
-        }
-      }
-    };
 
     await multi.exec();
 

--- a/src/interfaces/flow-job.ts
+++ b/src/interfaces/flow-job.ts
@@ -1,14 +1,18 @@
 import { JobsOptions } from './jobs-options';
 import { QueueOptions } from './queue-options';
 
-export interface FlowJob {
+interface FlowJobBase<T> {
   name: string;
   queueName: string;
   data?: any;
   prefix?: string;
-  opts?: Omit<JobsOptions, 'parent' | 'repeat'>;
-  children?: FlowJob[];
+  opts?: T;
+  children?: FlowChildJob[];
 }
+
+export type FlowChildJob = FlowJobBase<Omit<JobsOptions, 'parent'>>;
+
+export type FlowJob = FlowJobBase<JobsOptions>;
 
 export type FlowQueuesOpts = Record<
   string,

--- a/tests/test_flow.ts
+++ b/tests/test_flow.ts
@@ -135,7 +135,7 @@ describe('flows', () => {
 
     const parentQueueName = `parent-queue-${v4()}`;
     const grandparentQueueName = `grandparent-queue-${v4()}`;
-    const grandparentQueue = new Queue(grandparentQueueName);
+    const grandparentQueue = new Queue(grandparentQueueName, { connection });
     const grandparentJob = await grandparentQueue.add('grandparent', {
       foo: 'bar',
     });
@@ -178,12 +178,16 @@ describe('flows', () => {
       }),
     ]);
 
-    const parentWorker = new Worker(parentQueueName, parentProcessor);
-    const childrenWorker = new Worker(queueName, childrenProcessor);
+    const parentWorker = new Worker(parentQueueName, parentProcessor, {
+      connection,
+    });
+    const childrenWorker = new Worker(queueName, childrenProcessor, {
+      connection,
+    });
     await parentWorker.waitUntilReady();
     await childrenWorker.waitUntilReady();
 
-    const flow = new FlowProducer();
+    const flow = new FlowProducer({ connection });
     const tree = await flow.add({
       name: 'parent-job',
       queueName: parentQueueName,

--- a/tests/test_flow.ts
+++ b/tests/test_flow.ts
@@ -129,6 +129,103 @@ describe('flows', () => {
     await removeAllQueueData(new IORedis(), parentQueueName);
   });
 
+  it('should allow parent opts on the root job', async () => {
+    const name = 'child-job';
+    const values = [{ bar: 'something' }, { baz: 'something' }];
+
+    const parentQueueName = `parent-queue-${v4()}`;
+    const grandparentQueueName = `grandparent-queue-${v4()}`;
+    const grandparentQueue = new Queue(grandparentQueueName);
+    const grandparentJob = await grandparentQueue.add('grandparent', {
+      foo: 'bar',
+    });
+
+    let childrenProcessor,
+      parentProcessor,
+      processedChildren = 0;
+    const processingChildren = new Promise<void>(
+      resolve =>
+        (childrenProcessor = async (job: Job) => {
+          processedChildren++;
+
+          if (processedChildren == values.length) {
+            resolve();
+          }
+          return values[job.data.idx];
+        }),
+    );
+
+    const processingParent = new Promise<void>((resolve, reject) => [
+      (parentProcessor = async (job: Job) => {
+        try {
+          const { processed, nextProcessedCursor } = await job.getDependencies({
+            processed: {},
+          });
+          expect(nextProcessedCursor).to.be.equal(0);
+          expect(Object.keys(processed)).to.have.length(2);
+
+          const childrenValues = await job.getChildrenValues();
+
+          for (let i = 0; i < values.length; i++) {
+            const jobKey = queue.toKey(tree.children[i].job.id);
+            expect(childrenValues[jobKey]).to.be.deep.equal(values[i]);
+          }
+          resolve();
+        } catch (err) {
+          console.error(err);
+          reject(err);
+        }
+      }),
+    ]);
+
+    const parentWorker = new Worker(parentQueueName, parentProcessor);
+    const childrenWorker = new Worker(queueName, childrenProcessor);
+    await parentWorker.waitUntilReady();
+    await childrenWorker.waitUntilReady();
+
+    const flow = new FlowProducer();
+    const tree = await flow.add({
+      name: 'parent-job',
+      queueName: parentQueueName,
+      data: {},
+      children: [
+        { name, data: { idx: 0, foo: 'bar' }, queueName },
+        { name, data: { idx: 1, foo: 'baz' }, queueName },
+      ],
+      opts: {
+        parent: {
+          id: grandparentJob.id,
+          queue: `bull:${grandparentQueueName}`,
+        },
+      },
+    });
+
+    expect(tree).to.have.property('job');
+    expect(tree).to.have.property('children');
+
+    const { children, job } = tree;
+
+    expect(job.parentKey).to.be.equal(
+      `bull:${grandparentQueueName}:${grandparentJob.id}`,
+    );
+    const parentState = await job.getState();
+
+    expect(parentState).to.be.eql('waiting-children');
+    expect(children).to.have.length(2);
+
+    await processingChildren;
+    await childrenWorker.close();
+
+    await processingParent;
+    await parentWorker.close();
+
+    await flow.close();
+
+    await grandparentQueue.close();
+    await removeAllQueueData(new IORedis(), grandparentQueueName);
+    await removeAllQueueData(new IORedis(), parentQueueName);
+  });
+
   describe('when moving jobs from wait to active continuing', async () => {
     it('begins with attemptsMade as 1', async () => {
       const queueScheduler = new QueueScheduler(queueName, { connection });


### PR DESCRIPTION
This PR allows to add parent opts for a root job in a flow, it makes sense only allow this for the first parent job since children are concatenated into their parents so children should not have this option, this option is generated by add flow method.