### PR TITLE
fix(scripts): Type Hinting wit Union type instead of | operator

### DIFF
--- a/python/bullmq/scripts.py
+++ b/python/bullmq/scripts.py
@@ -126,7 +126,7 @@ class Scripts:
     def moveToFailed(self, job: Job, failedReason: str, removeOnFailed, token: str, opts: dict, fetchNext = True):
         return self.moveToFinished(job, failedReason, "failedReason", removeOnFailed, "failed", token, opts, fetchNext)
 
-    async def moveToFinished(self, job: Job, val: Any, propVal: str, shouldRemove, target, token: str, opts: dict, fetchNext = True ) -> list[Any] | None:
+    async def moveToFinished(self, job: Job, val: Any, propVal: str, shouldRemove, target, token: str, opts: dict, fetchNext = True ) -> Union[list[Any],None]:
         timestamp = round(time.time() * 1000)
         metricsKey = self.toKey('metrics:' + target);
 
@@ -210,7 +210,7 @@ def finishedErrors(code: int, jobId: str, command: str, state: str) -> TypeError
     else:
         return TypeError("Unknown code " + str(code) + " error for " + jobId + "." + command)
 
-def raw2NextJobData(raw: list[Any]) -> list[Any] | None:
+def raw2NextJobData(raw: list[Any]) -> Union[list[Any],None]:
     if raw:
         # TODO: return all the raw datas (up to 4)
         if raw[0]:


### PR DESCRIPTION
It returns the below message when I run it locally:
`TypeError: unsupported operand type(s) for |: 'types.GenericAlias' and 'NoneType'`

After checking serval possibilities, it would be nice if we could refactor part of type hints.

thanks!