### PR TITLE
feat(sandboxed-job): add support for getChildrenValues

### DIFF
--- a/src/classes/sandbox.ts
+++ b/src/classes/sandbox.ts
@@ -39,6 +39,16 @@ const sandbox = <T, R, N extends string>(
           case ParentCommand.Update:
             await job.update(msg.value);
             break;
+          case ParentCommand.GetChildrenValues:
+            {
+              const value = await job.getChildrenValues();
+              await parentSend(child, {
+                cmd: ChildCommand.GetChildrenValues,
+                value,
+              });
+            }
+
+            break;
         }
       };
 

--- a/src/interfaces/child-command.ts
+++ b/src/interfaces/child-command.ts
@@ -2,4 +2,5 @@ export enum ChildCommand {
   Init,
   Start,
   Stop,
+  GetChildrenValues,
 }

--- a/src/interfaces/parent-command.ts
+++ b/src/interfaces/parent-command.ts
@@ -7,4 +7,5 @@ export enum ParentCommand {
   Log,
   Progress,
   Update,
+  GetChildrenValues,
 }

--- a/src/interfaces/sandboxed-job.ts
+++ b/src/interfaces/sandboxed-job.ts
@@ -14,5 +14,6 @@ export interface SandboxedJob<T = any, R = any>
   updateProgress: (value: object | number) => Promise<void>;
   log: (row: any) => void;
   update: (data: any) => Promise<void>;
+  getChildrenValues: <CT = any>() => Promise<{ [jobKey: string]: CT }>;
   returnValue: R;
 }

--- a/tests/fixtures/fixture_processor_getChildrenValues.js
+++ b/tests/fixtures/fixture_processor_getChildrenValues.js
@@ -1,0 +1,11 @@
+/**
+ * A processor file to be used in tests.
+ *
+ */
+'use strict';
+
+const delay = require('./delay');
+
+module.exports = async function (job) {
+  return job.getChildrenValues();
+};

--- a/tests/fixtures/fixture_processor_getChildrenValues_child.js
+++ b/tests/fixtures/fixture_processor_getChildrenValues_child.js
@@ -1,0 +1,11 @@
+/**
+ * A processor file to be used in tests.
+ *
+ */
+'use strict';
+
+const delay = require('./delay');
+
+module.exports = function (job) {
+  return { childResult: 'bar' };
+};

--- a/tests/test_sandboxed_process.ts
+++ b/tests/test_sandboxed_process.ts
@@ -514,7 +514,7 @@ describe('sandboxed process', () => {
   });
 
   it('can get children values by calling getChildrenValues', async () => {
-    let childJobId: string | undefined;
+    const childJobId = 'child-job-id';
     const childProcessFile =
       __dirname + '/fixtures/fixture_processor_getChildrenValues_child.js';
     const parentProcessFile =
@@ -546,28 +546,14 @@ describe('sandboxed process', () => {
       });
     });
 
-    const childCompleting = new Promise<void>((resolve, reject) => {
-      childWorker.on('completed', async (job: Job) => {
-        try {
-          childJobId = job.id;
-          await childWorker.close();
-          resolve();
-        } catch (err) {
-          await childWorker.close();
-          reject(err);
-        }
-      });
-    });
-
     const flow = new FlowProducer({ connection });
     await flow.add({
       name: 'parent-job',
       queueName: parentQueueName,
       opts: { jobId: 'job-id' },
-      children: [{ name: 'child-job', queueName }],
+      children: [{ name: 'child-job', queueName, opts: { jobId: childJobId } }],
     });
 
-    await childCompleting;
     await parentCompleting;
     await parentWorker.close();
     await childWorker.close();

--- a/tests/test_sandboxed_process.ts
+++ b/tests/test_sandboxed_process.ts
@@ -513,6 +513,67 @@ describe('sandboxed process', () => {
     await flow.close();
   });
 
+  it('can get children values by calling getChildrenValues', async () => {
+    let childJobId: string | undefined;
+    const childProcessFile =
+      __dirname + '/fixtures/fixture_processor_getChildrenValues_child.js';
+    const parentProcessFile =
+      __dirname + '/fixtures/fixture_processor_getChildrenValues.js';
+    const parentQueueName = `parent-queue-${v4()}`;
+
+    const parentWorker = new Worker(parentQueueName, parentProcessFile, {
+      connection,
+      drainDelay: 1,
+    });
+
+    const childWorker = new Worker(queueName, childProcessFile, {
+      connection,
+      drainDelay: 1,
+    });
+
+    const parentCompleting = new Promise<void>((resolve, reject) => {
+      parentWorker.on('completed', async (job: Job, value: any) => {
+        try {
+          expect(value).to.be.eql({
+            [`bull:${queueName}:${childJobId}`]: { childResult: 'bar' },
+          });
+          await parentWorker.close();
+          resolve();
+        } catch (err) {
+          await parentWorker.close();
+          reject(err);
+        }
+      });
+    });
+
+    const childCompleting = new Promise<void>((resolve, reject) => {
+      childWorker.on('completed', async (job: Job) => {
+        try {
+          childJobId = job.id;
+          await childWorker.close();
+          resolve();
+        } catch (err) {
+          await childWorker.close();
+          reject(err);
+        }
+      });
+    });
+
+    const flow = new FlowProducer({ connection });
+    await flow.add({
+      name: 'parent-job',
+      queueName: parentQueueName,
+      opts: { jobId: 'job-id' },
+      children: [{ name: 'child-job', queueName }],
+    });
+
+    await childCompleting;
+    await parentCompleting;
+    await parentWorker.close();
+    await childWorker.close();
+    await flow.close();
+  });
+
   it('should process and fail', async () => {
     const processFile = __dirname + '/fixtures/fixture_processor_fail.js';
 


### PR DESCRIPTION
Hi @manast @roggervalf :D 

Looking to get this feature added for sandboxed workers. The only part I'm not certain on is how you'd like [this error](https://github.com/rosslavery/bullmq/blob/feat/sandbox-getchildrenvalues/src/classes/child-processor.ts#L229) to be handled, or if there is try/catch further up the chain so it's not needed here.

Fixes https://github.com/taskforcesh/bullmq-pro-support/issues/21
Fixes https://github.com/taskforcesh/bullmq/issues/1306
Fixes https://github.com/taskforcesh/bullmq/issues/753