### PR TITLE
Fix rateLimiter: check groupKey is not undefined

### DIFF
--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { get, isUndefined } from 'lodash';
 import { v4 } from 'uuid';
 import { JobsOptions, QueueOptions, RepeatOptions } from '../interfaces';
 import { Repeat } from './repeat';
@@ -80,9 +80,10 @@ export class Queue<
 
   private jobIdForGroup(opts: JobsOptions, data: T) {
     const jobId = opts && opts.jobId;
-    const groupKey = get(this, 'limiter.groupKey');
-    if (groupKey) {
-      return `${jobId || v4()}:${get(data, groupKey)}`;
+    const groupKeyPath = get(this, 'limiter.groupKey');
+    const groupKey = get(data, groupKeyPath);
+    if (groupKeyPath && !isUndefined(groupKey)) {
+      return `${jobId || v4()}:${groupKey}`;
     }
     return jobId;
   }

--- a/src/test/test_worker.ts
+++ b/src/test/test_worker.ts
@@ -82,20 +82,23 @@ describe('workers', function() {
       expect(job.id).to.be.ok;
       expect(job.data.foo).to.be.eql('bar');
 
-      return new Promise((resolve, reject) => {
+      const completed = new Promise((resolve, reject) => {
         worker.on('completed', async (job: Job) => {
           try {
             const gotJob = await queue.getJob(job.id);
             expect(gotJob).to.be.equal(undefined);
             const counts = await queue.getJobCounts('completed');
             expect(counts.completed).to.be.equal(0);
-            await worker.close();
             resolve();
           } catch (err) {
             reject(err);
           }
         });
       });
+
+      await completed;
+
+      await worker.close();
     });
 
     it('should remove a job after completed if the default job options specify removeOnComplete', async () => {


### PR DESCRIPTION
when processing a job that does not have a groupKey, the id is generated with undefined at the end, so every job with this content also ends with undefined too