### PR TITLE
fix(add-job): throw error when missing parent key

### DIFF
--- a/src/commands/addJob-8.lua
+++ b/src/commands/addJob-8.lua
@@ -37,10 +37,21 @@
       ARGV[11] parentKey?
       ARGV[12] waitChildrenKey key.
       ARGV[13] parent dependencies key.
+
+      Output:
+        jobId  - OK
+        -5     - Missing parent key
 ]]
 local jobId
 local jobIdKey
 local rcall = redis.call
+local parentKey = ARGV[11]
+
+if parentKey ~= "" then
+  if rcall("EXISTS", parentKey) ~= 1 then
+    return -5
+  end
+end
 
 local jobCounter = rcall("INCR", KEYS[4])
 
@@ -57,7 +68,7 @@ end
 
 -- Store the job.
 rcall("HMSET", jobIdKey, "name", ARGV[3], "data", ARGV[4], "opts", ARGV[5],
-      "timestamp", ARGV[6], "delay", ARGV[7], "priority", ARGV[9], "parentKey", ARGV[11])
+      "timestamp", ARGV[6], "delay", ARGV[7], "priority", ARGV[9], "parentKey", parentKey)
 
 rcall("XADD", KEYS[7], "*", "event", "added", "jobId", jobId, "name", ARGV[3], "data", ARGV[4], "opts", ARGV[5])
 

--- a/src/enums/error-codes.enum.ts
+++ b/src/enums/error-codes.enum.ts
@@ -3,4 +3,5 @@ export enum ErrorCodes {
   JobLockNotExist = -2,
   JobNotInState = -3,
   JobPendingDependencies = -4,
+  ParentJobNotExist = -5,
 }

--- a/src/test/test_job.ts
+++ b/src/test/test_job.ts
@@ -91,6 +91,17 @@ describe('Job', function() {
         `The size of job test exceeds the limit ${opts.sizeLimit} bytes`,
       );
     });
+
+    describe('when parent key is missing', () => {
+      it('throws an error', async () => {
+        const data = { foo: 'bar' };
+        const parentId = v4();
+        const opts = { parent: { id: parentId, queue: queueName } };
+        await expect(Job.create(queue, 'test', data, opts)).to.be.rejectedWith(
+          `Missing key for parent job ${queueName}:${parentId}. addJob`,
+        );
+      });
+    });
   });
 
   describe('JSON.stringify', () => {


### PR DESCRIPTION
In order to prevent people to create a job when the parent does not exist