### PR TITLE
docs: update Worker constructor parameters in Jobs -> Stalled example

### DIFF
--- a/docs/gitbook/guide/jobs/stalled.md
+++ b/docs/gitbook/guide/jobs/stalled.md
@@ -20,7 +20,7 @@ Another way to reduce the chance for stalled jobs is using so called "sandboxed"
 ```typescript
 import { Worker } from 'bullmq';
 
-const worker = new Worker('Paint', painter);
+const worker = new Worker('Paint', 'painter.ts');
 ```
 {% endcode %}
 


### PR DESCRIPTION
update Worker constructor parameters to be correct according to https://github.com/taskforcesh/bullmq/blob/7a3206f/src/classes/worker.ts:

* use string with sandboxed worker file name instead of an undeclared variable
* add the required .ts extension as https://github.com/taskforcesh/bullmq/blob/7a3206f/src/classes/worker.ts#L199 will try to append a .js extension if one is missing from file name, which will result in searching for painter.js file, but an example states that the worker file name is painter.ts, not painter.js.
If the example assumes that there is a background compliation from .ts to .js, so no extension needs to be used, it should be stated explicitly.