### PR TITLE
chore: upgrade get-port

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "cron-parser": "^4.6.0",
-    "get-port": "^5.1.1",
+    "get-port": "6.1.2",
     "glob": "^8.0.3",
     "ioredis": "^5.2.2",
     "lodash": "^4.17.21",

--- a/src/classes/child-pool.ts
+++ b/src/classes/child-pool.ts
@@ -1,7 +1,6 @@
 import { ChildProcess, fork } from 'child_process';
 import * as path from 'path';
 import { flatten } from 'lodash';
-import * as getPort from 'get-port';
 import { killAsync } from './process-utils';
 import { ParentCommand, ChildCommand } from '../interfaces';
 import { parentSend } from '../utils';
@@ -22,7 +21,7 @@ const convertExecArgv = async (execArgv: string[]): Promise<string[]> => {
       standard.push(arg);
     } else {
       const argName = arg.split('=')[0];
-      const port = await getPort();
+      const port = await (await import('get-port')).default();
       convertedArgs.push(`${argName}=${port}`);
     }
   }

--- a/src/types/net.d.ts
+++ b/src/types/net.d.ts
@@ -1,0 +1,4 @@
+/* TODO: remove as soon as node 12 is deprecated */
+declare module 'node:net' {
+  export * from 'net';
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2946,10 +2946,10 @@ get-package-type@^0.1.0:
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
-get-port@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
-  integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
+get-port@6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-6.1.2.tgz#c1228abb67ba0e17fb346da33b15187833b9c08a"
+  integrity sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==
 
 get-stream@^5.0.0:
   version "5.2.0"


### PR DESCRIPTION
... without deprecating node12.

In the light of https://github.com/taskforcesh/bullmq/pull/1346 I want to explore alternatives to deprecating node12 (for now).

reasoning: 

as per the release notes for node 12.20, node supports using the `node:` prefix in dynamic imports. my hope is, that by importing get-port dynamically, this automatically adds support for the non-dynamic `node:` imports 'inside' get-port.

I tested this using the following script (copied over from the readme) run by node12:

```js
const bullmq = require('../dist/cjs/index');

const queue = new bullmq.Queue('Paint');

queue.add('cars', { color: 'blue' });

const worker = new bullmq.Worker('Paint', async job => {
    if (job.name === 'cars') {
      console.log(job);
    }
});
```

and I successfully tried to build a similar file (with es imports) using ts-up.

closes https://github.com/taskforcesh/bullmq/issues/201
superseeds https://github.com/taskforcesh/bullmq/pull/1173
superseeds https://github.com/taskforcesh/bullmq/pull/1346