### PR TITLE
feat(worker): save worker name into client

### DIFF
--- a/src/classes/queue-getters.ts
+++ b/src/classes/queue-getters.ts
@@ -247,8 +247,10 @@ export class QueueGetters extends QueueBase {
         client[key] = value;
       });
       const name = client['name'];
-      if (name && name === this.clientName()) {
-        client['name'] = this.name;
+      const clientName = this.clientName();
+      if (name && name.startsWith(clientName)) {
+        const workerName = name.substring(clientName.length + 1);
+        client['name'] = workerName ? workerName : this.name;
         clients.push(client);
       }
     });

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -220,7 +220,7 @@ export class Worker<
     return new Promise<Repeat>(async resolve => {
       if (!this._repeat) {
         const connection = await this.client;
-        this._repeat = new Repeat(this.name, {
+        this._repeat = new Repeat(this.queueName, {
           ...this.opts,
           connection,
         });

--- a/src/interfaces/worker-options.ts
+++ b/src/interfaces/worker-options.ts
@@ -21,6 +21,7 @@ export interface WorkerOptions extends QueueBaseOptions {
    * @see {@link https://docs.bullmq.io/guide/rate-limiting}
    */
   limiter?: RateLimiterOptions;
+  name?: string;
   skipDelayCheck?: boolean;
   drainDelay?: number;
   lockDuration?: number;


### PR DESCRIPTION
separate queueName from worker name

BREAKING CHANGE: name property is renamed to queueName and name is passed into opts

fix #456