### PR TITLE
refactor(python): replace string concatenation with string formatting

### DIFF
--- a/python/bullmq/queue.py
+++ b/python/bullmq/queue.py
@@ -49,7 +49,7 @@ class Queue:
         return self.scripts.pause(False)
 
     async def isPaused(self):
-        pausedKeyExists = await self.client.hexists(self.opts.get("prefix") or "bull" + ":" + self.name + ":meta", "paused")
+        pausedKeyExists = await self.client.hexists(self.opts.get("prefix") or f"bull:{self.name}:meta", "paused")
         return pausedKeyExists == 1
 
     """
@@ -80,7 +80,7 @@ class Queue:
         Trim the event stream to an approximately maxLength.
     """
     def trimEvents(self, maxLength: int):
-        return self.client.xtrim(self.opts.get("prefix") or "bull" + ":" + self.name + ":events", "MAXLEN", "~", maxLength)
+        return self.client.xtrim(self.opts.get("prefix") or f"bull:{self.name}:events", "MAXLEN", "~", maxLength)
 
     """
         Closes the queue and the underlying connection to Redis.
@@ -90,7 +90,7 @@ class Queue:
         return self.redisConnection.close()
 
 async def fromId(queue: Queue, jobId: str):
-    key = queue.prefix + ":" + queue.name + ":" + jobId
+    key = f"{queue.prefix}:{queue.name}:{jobId}"
     rawData = await queue.client.hgetall(key)
     return Job.fromJSON(queue.client, rawData, jobId)
 

--- a/python/bullmq/scripts.py
+++ b/python/bullmq/scripts.py
@@ -39,11 +39,11 @@ class Scripts:
             self.keys[name] = self.toKey(name)
     
     def toKey(self, name):
-        return self.prefix + ":" + self.queueName + ":" + name
+        return f"{self.prefix}:{self.queueName}:{name}"
 
     def getScript(self, name):
         "Get a script by name"
-        file = open(basePath + "/commands/" + name, "r")
+        file = open(f"{basePath}/commands/{name}", "r")
         data = file.read()
         file.close()
         return data
@@ -196,19 +196,19 @@ class Scripts:
 
 def finishedErrors(code: int, jobId: str, command: str, state: str) -> TypeError:
     if code == ErrorCode.JobNotExist.value:
-        return TypeError("Missing key for job " + jobId + "." + command)
+        return TypeError(f"Missing key for job {jobId}.{command}")
     elif code == ErrorCode.JobLockNotExist.value:
-        return TypeError("Missing lock for job " + jobId + "." + command)
+        return TypeError(f"Missing lock for job {jobId}.{command}")
     elif code == ErrorCode.JobNotInState.value:
-        return TypeError("Job " + jobId + " is not in the state" + state + "." + command)
+        return TypeError(f"Job {jobId} is not in the state {state}.{command}")
     elif code == ErrorCode.JobPendingDependencies.value:
-        return TypeError("Job " + jobId + " has pending dependencies. " + command)
+        return TypeError(f"Job {jobId} has pending dependencies.{command}")
     elif code == ErrorCode.ParentJobNotExist.value:
-        return TypeError("Missing key for parent job " + jobId + "." + command)
+        return TypeError(f"Missing key for parent job {jobId}.{command}")
     elif code == ErrorCode.JobLockMismatch.value:
-        return TypeError("Lock mismatch for job " + jobId + ". Cmd "+ command + " from " + state)
+        return TypeError(f"Lock mismatch for job {jobId}. Cmd {command} from {state}")
     else:
-        return TypeError("Unknown code " + str(code) + " error for " + jobId + "." + command)
+        return TypeError(f"Unknown code {str(code)} error for {jobId}.{command}")
 
 def raw2NextJobData(raw: list[Any]) -> list[Any] | None:
     if raw:


### PR DESCRIPTION
## Changelog

This PR replaces the all string concatenation in the python folder with string formatting with the `f""` literal.

They were introduced in [python 3.6](https://peps.python.org/pep-0498/) so there shouldn't be any compatibility issue with oldest interpreters.

Also, formatted string have been seen to perform better than string concatenation, and they are also more easily to read. 