### PR TITLE
Fix/allow ioredis cluster connection by dsn string

### DIFF
--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -113,8 +113,8 @@ export class RedisConnection extends EventEmitter {
 
   private checkUpstashHost(host: string[] | string | undefined) {
     const includesUpstash = Array.isArray(host)
-      ? host.some(node => node.endsWith('upstash.io'))
-      : host?.endsWith('upstash.io');
+      ? host.some(node => node.includes('upstash.io'))
+      : host?.includes('upstash.io');
     if (includesUpstash) {
       throw new Error(upstashMessage);
     }

--- a/tests/test_connection.ts
+++ b/tests/test_connection.ts
@@ -71,6 +71,14 @@ describe('connection', () => {
     });
   });
 
+  describe('when instantiating with a clustered ioredis connection', () => {
+    it('should not fail when using dsn strings', async () => {
+      const connection = new IORedis.Cluster(['redis://10.0.6.161:7379']);
+      const myQueue = new Queue('myqueue', { connection });
+      connection.disconnect();
+    });
+  });
+
   describe('when host belongs to Upstash', async () => {
     it('throws an error', async () => {
       const opts = {


### PR DESCRIPTION
Add a test to cover this case: https://github.com/taskforcesh/bullmq/issues/1595
Also use ```includes``` instead of ```endsWith``` which is a bit more reliable.