### PR TITLE
fix(connection): apply console.warn in noeviction message

### DIFF
--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -285,7 +285,7 @@ export class RedisConnection extends EventEmitter {
       if (lines[i].indexOf(maxMemoryPolicyPrefix) === 0) {
         const maxMemoryPolicy = lines[i].substr(maxMemoryPolicyPrefix.length);
         if (maxMemoryPolicy !== 'noeviction') {
-          console.error(
+          console.warn(
             `IMPORTANT! Eviction policy is ${maxMemoryPolicy}. It should be "noeviction"`,
           );
         }


### PR DESCRIPTION
As stated in https://github.com/taskforcesh/bullmq/pull/1440 it should be a warning, not an error. 