### PR TITLE
fix(job): console warn custom job ids when they represent integers

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -1058,7 +1058,8 @@ export class Job<
 
     if (`${parseInt(this.id, 10)}` === this.id) {
       //TODO: throw an error in next breaking change
-      console.warn('Custom Ids cannot be integers');
+      console.warn(`Custom Ids should not be integers to avoid potential edge cases.
+ref https://github.com/taskforcesh/bullmq/pull/1569`);
     }
 
     return this.scripts.addJob(

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -1058,8 +1058,9 @@ export class Job<
 
     if (`${parseInt(this.id, 10)}` === this.id) {
       //TODO: throw an error in next breaking change
-      console.warn(`Custom Ids should not be integers to avoid potential edge cases.
-ref https://github.com/taskforcesh/bullmq/pull/1569`);
+      console.warn(
+        'Custom Ids should not be integers: https://github.com/taskforcesh/bullmq/pull/1569',
+      );
     }
 
     return this.scripts.addJob(

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -1057,7 +1057,8 @@ export class Job<
     }
 
     if (`${parseInt(this.id, 10)}` === this.id) {
-      throw new Error('Custom Ids cannot be integers');
+      //TODO: throw an error in next breaking change
+      console.warn('Custom Ids cannot be integers');
     }
 
     return this.scripts.addJob(

--- a/tests/test_queue.ts
+++ b/tests/test_queue.ts
@@ -96,7 +96,8 @@ describe('queues', function () {
     await removeAllQueueData(new IORedis(), queueName);
   });
 
-  describe('.add', () => {
+  //TODO: restore this tests in next breaking change
+  describe.skip('.add', () => {
     describe('when jobId is provided as integer', () => {
       it('throws error', async function () {
         await expect(


### PR DESCRIPTION
ref https://github.com/taskforcesh/bullmq/pull/1556, in next breaking change we can restore throwing the error to avoid this edge case