### PR TITLE
Fix imports for ESM modules.

### DIFF
--- a/src/classes/child-pool.ts
+++ b/src/classes/child-pool.ts
@@ -1,7 +1,7 @@
 import { ChildProcess, fork } from 'child_process';
 import * as path from 'path';
 import { flatten } from 'lodash';
-import * as getPort from 'get-port';
+import getPort from 'get-port';
 import { killAsync } from './process-utils';
 import { ParentCommand, ChildCommand } from '../interfaces';
 import { parentSend } from '../utils';

--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import * as IORedis from 'ioredis';
+import IORedis from 'ioredis';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { CONNECTION_CLOSED_ERROR_MSG } from 'ioredis/built/utils';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,8 @@
     "jsx": "preserve",
     "importHelpers": true,
     "moduleResolution": "node",
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "strictNullChecks": false,
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
Using ESM imports along with [Esbuild](https://esbuild.github.io/content-types/#es-module-interop) or Tsup fails on runtime due to default importing the `get-port` and `ioredis` modules. This pull request changes the `tsconfig` file and the failing imports across the BullMQ package in order to play nicely with these bundlers.

_Reference: trying to bundle BullMQ failed Esbuild error_
<img width="954" alt="Screenshot 2022-04-04 at 1 35 03 PM" src="https://user-images.githubusercontent.com/1022166/161527546-51999870-71f4-4617-b9be-a9a2b6b120f2.png">

