### PR TITLE
refactor(backoffoptions): improved IntelliSense for backoff types

### DIFF
--- a/src/interfaces/backoff-options.ts
+++ b/src/interfaces/backoff-options.ts
@@ -7,7 +7,7 @@ export interface BackoffOptions {
   /**
    * Name of the backoff strategy.
    */
-  type: string;
+  type: 'fixed' | 'exponential' | Omit<string, 'fixed' | 'exponential'>;
   /**
    * Delay in milliseconds.
    */

--- a/src/interfaces/backoff-options.ts
+++ b/src/interfaces/backoff-options.ts
@@ -7,7 +7,7 @@ export interface BackoffOptions {
   /**
    * Name of the backoff strategy.
    */
-  type: 'fixed' | 'exponential' | Omit<string, 'fixed' | 'exponential'>;
+  type: 'fixed' | 'exponential' | (string & {});
   /**
    * Delay in milliseconds.
    */


### PR DESCRIPTION
Currently, the `type` field is typed to `string` which makes it hard for users to know which values
work out-of-the-box without consulting the online documentation. This change fixes that by improving
the discoverability of the framework-defined backoff types while typing. Moreover, users will better
understand what values are supported by looking at the type definition file without having to leave
the IDE.