### PR TITLE
feat(child-pool): Helpful Error on Interpolation

### DIFF
--- a/src/classes/master.ts
+++ b/src/classes/master.ts
@@ -53,7 +53,13 @@ process.on('SIGINT', waitForCurrentJobAndExit);
 process.on('message', msg => {
   switch (msg.cmd) {
     case 'init':
-      processor = require(msg.value);
+      try {
+        processor = require(msg.value);
+      } catch (err) {
+        processor = function() {
+          return Promise.reject(err); 
+        }
+      }
       if (processor.default) {
         // support es2015 module.
         processor = processor.default;


### PR DESCRIPTION
If you have an error in your sandboxed code that a causes NodeJS to crash (ie. doing a require to a file that does not exist) you get an un-helpful error `Error initializing child: Internal Exception Handler Run-Time Failure and signal null`.

This change propagates the actual error up as a job failure.