### PR TITLE
refactor(job): replace slow object destructuring with single object

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -670,8 +670,9 @@ export class Job<
       ];
 
       const transformedProcessed = Object.entries(processed).reduce(
-        (accumulator, [key, value]) => {
-          return { ...accumulator, [key]: JSON.parse(value) };
+        (accumulator: Record<string, any>, [key, value]) => {
+          accumulator[key] = JSON.parse(value);
+          return accumulator;
         },
         {},
       );


### PR DESCRIPTION
Object/Array destructuring is slow! Please don't use it at scale.

Example:
```
const grades =
[
 { studentId: 1000, grade: 10, name: 'John Doe' },
 { studentId: 2000, grade: 8, name: 'Jack Lowery' },
 { studentId: 3000, grade: 9, name: 'Luke SkyWalker' }
];
```

New object every time:
`grades.reduce((previousValue, current) => ({...previousValue, [current.studentId]: current}), {})`

Single object:
```
grades.reduce((previousValue, current) => {
previousValue[current.studentId] = current
return previousValue;
}, {})
```

Graph: https://i.imgur.com/rWoLY5K.png