### PR TITLE
ci: set up nyc coverage limits and coveralls action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       node-version: lts/*
       redis-version: 7-alpine
+      allowed_coverage_change: -0.25
 
     steps:
       - name: Checkout repository
@@ -37,10 +38,22 @@ jobs:
       - run: yarn install --frozen-lockfile --non-interactive
       - run: yarn build
       - run: yarn coverage
-      - name: Coverage
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: yarn coveralls
+      - name: Upload LCOV to Coveralls
+        if: ${{ ( github.event_name == 'pull_request' && github.event.pull_request.head.fork == false ) || github.event_name == 'push' }}
+        uses: coverallsapp/github-action@3284643be2c47fb6432518ecec17f1255e8a06a6 # branch=master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check coverage change not below threshold
+        shell: bash
+        run: |
+          sleep 2
+          COVERAGE_CHANGE=$(curl -s https://coveralls.io/builds/${{ github.sha }}.json | jq '.coverage_change')
+          echo coverage changed by ${COVERAGE_CHANGE}%
+
+          if [[ -z "$(echo ${COVERAGE_CHANGE} ${{ env.allowed_coverage_change }} | awk '$1 >= $2')" ]]; then 
+            echo current coverage change ${COVERAGE_CHANGE}% below threshold ${{ env.allowed_coverage_change }}%
+            exit 1
+          fi
 
   compatibility:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ yarn-error.log*
 
 # Coverage files
 .nyc_output
+coverage
+coverage/*
 
 # Editor directories and files
 .idea

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "clean:temp:files": "rimraf dist/cjs/bullmq.d.ts dist/esm/bullmq.d.ts dist/tsdoc-metadata.json",
     "copy:lua": "copyfiles -f ./src/commands/*.lua ./dist/cjs/commands && copyfiles -f ./src/commands/*.lua ./dist/esm/commands",
     "copy:includes:lua": "copyfiles -f ./src/commands/includes/*.lua ./dist/cjs/commands/includes && copyfiles -f ./src/commands/includes/*.lua ./dist/esm/commands/includes",
-    "coverage": "nyc --reporter=text npm run test",
-    "coveralls": "nyc report --reporter=text-lcov | coveralls",
+    "coverage": "nyc --reporter=text --reporter=lcovonly yarn test",
     "cm": "git cz",
     "docs": "typedoc --excludeExternals --excludeProtected --excludePrivate --readme none src/index.ts",
     "dc:up": "docker-compose -f docker-compose.yml up -d",
@@ -120,7 +119,29 @@
     ],
     "exclude": [
       "bullmq-tests/test_*.ts"
-    ]
+    ],
+    "lines": 80,
+    "functions": 80,
+    "branches": 70,
+    "statements": 80,
+    "watermarks": {
+      "lines": [
+        80,
+        95
+      ],
+      "functions": [
+        80,
+        95
+      ],
+      "branches": [
+        80,
+        95
+      ],
+      "statements": [
+        80,
+        95
+      ]
+    }
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
- uses coveralls github action to submit coverage
- sets nyc limits to realistic values
- adds a check how much a PR lowered the coverage

you can see it in action [here](https://github.com/boredland/bullmq/pull/14).
