### PR TITLE
chore: upgrade to ioredis 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "cron-parser": "^4.6.0",
     "get-port": "^5.1.1",
     "glob": "^8.0.3",
-    "ioredis": "^4.28.5",
+    "ioredis": "^5.2.2",
     "lodash": "^4.17.21",
     "msgpackr": "^1.6.2",
     "semver": "^7.3.7",

--- a/src/classes/flow-producer.ts
+++ b/src/classes/flow-producer.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import { get } from 'lodash';
-import { Redis, Pipeline } from 'ioredis';
+import { Redis, ChainableCommander } from 'ioredis';
 import { v4 } from 'uuid';
 import {
   FlowJob,
@@ -16,7 +16,7 @@ import { KeysMap, QueueKeys } from './queue-keys';
 import { RedisConnection } from './redis-connection';
 
 export interface AddNodeOpts {
-  multi: Pipeline;
+  multi: ChainableCommander;
   node: FlowJob;
   parent?: {
     parentOpts: {
@@ -32,7 +32,7 @@ export interface AddNodeOpts {
 }
 
 export interface AddChildrenOpts {
-  multi: Pipeline;
+  multi: ChainableCommander;
   nodes: FlowJob[];
   parent: {
     parentOpts: {
@@ -242,7 +242,7 @@ export class FlowProducer extends EventEmitter {
    * a parent and a child job at the same time depending on where it is located
    * in the tree hierarchy.
    *
-   * @param multi - ioredis pipeline
+   * @param multi - ioredis ChainableCommander
    * @param node - the node representing a job to be added to some queue
    * @param parent - parent data sent to children to create the "links" to their parent
    * @returns
@@ -321,11 +321,11 @@ export class FlowProducer extends EventEmitter {
    * a parent and a child job at the same time depending on where it is located
    * in the tree hierarchy.
    *
-   * @param multi - ioredis pipeline
+   * @param multi - ioredis ChainableCommander
    * @param nodes - the nodes representing jobs to be added to some queue
    * @returns
    */
-  protected addNodes(multi: Pipeline, nodes: FlowJob[]): JobNode[] {
+  protected addNodes(multi: ChainableCommander, nodes: FlowJob[]): JobNode[] {
     return nodes.map(node => this.addNode({ multi, node }));
   }
 

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -1,4 +1,4 @@
-import { Pipeline } from 'ioredis';
+import { ChainableCommander, Pipeline } from 'ioredis';
 import { fromPairs } from 'lodash';
 import { debuglog } from 'util';
 import {
@@ -545,13 +545,13 @@ export class Job<
     }
 
     const results = await multi.exec();
-    const code = results[results.length - 1][1];
+    const code = results[results.length - 1][1] as number;
     if (code < 0) {
       throw this.scripts.finishedErrors(code, this.id, command, 'active');
     }
 
-    if (finishedOn) {
-      this.finishedOn = finishedOn as number;
+    if (finishedOn && typeof finishedOn === 'number') {
+      this.finishedOn = finishedOn;
     }
   }
 
@@ -707,7 +707,7 @@ export class Job<
         );
       }
 
-      const [result1, result2] = await multi.exec();
+      const [result1, result2] = (await multi.exec()) as [Error, [number[], string[] | undefined]][];
 
       const [processedCursor, processed = []] = opts.processed
         ? result1[1]
@@ -970,7 +970,7 @@ export class Job<
     return this.scripts.addJob(client, jobData, this.opts, this.id, parentOpts);
   }
 
-  protected saveStacktrace(multi: Pipeline, err: Error) {
+  protected saveStacktrace(multi: ChainableCommander, err: Error): void {
     this.stacktrace = this.stacktrace || [];
 
     if (err?.stack) {

--- a/src/classes/queue-events.ts
+++ b/src/classes/queue-events.ts
@@ -231,7 +231,7 @@ export class QueueEvents extends QueueBase {
         const client = await this.client;
 
         try {
-          await client.client('setname', this.clientName(QUEUE_EVENT_SUFFIX));
+          await client.client('SETNAME', this.clientName(QUEUE_EVENT_SUFFIX));
         } catch (err) {
           if (!clientCommandMessageReg.test((<Error>err).message)) {
             throw err;

--- a/src/classes/queue-scheduler.ts
+++ b/src/classes/queue-scheduler.ts
@@ -140,7 +140,7 @@ export class QueueScheduler extends QueueBase {
 
         try {
           await client.client(
-            'setname',
+            'SETNAME',
             this.clientName(QUEUE_SCHEDULER_SUFFIX),
           );
         } catch (err) {

--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import * as IORedis from 'ioredis';
+import { default as IORedis } from 'ioredis';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { CONNECTION_CLOSED_ERROR_MSG } from 'ioredis/built/utils';
@@ -69,7 +69,7 @@ export class RedisConnection extends EventEmitter {
         const hosts = (<any>this._client).startupNodes.map(
           (node: { host: string }) => node.host,
         );
-        this.checkUpstashHost(this._client.options.redisOptions?.host || hosts);
+        this.checkUpstashHost(hosts);
       } else {
         this.opts = this._client.options;
 

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -321,7 +321,7 @@ export class Worker<
           // metadata of the worker. The worker key gets expired every 30 seconds or so, we renew the worker metadata.
           //
           try {
-            await client.client('setname', this.clientName(WORKER_SUFFIX));
+            await client.client('SETNAME', this.clientName(WORKER_SUFFIX));
           } catch (err) {
             if (!clientCommandMessageReg.test((<Error>err).message)) {
               throw err;

--- a/tests/test_connection.ts
+++ b/tests/test_connection.ts
@@ -77,28 +77,6 @@ describe('connection', () => {
         await connection.disconnect();
       });
     });
-
-    describe('when using redisOptions', async () => {
-      it('throws an error', async () => {
-        const connection = new IORedis.Cluster(
-          [
-            {
-              host: 'localhost',
-            },
-          ],
-          {
-            redisOptions: {
-              host: 'https://upstash.io',
-            },
-          },
-        );
-
-        expect(() => new QueueBase(queueName, { connection })).to.throw(
-          'BullMQ: Upstash is not compatible with BullMQ.',
-        );
-        await connection.disconnect();
-      });
-    });
   });
 
   it('should recover from a connection loss', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -405,6 +405,11 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@ioredis/commands@^1.1.1":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"
+  integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
+
 "@isaacs/string-locale-compare@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz#291c227e93fd407a96ecd59879a35809120e432b"
@@ -2101,13 +2106,6 @@ debug@4, debug@4.3.4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, de
   dependencies:
     ms "2.1.2"
 
-debug@^4.3.1:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
-  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
-  dependencies:
-    ms "2.1.2"
-
 debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -2199,10 +2197,10 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
 
-denque@^1.1.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.1.tgz#07f670e29c9a78f8faecb2566a1e2c11929c5cbf"
-  integrity sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==
+denque@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
+  integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
 
 depd@^1.1.2:
   version "1.1.2"
@@ -3445,19 +3443,17 @@ into-stream@^6.0.0:
     from2 "^2.3.0"
     p-is-promise "^3.0.0"
 
-ioredis@^4.28.5:
-  version "4.28.5"
-  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.28.5.tgz#5c149e6a8d76a7f8fa8a504ffc85b7d5b6797f9f"
-  integrity sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==
+ioredis@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.2.2.tgz#212467e04f6779b4e0e800cece7bb7d3d7b546d2"
+  integrity sha512-wryKc1ur8PcCmNwfcGkw5evouzpbDXxxkMkzPK8wl4xQfQf7lHe11Jotell5ikMVAtikXJEu/OJVaoV51BggRQ==
   dependencies:
+    "@ioredis/commands" "^1.1.1"
     cluster-key-slot "^1.1.0"
-    debug "^4.3.1"
-    denque "^1.1.0"
+    debug "^4.3.4"
+    denque "^2.0.1"
     lodash.defaults "^4.2.0"
-    lodash.flatten "^4.4.0"
     lodash.isarguments "^3.1.0"
-    p-map "^2.1.0"
-    redis-commands "1.7.0"
     redis-errors "^1.2.0"
     redis-parser "^3.0.0"
     standard-as-callback "^2.1.0"
@@ -4150,11 +4146,6 @@ lodash.escaperegexp@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
   integrity sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==
-
-lodash.flatten@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
-  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
@@ -5149,7 +5140,7 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
-p-map@^2.0.0, p-map@^2.1.0:
+p-map@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
@@ -5638,11 +5629,6 @@ redeyed@~2.1.0:
   integrity sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==
   dependencies:
     esprima "~4.0.0"
-
-redis-commands@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.7.0.tgz#15a6fea2d58281e27b1cd1acfb4b293e278c3a89"
-  integrity sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==
 
 redis-errors@^1.0.0, redis-errors@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
imo this is a relatively non-breaking split-out from https://github.com/taskforcesh/bullmq/pull/1346

- the ioredis commands are now uppercased (typed)
- the return type for multi.exec() changed, so it returns unknown instead of any. hence I needed to do some typecasts there.
- removed test "when using redisOptions" and the code it was testing, as IORedis no longer accepts that parameter

closes https://github.com/taskforcesh/bullmq/issues/1332