### PR TITLE
docs: update Queue Scheduler API Reference

### DIFF
--- a/docs/gitbook/guide/jobs/delayed.md
+++ b/docs/gitbook/guide/jobs/delayed.md
@@ -24,4 +24,4 @@ await myQueue.add('house', { color: 'white' }, { delay: 5000 });
 
 ## Read more:
 
-* 💡 [Queue Scheduler API Reference](https://api.docs.bullmq.io/classes/QueueScheduler.html)
+* 💡 [Queue Scheduler API Reference](https://github.com/taskforcesh/bullmq/blob/v1.91.1/docs/gitbook/api/bullmq.queuescheduler.md)

--- a/docs/gitbook/guide/jobs/stalled.md
+++ b/docs/gitbook/guide/jobs/stalled.md
@@ -38,4 +38,4 @@ export default = (job) => {
 
 ## Read more:
 
-* 💡 [Queue Scheduler API Reference](https://api.docs.bullmq.io/classes/QueueScheduler.html)
+* 💡 [Queue Scheduler API Reference](https://github.com/taskforcesh/bullmq/blob/v1.91.1/docs/gitbook/api/bullmq.queuescheduler.md)

--- a/docs/gitbook/guide/queuescheduler.md
+++ b/docs/gitbook/guide/queuescheduler.md
@@ -31,4 +31,4 @@ It is ok to have as many QueueScheduler instances as you want, just keep in mind
 
 ## Read more:
 
-* 💡 [Queue Scheduler API Reference](https://api.docs.bullmq.io/classes/QueueScheduler.html)
+* 💡 [Queue Scheduler API Reference](https://github.com/taskforcesh/bullmq/blob/v1.91.1/docs/gitbook/api/bullmq.queuescheduler.md)


### PR DESCRIPTION
The html page is no longer generated by typedoc since v2