### PR TITLE
Fix redis-connection: add error event in waitUntilReady

### DIFF
--- a/src/test/test_connection.ts
+++ b/src/test/test_connection.ts
@@ -16,7 +16,7 @@ describe('connection', () => {
   let queueName: string;
 
   beforeEach(async function() {
-    queueName = 'test-' + v4();
+    queueName = `test-${v4()}`;
     queue = new Queue(queueName);
   });
 

--- a/src/test/test_connection.ts
+++ b/src/test/test_connection.ts
@@ -165,6 +165,21 @@ describe('connection', () => {
     );
   });
 
+  it('should emit error if redis connection fails', async () => {
+    const queueFail = new Queue('connection fail port', {
+      connection: { port: 1234, host: '127.0.0.1', retryStrategy: () => null },
+    });
+
+    const waitingErrorEvent = new Promise(resolve => {
+      queueFail.on('error', err => {
+        expect(err.message).to.equal('Connection is closed.');
+        resolve();
+      });
+    });
+
+    await waitingErrorEvent;
+  });
+
   it('should close if connection has failed', async () => {
     const queueFail = new Queue('connection fail port', {
       connection: { port: 1234, host: '127.0.0.1', retryStrategy: () => null },


### PR DESCRIPTION
Following #666 I tried to address this issue, so I don't see this log
```sh
[ioredis] Unhandled error event: Error: connect ECONNREFUSED 127.0.0.1:6379
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1142:16)
```
anymore when running the test