### PR TITLE
[Docs] Clarify jobs priority

### DIFF
--- a/docs/gitbook/guide/jobs/prioritized.md
+++ b/docs/gitbook/guide/jobs/prioritized.md
@@ -8,7 +8,7 @@ Adding prioritized jobs is a slower operation than the other types of jobs, with
 
 Priorities goes from 1 to MAX_INT, whereas lower number is always higher priority than higher numbers.
 
-In a queue where only some jobs have a priority assigned, jobs without priority will be processed last.
+Jobs without a priority assigned will get the least priority.
 
 ```typescript
 import { Queue } from 'bullmq';

--- a/docs/gitbook/guide/jobs/prioritized.md
+++ b/docs/gitbook/guide/jobs/prioritized.md
@@ -8,6 +8,8 @@ Adding prioritized jobs is a slower operation than the other types of jobs, with
 
 Priorities goes from 1 to MAX_INT, whereas lower number is always higher priority than higher numbers.
 
+In a queue where only some jobs have a priority assigned, jobs without priority will be processed last.
+
 ```typescript
 import { Queue } from 'bullmq';
 


### PR DESCRIPTION
Note that jobs without priority are processed last. This is not what I had assumed, so it's better to clarify it.