### PR TITLE
fix: allow lazy redis connections

### DIFF
--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -85,7 +85,7 @@ export class RedisConnection extends EventEmitter {
       return;
     }
 
-    if (client.status === 'wait') {
+    if (client.status === 'wait' && !client.options.lazyConnect) {
       return client.connect();
     }
 


### PR DESCRIPTION
#642 introduced a change that force connected lazy connections on boot of BullMQ. In this [comment](https://github.com/taskforcesh/bullmq/pull/657#discussion_r728602683), the suggestion is to essentially undo that by checking to see if `lazyConnect: true`.

In the case of #642, which appears to be introduced to satisfy unit tests, perhaps the solution would be not lazily connecting for unit tests?