### PR TITLE
feat(./src/index.ts): add worker and job infering types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,23 @@ export * from './enums';
 export * from './interfaces';
 export * from './types';
 export * from './utils';
+
+import type { Queue } from './classes/queue';
+import type { Worker } from './classes/worker';
+import type { Job } from './classes/job';
+
+export type QueueWorker<Q> = Q extends Queue<
+  infer DataType,
+  infer ResultType,
+  infer NameType
+>
+  ? Worker<DataType, ResultType, NameType>
+  : unknown;
+
+export type QueueJob<Q> = Q extends Queue<
+  infer DataType,
+  infer ResultType,
+  infer NameType
+>
+  ? Job<DataType, ResultType, NameType>
+  : unknown;


### PR DESCRIPTION
Add the QueueWorker<T> and QueueJob<T> types to allow one to infer the types on a corrisponding
worker easily.

This allows for nice typing such as the following

`queues.ts`
```ts
import { Queue } from "bullmq"

export const exampleQueue = new Queue<
  { buildId: number },
  boolean,
  "pass" | "fail"
>("exampleQueue")
```

`workers.ts`
```ts
import { QueueWorker, Worker } from "bullmq"
import type { exampleQueue } from "./queues"

const worker: QueueWorker<typeof exampleQueue> = new Worker("exampleQueue", async (job) => {
  switch(job.name) { // Strongly typed
    case "pass": 
      return true // also checked
    case "fail":
      return false
  }
})
```