### PR TITLE
fix(repeat): allow easy migration from bullmq <3 to >=3

### DIFF
--- a/src/classes/repeat.ts
+++ b/src/classes/repeat.ts
@@ -26,7 +26,12 @@ export class Repeat extends QueueBase {
     opts: JobsOptions,
     skipCheckExists?: boolean,
   ): Promise<Job<T, R, N>> {
-    const repeatOpts = { ...opts.repeat };
+    // HACK: This is a temporary fix to enable easy migration from bullmq <3.0.0
+    // to >= 3.0.0. It should be removed when moving to 4.x.
+    const repeatOpts: RepeatOptions & { cron?: string } = { ...opts.repeat };
+    repeatOpts.pattern ??= repeatOpts.cron;
+    delete repeatOpts.cron;
+
     const prevMillis = opts.prevMillis || 0;
     const currentCount = repeatOpts.count ? repeatOpts.count + 1 : 1;
 


### PR DESCRIPTION
This adds a small migration step to `addNextRepeatableJob` to convert from the old `cron` key to the new `pattern` key.

Using `pattern` instead of `cron` has been supported since 1.90, but it only started being _required_ in 3.0.0. Unfortunately throughout all of 2.x, passing the `cron` key to job creation would _not_ translate it into a `pattern` key internally. This means that any repeatable jobs created between 1.90 and 3.0.0 that use the `cron` key instead of `pattern` will fail when upgrading to 3.0.0 with the error `Validation error, cannot resolve alias "und"`. This patch aims to smooth out that transition by silently migrating any existing jobs with a `repeat.cron` key to instead have `repeat.pattern`.

For maximum compatibility this patch should stick around until at least v4.0.0.