### PR TITLE
fix(sandbox): exit uncaughtException instead of throwing error

### DIFF
--- a/src/classes/child-pool.ts
+++ b/src/classes/child-pool.ts
@@ -76,8 +76,6 @@ async function initChild(child: ChildProcess, processFile: string) {
     };
 
     child.on('message', onMessageHandler);
-
-    // TODO: we need to clean this listener too.
     child.on('close', onCloseHandler);
   });
 

--- a/src/classes/master.ts
+++ b/src/classes/master.ts
@@ -35,5 +35,7 @@ process.on('uncaughtException', async (err: Error) => {
     value: err,
   });
 
-  throw err;
+  // An uncaughException leaves this process in a potentially undetermined state so
+  // we must exit
+  process.exit(-1);
 });


### PR DESCRIPTION
Fixes #956.

Throwing an exception from within the uncaughException handler just results in this handler being called again, so kind of an infinite loop. Furthermore, since the process is in an errored state forever, all jobs ending in this process will fail one after another. 