### PR TITLE
fix: avoid calling delay() if queue is being closed

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -139,6 +139,7 @@ export class Worker<
   private waiting = false;
   private running = false;
   private blockTimeout = 0;
+  private beingClosed = false;
 
   protected processFn: Processor<DataType, ResultType, NameType>;
 
@@ -468,7 +469,9 @@ export class Worker<
       if (isNotConnectionError(<Error>error)) {
         this.emit('error', <Error>error);
       }
-      await this.delay();
+      if (!this.beingClosed) {
+        await this.delay();
+      }
     } finally {
       this.waiting = false;
     }
@@ -668,6 +671,7 @@ export class Worker<
     if (this.closing) {
       return this.closing;
     }
+    this.beingClosed = true;
     this.closing = (async () => {
       this.emit('closing', 'closing queue');
 

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -139,7 +139,6 @@ export class Worker<
   private waiting = false;
   private running = false;
   private blockTimeout = 0;
-  private beingClosed = false;
 
   protected processFn: Processor<DataType, ResultType, NameType>;
 
@@ -469,7 +468,7 @@ export class Worker<
       if (isNotConnectionError(<Error>error)) {
         this.emit('error', <Error>error);
       }
-      if (!this.beingClosed) {
+      if (!this.closing) {
         await this.delay();
       }
     } finally {
@@ -671,7 +670,6 @@ export class Worker<
     if (this.closing) {
       return this.closing;
     }
-    this.beingClosed = true;
     this.closing = (async () => {
       this.emit('closing', 'closing queue');
 


### PR DESCRIPTION
One easy way to fix this: https://github.com/taskforcesh/bullmq/issues/1294

Please advise if there is any better way.