### PR TITLE
docs: fix Object.values usage in flows guide

### DIFF
--- a/docs/gitbook/guide/flows/README.md
+++ b/docs/gitbook/guide/flows/README.md
@@ -77,8 +77,7 @@ import { Worker } from 'bullmq';
 const stepsQueue = new Worker('renovate', async job => {
   const childrenValues = await job.getChildrenValues();
 
-  const totalCosts = Object(childrenValues)
-    .values()
+  const totalCosts = Object.values(childrenValues)
     .reduce((prev, cur) => prev + cur, 0);
 
   await sendInvoice(totalCosts);


### PR DESCRIPTION
While implementing jobs using the "Flows" guide i noticed a `TypeError: Object(...).values is not a function` error when using the code from the docs. Changing it to `Object.values(childrenValues)` is the correct usage.