### PR TITLE
Readme: Fixed incorrect typescript example

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ queueEvents.on('completed', ({ jobId }) => {
   console.log('done painting');
 });
 
-queueEvents.on('failed', ({ jobId, failedReason }: { jobId: string, failedReason: string}) => {
+queueEvents.on('failed', ({ jobId, failedReason }: { jobId: string, failedReason: string }) => {
   console.error('error painting', failedReason);
 });
 ```

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ queueEvents.on('completed', ({ jobId }) => {
   console.log('done painting');
 });
 
-queueEvents.on('failed', ({ jobId: string, failedReason: string }) => {
+queueEvents.on('failed', ({ jobId, failedReason }: { jobId: string, failedReason: string}) => {
   console.error('error painting', failedReason);
 });
 ```


### PR DESCRIPTION
The example in the Readme contains incorrect typescript. The `string` types are actually used like destructuring here.