### PR TITLE
Hotfix for connection hanging when `close()`

### DIFF
--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -66,6 +66,10 @@ export class RedisConnection extends EventEmitter {
 
         client.once('ready', handleReady);
         client.once('error', handleError);
+        
+        if (client.status === 'wait') {
+          client.connect(); 
+        }
       }
     });
   }


### PR DESCRIPTION
Summary: When supplying your own IORedis instance and `lazyConnect` is true, the RedisConnection instance will not connect on its own because it does not check if it's `status` is "wait". While this may be intended behavior, there is no direct way to call `connect` on the duplicated Redis instance causing it to never connect and indefinitely wait until ready.

Context: Came across this issue when trying to create unit tests for my application. I didn't look at any guidelines for PRs or issues because its such a simple fix so if you don't merge mine at least you know the problem and how to fix it yourself.