### PR TITLE
fix(worker): clear stalled jobs timer when closing worker

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -758,9 +758,11 @@ export class Worker<
     try {
       if (!this.closing) {
         await this.checkConnectionError(() => this.moveStalledJobsToWait());
-        setTimeout(async () => {
-          this.runStalledJobsCheck();
-        }, this.opts.stalledInterval);
+        this.timerManager.setTimer(
+          'checkStalledJobs',
+          this.opts.stalledInterval,
+          () => this.runStalledJobsCheck(),
+        );
       }
     } catch (err) {
       this.emit('error', <Error>err);


### PR DESCRIPTION
Hi, thank you for this library.

The stalled jobs timer currently prevents Node from exiting - which can take up to 30 seconds with the default configuration. This small PR uses the worker's already available `TimerManager` to clear it when the worker is `close`d, allowing Node to exit promptly.