### PR TITLE
feat(upstash): don't throw an error when detecting an upstash host

### DIFF
--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -22,8 +22,6 @@ const deprecationMessage = [
   'On the next versions having this settings will throw an exception',
 ].join(' ');
 
-const upstashMessage = 'BullMQ: Upstash is not compatible with BullMQ.';
-
 export interface RawCommand {
   content: string;
   name: string;
@@ -68,8 +66,6 @@ export class RedisConnection extends EventEmitter {
       if (this.blocking) {
         this.opts.maxRetriesPerRequest = null;
       }
-
-      this.checkUpstashHost(this.opts.host);
     } else {
       this._client = opts;
 
@@ -87,11 +83,8 @@ export class RedisConnection extends EventEmitter {
           (node: { host: string } | string) =>
             typeof node == 'string' ? node : node.host,
         );
-        this.checkUpstashHost(hosts);
       } else {
         this.opts = this._client.options;
-
-        this.checkUpstashHost(this.opts.host);
       }
 
       this.checkBlockingOptions(deprecationMessage, this.opts);
@@ -116,15 +109,6 @@ export class RedisConnection extends EventEmitter {
   private checkBlockingOptions(msg: string, options?: RedisOptions) {
     if (this.blocking && options && options.maxRetriesPerRequest) {
       console.error(msg);
-    }
-  }
-
-  private checkUpstashHost(host: string[] | string | undefined) {
-    const includesUpstash = Array.isArray(host)
-      ? host.some(node => node.includes('upstash.io'))
-      : host?.includes('upstash.io');
-    if (includesUpstash) {
-      throw new Error(upstashMessage);
     }
   }
 

--- a/tests/test_connection.ts
+++ b/tests/test_connection.ts
@@ -109,54 +109,6 @@ describe('connection', () => {
     });
   });
 
-  describe('when host belongs to Upstash', async () => {
-    it('throws an error', async () => {
-      const opts = {
-        connection: {
-          host: 'https://upstash.io',
-        },
-      };
-
-      expect(() => new QueueBase(queueName, opts)).to.throw(
-        'BullMQ: Upstash is not compatible with BullMQ.',
-      );
-    });
-
-    describe('when using Cluster instance', async () => {
-      it('throws an error', async () => {
-        const connection = new IORedis.Cluster(
-          [
-            {
-              host: 'https://upstash.io',
-            },
-          ],
-          { natMap: {} },
-        );
-
-        expect(() => new QueueBase(queueName, { connection })).to.throw(
-          'BullMQ: Upstash is not compatible with BullMQ.',
-        );
-        await connection.disconnect();
-      });
-
-      describe('when using nodes provides an array of strings as hosts', async () => {
-        it('throws an error', async () => {
-          const connection = new IORedis.Cluster(
-            ['localhost', 'https://upstash.io'],
-            {
-              natMap: {},
-            },
-          );
-
-          expect(() => new QueueBase(queueName, { connection })).to.throw(
-            'BullMQ: Upstash is not compatible with BullMQ.',
-          );
-          await connection.disconnect();
-        });
-      });
-    });
-  });
-
   it('should recover from a connection loss', async () => {
     let processor;
 


### PR DESCRIPTION
Upstash is currently rolling out redis streams to all remaining regions and will be compatible with bullmq.
This draft is just a preparation for when the time comes.

Please let me know if you're happy with these changes.