### PR TITLE
Fix reduce initial value

### DIFF
--- a/src/classes/queue-getters.ts
+++ b/src/classes/queue-getters.ts
@@ -60,7 +60,7 @@ export class QueueGetters<
    */
   async getJobCountByTypes(...types: string[]): Promise<number> {
     const result = await this.getJobCounts(...types);
-    return Object.values(result).reduce((sum, count) => sum + count);
+    return Object.values(result).reduce((sum, count) => sum + count, 0);
   }
 
   /**

--- a/tests/test_getters.ts
+++ b/tests/test_getters.ts
@@ -402,4 +402,19 @@ describe('Jobs getters', function () {
     queue.add('test', { foo: 1 });
     queue.add('test', { foo: 2 });
   });
+
+  it('should return 0 if queue is empty', async function () {
+    const count = await queue.getJobCountByTypes();
+    expect(count).to.be.a('number');
+    expect(count).to.be.equal(0);
+  });
+
+  it('should return 0 if no type provided', async function () {
+    await queue.add('test', { foo: 'bar' });
+    await queue.add('test', { baz: 'qux' });
+    
+    const count = await queue.getJobCountByTypes();
+    expect(count).to.be.a('number');
+    expect(count).to.be.equal(0);
+  });
 });


### PR DESCRIPTION
if you don't provide `type` to `getJobCountByTypes` get an error would be thrown.

```bash
TypeError: Reduce of empty array with no initial value
```

I guess we can validate the parameters. but in `getJobCount` if you don't provide `type` an empty object is returned. so I guess this patch is acceptable. 