### PR TITLE
fix(connection): throw error when no noeviction policy

### DIFF
--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -192,14 +192,27 @@ export class RedisConnection extends EventEmitter {
 
   private async getRedisVersion() {
     const doc = await this._client.info();
-    const prefix = 'redis_version:';
+    const redisPrefix = 'redis_version:';
+    const maxMemoryPolicyPrefix = 'maxmemory_policy:';
     const lines = doc.split('\r\n');
+    let redisVersion;
 
     for (let i = 0; i < lines.length; i++) {
-      if (lines[i].indexOf(prefix) === 0) {
-        return lines[i].substr(prefix.length);
+      if (lines[i].indexOf(maxMemoryPolicyPrefix) === 0) {
+        const maxMemoryPolicy = lines[i].substr(maxMemoryPolicyPrefix.length);
+        if (maxMemoryPolicy !== 'noeviction') {
+          throw new Error(
+            `Eviction policy is ${maxMemoryPolicy}. It should be "noeviction"`,
+          );
+        }
+      }
+
+      if (lines[i].indexOf(redisPrefix) === 0) {
+        redisVersion = lines[i].substr(redisPrefix.length);
       }
     }
+
+    return redisVersion;
   }
 
   get redisVersion(): string {

--- a/tests/test_connection.ts
+++ b/tests/test_connection.ts
@@ -42,6 +42,27 @@ describe('connection', () => {
     checkOptions(await queue.client);
   });
 
+  describe('when maxmemory-policy is different than noeviction in Redis', () => {
+    it('throws an error', async () => {
+      const opts = {
+        connection: {
+          host: 'localhost',
+        },
+      };
+
+      const queue = new QueueBase(queueName, opts);
+      const client = await queue.client;
+      await client.config('SET', 'maxmemory-policy', 'volatile-lru');
+
+      const queue2 = new QueueBase(`${queueName}2`, opts);
+
+      await expect(queue2.client).to.be.eventually.rejectedWith(
+        'Eviction policy is volatile-lru. It should be "noeviction"',
+      );
+      await client.config('SET', 'maxmemory-policy', 'noeviction');
+    });
+  });
+
   it('should recover from a connection loss', async () => {
     let processor;
 


### PR DESCRIPTION
noeviction maxmemory-policy is the only option allowed

BREAKING CHANGE: noeviction maxmemory-policy is the only option allowed

re #921