### PR TITLE
fix(queue-getters): getting undefined when getting repeat jobs

### DIFF
--- a/src/classes/queue-getters.ts
+++ b/src/classes/queue-getters.ts
@@ -32,13 +32,22 @@ export class QueueGetters<
     >;
   }
 
+  private resolveAliasJobType(type: string) {
+    const typeToAliases: Record<string, string> = {
+      'waiting': 'wait',
+      'repeat': 'delayed'
+    };
+
+    return typeToAliases[type] || type;
+  }
+
   private commandByType(
     types: JobType[],
     count: boolean,
     callback: (key: string, dataType: string) => void,
   ) {
     return types.map((type: string) => {
-      type = type === 'waiting' ? 'wait' : type; // alias
+      type = this.resolveAliasJobType(type);
 
       const key = this.toKey(type);
 

--- a/tests/test_repeat.ts
+++ b/tests/test_repeat.ts
@@ -1174,4 +1174,16 @@ describe('repeat', function () {
     await worker.close();
     await queueScheduler.close();
   });
+
+  it('should get repeatable jobs using the getJobs method of the queue', async function() {
+    const queueScheduler = new QueueScheduler(queueName, { connection });
+    await queueScheduler.waitUntilReady();
+
+    await queue.add('test', { foo: 'bar' }, { repeat: { every: 1000 } });
+
+    const queueJobs = await queue.getJobs(); // right: 'repeat:5b8589ce9156aede92c064e935c4edcf:1000'
+
+    expect(queueJobs.length).to.be.eql(1);
+    expect(queueJobs[0].data).to.be.eql({foo: 'bar'});
+  });
 });


### PR DESCRIPTION
This will fix https://github.com/taskforcesh/bullmq/issues/248

This happened because `repeat` jobs where actually considered to be delayed jobs when using the queue's `getJobs` function.

I also added a test for it.