### PR TITLE
Add job.runAt property to expose timestamp that job is supposed to run at

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -89,6 +89,11 @@ export class Job<
   timestamp: number;
 
   /**
+   * Timestamp when the job is expected to run
+   */
+  runAt?: number;
+
+  /**
    * Number of attempts after the job has failed.
    * @defaultValue 0
    */
@@ -168,6 +173,7 @@ export class Job<
     this.repeatJobKey = repeatJobKey;
 
     this.timestamp = opts.timestamp ? opts.timestamp : Date.now();
+    this.runAt = this.timestamp + (this.delay || 0);
 
     this.opts.backoff = Backoffs.normalize(opts.backoff);
 
@@ -286,6 +292,10 @@ export class Job<
 
     job.timestamp = parseInt(json.timestamp);
 
+    if (json.runAt) {
+      job.runAt = parseInt(json.runAt);
+    }
+
     if (json.finishedOn) {
       job.finishedOn = parseInt(json.finishedOn);
     }
@@ -385,6 +395,7 @@ export class Job<
       attemptsMade: this.attemptsMade,
       finishedOn: this.finishedOn,
       processedOn: this.processedOn,
+      runAt: this.runAt,
       timestamp: this.timestamp,
       failedReason: JSON.stringify(this.failedReason),
       stacktrace: JSON.stringify(this.stacktrace),
@@ -729,7 +740,7 @@ export class Job<
    * @returns void
    */
   async changeDelay(delay: number): Promise<void> {
-    await this.scripts.changeDelay(this.id, delay);
+    this.runAt = await this.scripts.changeDelay(this.id, delay);
     this.delay = delay;
   }
 

--- a/src/commands/addJob-8.lua
+++ b/src/commands/addJob-8.lua
@@ -122,13 +122,15 @@ if repeatJobKey ~= nil then
   table.insert(optionalValues, repeatJobKey)
 end
 
-rcall("HMSET", jobIdKey, "name", args[3], "data", ARGV[2], "opts", jsonOpts,
-  "timestamp", timestamp, "delay", delay, "priority", priority, unpack(optionalValues))
-
-rcall("XADD", KEYS[8], "*", "event", "added", "jobId", jobId, "name", args[3])
-
 -- Check if job is delayed
 local delayedTimestamp = (delay > 0 and (timestamp + delay)) or 0
+local runAt = (delayedTimestamp > 0 and delayedTimestamp) or timestamp
+
+rcall("HMSET", jobIdKey, "name", args[3], "data", ARGV[2], "opts", jsonOpts,
+  "timestamp", timestamp, "delay", delay, "runAt", runAt, "priority", priority,
+  unpack(optionalValues))
+
+rcall("XADD", KEYS[8], "*", "event", "added", "jobId", jobId, "name", args[3])
 
 -- Check if job is a parent, if so add to the parents set
 local waitChildrenKey = args[6]

--- a/src/commands/changeDelay-3.lua
+++ b/src/commands/changeDelay-3.lua
@@ -30,7 +30,7 @@ if rcall("EXISTS", KEYS[2]) == 1 then
     return -3
   end
 
-  rcall("HSET", KEYS[2], "delay", tonumber(ARGV[1]))
+  rcall("HMSET", KEYS[2], "delay", tonumber(ARGV[1]), "runAt", delayedTimestamp)
   rcall("ZADD", KEYS[1], score, jobId)
 
   rcall("XADD", KEYS[3], "*", "event", "delayed", "jobId", jobId, "delay", delayedTimestamp);

--- a/src/commands/moveToDelayed-8.lua
+++ b/src/commands/moveToDelayed-8.lua
@@ -56,6 +56,7 @@ if rcall("EXISTS", jobKey) == 1 then
     end
 
     rcall("ZADD", delayedKey, score, jobId)
+    rcall("HSET", jobKey, "runAt", delayedTimestamp)
     rcall("XADD", KEYS[6], "*", "event", "delayed", "jobId", jobId, "delay", delayedTimestamp)
 
     -- Check if we need to push a marker job to wake up sleeping workers.

--- a/src/interfaces/job-json.ts
+++ b/src/interfaces/job-json.ts
@@ -10,6 +10,7 @@ export interface JobJson {
   attemptsMade: number;
   finishedOn?: number;
   processedOn?: number;
+  runAt?: number;
   timestamp: number;
   failedReason: string;
   stacktrace: string;
@@ -29,6 +30,7 @@ export interface JobJsonRaw {
   attemptsMade: string;
   finishedOn?: string;
   processedOn?: string;
+  runAt?: string;
   timestamp: string;
   failedReason: string;
   stacktrace: string[];

--- a/src/interfaces/minimal-job.ts
+++ b/src/interfaces/minimal-job.ts
@@ -68,6 +68,10 @@ export interface MinimalJob<
    */
   timestamp: number;
   /**
+   * Timestamp when the job is expected to run
+   */
+  runAt?: number;
+  /**
    * Number of attempts after the job has failed.
    * @defaultValue 0
    */

--- a/tests/test_job.ts
+++ b/tests/test_job.ts
@@ -43,10 +43,14 @@ describe('Job', function () {
       const storedJob = await Job.fromId(queue, job.id);
       expect(storedJob).to.have.property('id');
       expect(storedJob).to.have.property('data');
+      expect(storedJob).to.have.property('timestamp');
+      expect(storedJob).to.have.property('runAt');
 
       expect(storedJob.data.foo).to.be.equal('bar');
       expect(storedJob.opts).to.be.an('object');
       expect(storedJob.opts.timestamp).to.be.equal(timestamp);
+      expect(storedJob.timestamp).to.be.equal(timestamp);
+      expect(storedJob.runAt).to.be.equal(timestamp);
     });
 
     it('should use the custom jobId if one is provided', async function () {
@@ -709,11 +713,17 @@ describe('Job', function () {
       const isDelayed = await job.isDelayed();
       expect(isDelayed).to.be.equal(true);
 
+      const changeDelayTime = new Date().getTime();
       await job.changeDelay(4000);
 
       const isDelayedAfterChangeDelay = await job.isDelayed();
       expect(isDelayedAfterChangeDelay).to.be.equal(true);
       expect(job.delay).to.be.equal(4000);
+      expect(job.runAt).to.be.gte(changeDelayTime + 4000);
+
+      const storedJob = await Job.fromId(queue, job.id);
+      expect(storedJob.delay).to.be.equal(job.delay);
+      expect(storedJob.runAt).to.be.equal(job.runAt);
 
       await completing;
 


### PR DESCRIPTION
Fixes: #1782

- feat(job): add runAt field to job key in redis
- feat(job): add runAt property to Job
- test(job): extend job tests to check runAt correctness
