### PR TITLE
Get open port using built-in module instead of get-port

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   },
   "dependencies": {
     "cron-parser": "^4.6.0",
-    "get-port": "6.1.2",
     "glob": "^8.0.3",
     "ioredis": "^5.2.2",
     "lodash": "^4.17.21",

--- a/src/classes/child-pool.ts
+++ b/src/classes/child-pool.ts
@@ -1,6 +1,7 @@
 import { ChildProcess, fork } from 'child_process';
 import * as path from 'path';
 import { flatten } from 'lodash';
+import net from 'net';
 import { killAsync } from './process-utils';
 import { ParentCommand, ChildCommand } from '../interfaces';
 import { parentSend } from '../utils';
@@ -10,6 +11,16 @@ const CHILD_KILL_TIMEOUT = 30_000;
 export interface ChildProcessExt extends ChildProcess {
   processFile?: string;
 }
+
+const getFreePort = async () => {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.listen(0, () => {
+      const port = server.address().port;
+      server.close((error: any) => resolve(port));
+    });
+  });
+};
 
 const convertExecArgv = async (execArgv: string[]): Promise<string[]> => {
   const standard: string[] = [];
@@ -21,7 +32,7 @@ const convertExecArgv = async (execArgv: string[]): Promise<string[]> => {
       standard.push(arg);
     } else {
       const argName = arg.split('=')[0];
-      const port = await (await import('get-port')).default();
+      const port = await getFreePort();
       convertedArgs.push(`${argName}=${port}`);
     }
   }

--- a/src/classes/child-pool.ts
+++ b/src/classes/child-pool.ts
@@ -1,7 +1,7 @@
 import { ChildProcess, fork } from 'child_process';
 import * as path from 'path';
 import { flatten } from 'lodash';
-import net from 'net';
+import { AddressInfo, createServer } from 'node:net';
 import { killAsync } from './process-utils';
 import { ParentCommand, ChildCommand } from '../interfaces';
 import { parentSend } from '../utils';
@@ -13,11 +13,11 @@ export interface ChildProcessExt extends ChildProcess {
 }
 
 const getFreePort = async () => {
-  return new Promise((resolve) => {
-    const server = net.createServer();
+  return new Promise(resolve => {
+    const server = createServer();
     server.listen(0, () => {
-      const port = server.address().port;
-      server.close((error: any) => resolve(port));
+      const { port } = (server.address() as AddressInfo);
+      server.close(() => resolve(port));
     });
   });
 };

--- a/src/classes/child-pool.ts
+++ b/src/classes/child-pool.ts
@@ -1,7 +1,7 @@
 import { ChildProcess, fork } from 'child_process';
 import * as path from 'path';
 import { flatten } from 'lodash';
-import { AddressInfo, createServer } from 'node:net';
+import { AddressInfo, createServer } from 'net';
 import { killAsync } from './process-utils';
 import { ParentCommand, ChildCommand } from '../interfaces';
 import { parentSend } from '../utils';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2995,11 +2995,6 @@ get-package-type@^0.1.0:
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
-get-port@6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/get-port/-/get-port-6.1.2.tgz#c1228abb67ba0e17fb346da33b15187833b9c08a"
-  integrity sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==
-
 get-stream@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
@@ -4946,7 +4941,6 @@ npm@^8.3.0:
     "@npmcli/fs" "^2.1.0"
     "@npmcli/map-workspaces" "^2.0.3"
     "@npmcli/package-json" "^2.0.0"
-    "@npmcli/promise-spawn" "^3.0.0"
     "@npmcli/run-script" "^4.2.1"
     abbrev "~1.1.1"
     archy "~1.0.0"
@@ -4957,7 +4951,6 @@ npm@^8.3.0:
     cli-table3 "^0.6.2"
     columnify "^1.6.0"
     fastest-levenshtein "^1.0.12"
-    fs-minipass "^2.1.0"
     glob "^8.0.1"
     graceful-fs "^4.2.10"
     hosted-git-info "^5.1.0"
@@ -4977,7 +4970,6 @@ npm@^8.3.0:
     libnpmteam "^4.0.4"
     libnpmversion "^3.0.7"
     make-fetch-happen "^10.2.0"
-    minimatch "^5.1.0"
     minipass "^3.1.6"
     minipass-pipeline "^1.2.4"
     mkdirp "^1.0.4"


### PR DESCRIPTION
Fixes #1424 by replacing the `get-port` module, which causes errors in some scenarios when imported, with a simple function that uses the built-in NodeJS `net` module to find an open port for child processes. This has been tested using [patch-package](https://www.npmjs.com/package/patch-package) in a project where sandboxed jobs were previously unable to be processed due to this issue.