### PR TITLE
Fix the Queue.addBulk return signature

### DIFF
--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -229,8 +229,8 @@ export class Queue<
    */
   addBulk(
     jobs: { name: NameType; data: DataType; opts?: BulkJobOptions }[],
-  ): Promise<Job<DataType, DataType, NameType>[]> {
-    return this.Job.createBulk<DataType, DataType, NameType>(
+  ): Promise<Job<DataType, ResultType, NameType>[]> {
+    return this.Job.createBulk<DataType, ResultType, NameType>(
       this,
       jobs.map(job => ({
         name: job.name,


### PR DESCRIPTION
Currently the Queue.addBulk method's return type is incorrectly typed as
```ts
Promise<Job<DataType, DataType, NameType>[]>
```
Where it should be typed as 
```ts
Promise<Job<DataType, ResultType, NameType>[]>
```