### PR TITLE
fix(queue): ensure the Queue constructor doesn't try to hset queue options if the client is closed

### DIFF
--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -30,11 +30,13 @@ export class Queue<
     this.limiter = get(opts, 'limiter');
 
     this.waitUntilReady().then(client => {
-      client.hset(
-        this.keys.meta,
-        'opts.maxLenEvents',
-        get(opts, 'streams.events.maxLen', 10000),
-      );
+      if (!this.closing) {
+        client.hset(
+          this.keys.meta,
+          'opts.maxLenEvents',
+          get(opts, 'streams.events.maxLen', 10000),
+        );
+      }
     });
   }
 


### PR DESCRIPTION
In my app we disconnect queues sometimes quite quickly after constructing them, and see this error every so often in our CI logs:

```
/app/node_modules/bullmq/node_modules/ioredis/built/redis/index.js:620
        command.reject(new Error(utils_1.CONNECTION_CLOSED_ERROR_MSG));
                       ^
Error: Connection is closed.
    at Redis.sendCommand (/app/node_modules/bullmq/node_modules/ioredis/built/redis/index.js:620:24)
    at Redis.hset (/app/node_modules/bullmq/node_modules/ioredis/built/commander.js:111:25)
    at /app/node_modules/bullmq/src/classes/queue.ts:29:14
```

I am not exactly sure why it only happens sometimes but not others, but regardless, I think it's a good idea not to try to run the floating `hset` in the queue constructor if the client has been closed. This prevents that by first checking if the client has been closed before doing this floating work.