### PR TITLE
Define custom name for toJSON method

### DIFF
--- a/src/classes/child-processor.ts
+++ b/src/classes/child-processor.ts
@@ -99,7 +99,7 @@ export class ChildProcessor {
 // https://stackoverflow.com/questions/18391212/is-it-not-possible-to-stringify-an-error-using-json-stringify
 if (!('toJSON' in Error.prototype)) {
   Object.defineProperty(Error.prototype, 'toJSON', {
-    value: function () {
+    value: function toJSONByBull() {
       const alt: any = {};
       const _this = this;
 


### PR DESCRIPTION
Hi,
I found that bull adds to Error prototype method toJSON() to allow proper stringify of errors. But that global change causes some problems in my implementation of error handling and returning errors to the browser.
In my express error handler I'm checking if method `toJSON()` exists (that exists in my custom error's class), and then return result to browser.
```
const errorDetails = 'toJSON' in err ? err.toJSON() : {
        msg: err.message
      };
res.json(errorDetails);
```
Normally, any non-custom error is pushed to the browser with `msg` field only. But when something wrong happens inside bullmq processing, it is returned to `toJSON` method and for example stack trace is visible in browser (err.stack is in Error.prototype so it is returned by bull's custom toJSON method).

My PR adds custom method name to `toJSON()` method so it allows to detect that this is custom implementation, ex:
```
const errorDetails = 'toJSON' in err && err.toJSON.name !== 'toJSONByBull' ? err.toJSON() : {
        msg: err.message
      };
```

Regards,
Tomasz