### PR TITLE
fix(python scripts): fix typing on array2obj function

### DIFF
--- a/python/bullmq/scripts.py
+++ b/python/bullmq/scripts.py
@@ -219,7 +219,7 @@ def raw2NextJobData(raw: list[Any]) -> list[Any] | None:
             return (None, raw[1])
     return None
 
-def array2obj(arr: [str]) -> {str: str}:
+def array2obj(arr: list[str]) -> dict[str, str]:
     obj = {}
     for i in range(0, len(arr), 2):
         obj[arr[i]] = arr[i + 1]


### PR DESCRIPTION
## Changelog

This PR fixes two wrong types in the `Scripts.array2obj` method.

The previous version raised two errors, the first with the `arr` parameter with the following:

```
List expression not allowed in type annotation
  Use List[T] to indicate a list type or Union[T1, T2] to indicate a union type
```

And the second on the return type `{str: str}` failing with the following:

```
Dictionary expression not allowed in type annotation
  Use Dict[T1, T2] to indicate a dictionary type
```

The `List` and `Dict` types are deprecated since version [3.9](https://peps.python.org/pep-0585/), so I used `list` and `dict` as the rest of codebase