### PR TITLE
fix: remove Error from Promise return in moveToWaitingChildren

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -855,7 +855,7 @@ export class Job<
   moveToWaitingChildren(
     token: string,
     opts: MoveToChildrenOpts = {},
-  ): Promise<boolean | Error> {
+  ): Promise<boolean> {
     return Scripts.moveToWaitingChildren(this.queue, this.id, token, opts);
   }
 


### PR DESCRIPTION
Fixes #1196 