### PR TITLE
fix(job): fetch parent before job moves to complete

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -516,11 +516,6 @@ export class Job<
       throw errorObject.value;
     }
 
-    const jobData = await Job.fromId(this.queue, this.id);
-    // overwrite parent with redis response
-    this.parent = jobData.parent;
-    this.parentKey = jobData.parentKey;
-
     return this.scripts.moveToCompleted(
       this,
       stringifiedReturnValue,
@@ -597,11 +592,6 @@ export class Job<
     }
 
     if (moveToFailed) {
-      const jobData = await Job.fromId(this.queue, this.id);
-      // overwrite parent with redis response
-      this.parent = jobData.parent;
-      this.parentKey = jobData.parentKey;
-
       const args = this.scripts.moveToFailedArgs(
         this,
         message,

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -597,6 +597,11 @@ export class Job<
     }
 
     if (moveToFailed) {
+      const jobData = await Job.fromId(this.queue, this.id);
+      // overwrite parent with redis response
+      this.parent = jobData.parent;
+      this.parentKey = jobData.parentKey;
+
       const args = this.scripts.moveToFailedArgs(
         this,
         message,

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -516,6 +516,11 @@ export class Job<
       throw errorObject.value;
     }
 
+    const jobData = await Job.fromId(this.queue, this.id);
+    // overwrite parent with redis response
+    this.parent = jobData.parent;
+    this.parentKey = jobData.parentKey;
+
     return this.scripts.moveToCompleted(
       this,
       stringifiedReturnValue,

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -291,8 +291,6 @@ export class Scripts {
         keepJobs,
         limiter: opts.limiter,
         lockDuration: opts.lockDuration,
-        parent: job.opts?.parent,
-        parentKey: job.parentKey,
         attempts: job.opts.attempts,
         attemptsMade: job.attemptsMade,
         maxMetricsSize: opts.metrics?.maxDataPoints

--- a/tests/test_flow.ts
+++ b/tests/test_flow.ts
@@ -890,6 +890,65 @@ describe('flows', () => {
 
       await flow.close();
     });
+
+    it('processes parent jobs added while a child job is active', async function () {
+      this.timeout(10_000);
+
+      const worker = new Worker(
+        queueName,
+        async () => {
+          await new Promise(s => {
+            setTimeout(s, 1_000);
+          });
+        },
+        {
+          connection,
+        },
+      );
+
+      const completing = new Promise<void>(resolve => {
+        worker.on('completed', (job: Job) => {
+          if (job.id === 'tue') {
+            resolve();
+          }
+        });
+      });
+
+      const flow = new FlowProducer({ connection });
+      await flow.add({
+        queueName,
+        name: 'mon',
+        opts: {
+          jobId: 'mon',
+        },
+        children: [],
+      });
+
+      const tree = await flow.add({
+        queueName,
+        name: 'tue',
+        opts: {
+          jobId: 'tue',
+        },
+        children: [
+          {
+            name: 'mon',
+            queueName,
+            opts: {
+              jobId: 'mon',
+            },
+          },
+        ],
+      });
+
+      await completing;
+
+      const state = await tree.job.getState();
+
+      expect(state).to.be.equal('completed');
+
+      await flow.close();
+    });
   });
 
   describe('when custom prefix is set in flow producer', async () => {

--- a/tests/test_flow.ts
+++ b/tests/test_flow.ts
@@ -924,6 +924,10 @@ describe('flows', () => {
         children: [],
       });
 
+      await new Promise(s => {
+        setTimeout(s, 500);
+      });
+
       const tree = await flow.add({
         queueName,
         name: 'tue',


### PR DESCRIPTION
When creating a flow with a long-running job in the beginning (e.g. takes multiple seconds) and during the processing of the job you want to add a new parent to this job (because it should run after the long-running job) it doesn't execute the job which was added after.

The root cause of this issue is, that the worker fetches the `Job` from redis before it moves it to active. When the `Job` then finishes, the worker passes the previous fetched instance of the job to `moveToCompleted`. When an additional Job is added as `parent` of the current processing job, it never gets executed because the instance doesn't have the correct parent key. 

This PR adds an additional "sync" of the parent key of the job before it gets moved to completed to have the current instance up to date when in the meantime a new parent was added. 

Added a test which runs the following flow:

- Create Job 1 without children
  - Flow moves Job to active
  - Worker processes job (wait 1000ms)
- Client waits 500ms
- Client adds new Job 2 with children [Job1]
- Worker finishes Job 1
- Worker starts Job 2 
- Worker finishes Job 2