### PR TITLE
fix(redis-connection): allow undef client.options

### DIFF
--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -52,8 +52,8 @@ export class RedisConnection extends EventEmitter {
       this._client = <RedisClient>opts;
       this.checkOptions(deprecationMessage, this._client.options);
       if (
-        (<RedisOptions>this._client.options).maxRetriesPerRequest ||
-        this._client.options.enableReadyCheck
+        (<RedisOptions>this._client.options)?.maxRetriesPerRequest ||
+        this._client.options?.enableReadyCheck
       ) {
         console.error(deprecationMessage);
       }


### PR DESCRIPTION
In some scenarios (ioredis-mock for example) the `client.options` will be null. Due to https://github.com/taskforcesh/bullmq/pull/927, bullmq isn't checking `opts.maxRetriesPerRequest` anymore. While this should be solved in ioredis-mock eventually (currently "client" is missing [here](https://github.com/stipsan/ioredis-mock/blob/master/compat.md#supported-commands-)), making this optional here could be fine enough.