### PR TITLE
fix: infinite worker process spawned for invalid JS file

### DIFF
--- a/src/classes/child-pool.ts
+++ b/src/classes/child-pool.ts
@@ -15,7 +15,7 @@ const getFreePort = async () => {
   return new Promise(resolve => {
     const server = createServer();
     server.listen(0, () => {
-      const { port } = (server.address() as AddressInfo);
+      const { port } = server.address() as AddressInfo;
       server.close(() => resolve(port));
     });
   });
@@ -121,8 +121,13 @@ export class ChildPool {
     child.stdout.pipe(process.stdout);
     child.stderr.pipe(process.stderr);
 
-    await initChild(child, child.processFile);
-    return child;
+    try {
+      await initChild(child, child.processFile);
+      return child;
+    } catch (err) {
+      _this.release(child);
+      throw err;
+    }
   }
 
   release(child: ChildProcessExt): void {


### PR DESCRIPTION
 Resolves #1587

This issue has been interfering with my work so I decided to investigate the issue and submit a patch back to the community. Great work @manast @roggervalf on the library!

## Background

Infinite worker processes would spawn for invalid worker JS file. (i.e. default export not reachable)
Some examples how this could unintentionally happen:

```js
// worker.js

// Example 1: Library that throws an error for whatever reason
const lib = require("mylib")

// Example 2: Typo/SyntaxError in the file (usually happens in development)
constmyVar = 3; // ReferenceError constmyVar doesn't exist (need space between const keyword and var name)

module.exports = () => {
 // Worker implementation
}
```

## BullMQ failed tasks handling

**Case 1 (error thrown inside module.exports fn)**

1. BullMQ sends "Failed" signal from child-processor.ts:82

https://github.com/taskforcesh/bullmq/blob/77ca996d34652e75b4fed5475c871c830a3d00f3/src/classes/child-processor.ts#L81-L84

2. `finally` block runs in sandbox.ts (**important, it releases the process**)

https://github.com/taskforcesh/bullmq/blob/77ca996d34652e75b4fed5475c871c830a3d00f3/src/classes/sandbox.ts#L58-L67

3. Job gets marked as failed in worker.ts catch block

https://github.com/taskforcesh/bullmq/blob/77ca996d34652e75b4fed5475c871c830a3d00f3/src/classes/worker.ts#L672-L679

4. The cycle repeats all good.

**Case 2 (our case with invalid worker JS file / unreachable default export)**

1. BullMQ sends "InitFailed" signal from child-processor.ts

https://github.com/taskforcesh/bullmq/blob/77ca996d34652e75b4fed5475c871c830a3d00f3/src/classes/child-processor.ts#L38-L42

2. "InitFailed" signal gets received in child-pool.ts and bubbles up

https://github.com/taskforcesh/bullmq/blob/77ca996d34652e75b4fed5475c871c830a3d00f3/src/classes/child-pool.ts#L65-L70

3. Job gets marked as failed in worker.ts catch block

https://github.com/taskforcesh/bullmq/blob/77ca996d34652e75b4fed5475c871c830a3d00f3/src/classes/worker.ts#L672-L679

4. The cycle repeats all... not good.

The error bubbles up and we mark the job as failed, **however** the process never actually gets released!
And that's the problem here. Even though the jobs are marked as failed, processes on the host just keep spawning as each task is processed.

## Solution

If JS engine can't interpret the worker.js file for any reason (SyntaxError, typo, failed require of external dependency), we shouldn't keep processing tasks and spawning workers. We exit the process and log the error to the console so it's clear to the developer why default export is not reachable in worker.js file.

Thanks!