### PR TITLE
docs: make keyPrefix warning more pronounced

### DIFF
--- a/docs/gitbook/guide/connections.md
+++ b/docs/gitbook/guide/connections.md
@@ -34,7 +34,9 @@ const myWorker = new Worker('myworker', async (job)=>{}, { connection });
 
 Note that in the second example, even though the ioredis instance is being reused, the worker will create a duplicated connection that it needs internally to make blocking connections. Please read on the [ioredis](https://github.com/luin/ioredis/blob/master/API.md) documentation on how to properly create an instance of `IORedis.`
 
+{% hint style="danger" %}
 When using ioredis connections, be carefull not to use the "keyPrefix" option in [ioredis](https://luin.github.io/ioredis/interfaces/CommonRedisOptions.html#keyPrefix) as this option is not compatible with BullMQ that provides its own key prefixing mechanism.
+{% endhint %}
 
 If you can afford many connections, by all means just use them. Redis connections have quite low overhead, so you should not need to care about reusing connections unless your service provider is imposing you hard limitations.
 


### PR DESCRIPTION
This PR makes the `keyPrefix` warning message more pronounced, as that can cause incredibly hard to track down issues.

I would also suggest that BullMQ checks if the `keyPrefix` key is set and crashes out if it is, as this is a critical error on the user part, but this PR does not cover that case.