### PR TITLE
docs: update documentation of waitUntillFinished to match behavior

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -733,7 +733,8 @@ export class Job<
   }
 
   /**
-   * Returns a promise the resolves when the job has finished. (completed or failed).
+   * Returns a promise the resolves when the job has completed (containing the return value of the job),
+   * or rejects when the job has failed (containing the failedReason). 
    *
    * @param queueEvents - Instance of QueueEvents.
    * @param ttl - Time in milliseconds to wait for job to finish before timing out.


### PR DESCRIPTION
updates the documentation of the method to match the actual behavior, which returns a rejected promise when job failes. 

closes #1031