### PR TITLE
chore: allow esm imports through exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,17 @@
   "name": "bullmq",
   "version": "1.87.2",
   "description": "Queue for messages and jobs based on Redis",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "jsnext:main": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
-  "source": "src/index.ts",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "source": "./src/index.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.js",
+      "types": "./dist/esm/index.d.ts"
+    }
+  },
   "author": "Taskforce.sh Inc.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
split out from https://github.com/taskforcesh/bullmq/pull/1346

imo this should not be a breaking change, even though exports is only supported since node12(?), as for older node versions the `main` export remains. keep in mind that this still wont be fully esm compatible, as get-port and ioredis will be still be on non-esm versions.

contributes to https://github.com/taskforcesh/bullmq/issues/201