### PR TITLE
docs(prioritized): fix typo

### DIFF
--- a/docs/gitbook/guide/jobs/proritized.md
+++ b/docs/gitbook/guide/jobs/proritized.md
@@ -3,13 +3,13 @@
 Jobs can also include a priority option. Using priorities, job's processing order will be affected by the specified priority instead of following a FIFO or LIFO pattern.
 
 {% hint style="warning" %}
-Adding prioritised jobs is a slower operation than the other types of jobs, with a complexity O\(n\) relative to the number of jobs waiting in the Queue.
+Adding prioritized jobs is a slower operation than the other types of jobs, with a complexity O\(n\) relative to the number of jobs waiting in the Queue.
 {% endhint %}
 
-Priorities goes from 1 to MAX\_INT, whereas lower number is always higher priority than higher numbers.
+Priorities goes from 1 to MAX_INT, whereas lower number is always higher priority than higher numbers.
 
 ```typescript
-import { Queue } from 'bullmq'
+import { Queue } from 'bullmq';
 
 const myQueue = new Queue('Paint');
 
@@ -19,7 +19,4 @@ await myQueue.add('wall', { color: 'blue' }, { priority: 7 });
 
 // The wall will be painted first brown, then blue and
 // finally pink.
-
-
 ```
-


### PR DESCRIPTION
linter was applied to those files when editting