### PR TITLE
feat(job): add queueName to JobJson

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -314,6 +314,7 @@ export class Job<
       failedReason: JSON.stringify(this.failedReason),
       stacktrace: JSON.stringify(this.stacktrace),
       returnvalue: JSON.stringify(this.returnvalue),
+      queueName: this.queueName,
     };
   }
 
@@ -737,7 +738,7 @@ export class Job<
 
   /**
    * Returns a promise the resolves when the job has completed (containing the return value of the job),
-   * or rejects when the job has failed (containing the failedReason). 
+   * or rejects when the job has failed (containing the failedReason).
    *
    * @param queueEvents - Instance of QueueEvents.
    * @param ttl - Time in milliseconds to wait for job to finish before timing out.

--- a/src/interfaces/job-json.ts
+++ b/src/interfaces/job-json.ts
@@ -14,6 +14,7 @@ export interface JobJson {
   stacktrace: string;
   returnvalue: string;
   parentKey?: string;
+  queueName?: string;
 }
 
 export interface JobJsonRaw {

--- a/src/interfaces/job-json.ts
+++ b/src/interfaces/job-json.ts
@@ -14,7 +14,7 @@ export interface JobJson {
   stacktrace: string;
   returnvalue: string;
   parentKey?: string;
-  queueName?: string;
+  queueName: string;
 }
 
 export interface JobJsonRaw {

--- a/tests/fixtures/fixture_processor_queueName.js
+++ b/tests/fixtures/fixture_processor_queueName.js
@@ -1,0 +1,13 @@
+/**
+ * A processor file to be used in tests.
+ *
+ */
+'use strict';
+
+const delay = require('./delay');
+
+module.exports = function (job) {
+  return delay(500).then(() => {
+    return job.queueName;
+  });
+};


### PR DESCRIPTION
Added queueName to the JobJson type so that it will be available to sandboxed workers.

In response to [#1050](https://github.com/taskforcesh/bullmq/issues/1050)