### PR TITLE
ci: disable husky during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - master
+
+env:
+  HUSKY: 0
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
Currently the releases seem to be stuck. I saw that phenomenon when Husky was running in CI and there are [similar](https://github.com/semantic-release/git/issues/124) [issues](https://github.com/semantic-release/git/issues/154) on the web. Perhaps explicitly disabling it does the trick?