### PR TITLE
chore(python job): add JobOptions

### DIFF
--- a/python/bullmq/job.py
+++ b/python/bullmq/job.py
@@ -13,7 +13,7 @@ optsDecodeMap = {
 optsEncodeMap = {v: k for k, v in optsDecodeMap.items()}
 
 
-class KeepJosb(TypedDict, total=False):
+class KeepJobs(TypedDict, total=False):
     """
     Specify which jobs to keep after finishing. If both age and count are
     specified, then the jobs kept will be the ones that satisfies both
@@ -65,7 +65,7 @@ class JobOptions(TypedDict, total=False):
     @defaultValue 0
     """
 
-    removeOnComplete: bool | int | KeepJosb
+    removeOnComplete: bool | int | KeepJobs
     """
     If true, removes the job when it successfully completes
     When given a number, it specifies the maximum amount of
@@ -74,7 +74,7 @@ class JobOptions(TypedDict, total=False):
     Default behavior is to keep the job in the completed set.
     """
 
-    removeOnFail: bool | int | KeepJosb
+    removeOnFail: bool | int | KeepJobs
     """
     If true, removes the job when it fails after all attempts.
     When given a number, it specifies the maximum amount of

--- a/python/bullmq/job.py
+++ b/python/bullmq/job.py
@@ -1,9 +1,9 @@
-from typing import Any
+from redis import Redis
+from typing import List, Any, TypedDict, Literal
+
 import json
 import time
 
-from redis import Redis
-from typing import Dict, List, Union, Any
 
 optsDecodeMap = {
     'fpof': 'failParentOnFailure',
@@ -11,6 +11,77 @@ optsDecodeMap = {
 }
 
 optsEncodeMap = {v: k for k, v in optsDecodeMap.items()}
+
+
+class KeepJosb(TypedDict, total=False):
+    """
+    Specify which jobs to keep after finishing. If both age and count are
+    specified, then the jobs kept will be the ones that satisfies both
+    properties.
+    """
+
+    age: int
+    """
+    Maximum age in seconds for job to be kept.
+    """
+
+    count: int
+    """
+    Maximum count of jobs to be kept.
+    """
+
+
+class JobOptions(TypedDict, total=False):
+    jobId: str
+    """
+    Override the job ID - by default, the job ID is a unique
+    integer, but you can use this setting to override it.
+    
+    If you use this option, it is up to you to ensure the
+    jobId is unique. If you attempt to add a job with an id that
+    already exists, it will not be added.
+    """
+
+    timestamp: int
+    """
+    Timestamp when the job was created.
+
+    @defaultValue round(time.time() * 1000)
+    """
+
+    delay: int
+    """
+    An amount of milliseconds to wait until this job can be processed.
+    Note that for accurate delays, worker and producers
+    should have their clocks synchronized.
+
+    @defaultValue 0
+    """
+
+    attempts: int
+    """
+    The total number of attempts to try the job until it completes.
+    
+    @defaultValue 0
+    """
+
+    removeOnComplete: bool | int | KeepJosb
+    """
+    If true, removes the job when it successfully completes
+    When given a number, it specifies the maximum amount of
+    jobs to keep, or you can provide an object specifying max
+    age and/or count to keep. It overrides whatever setting is used in the worker.
+    Default behavior is to keep the job in the completed set.
+    """
+
+    removeOnFail: bool | int | KeepJosb
+    """
+    If true, removes the job when it fails after all attempts.
+    When given a number, it specifies the maximum amount of
+    jobs to keep, or you can provide an object specifying max
+    age and/or count to keep. It overrides whatever setting is used in the worker.
+    Default behavior is to keep the job in the failed set.
+    """
 
 
 class Job:
@@ -21,7 +92,7 @@ class Job:
     A Job instance is also passed to the Worker's process function.
     """
 
-    def __init__(self, client: Redis, name: str, data: Any, opts: dict = {}):
+    def __init__(self, client: Redis, name: str, data: Any, opts: JobOptions = {}):
         self.name = name
         self.id = opts.get("jobId", None)
         self.progress = 0

--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -11,7 +11,7 @@ import traceback
 import time
 
 
-class WorkerOptions(TypedDict):
+class WorkerOptions(TypedDict, total=False):
     autorun: bool
     """
     Condition to start processor at instance creation


### PR DESCRIPTION
## Changelog

This PR follows #1795, adding the typed dict `JobOptions` class for the python class `Job`.

In the previous, I forgot to add `total=False` to the `WorkerOptions` class, so I added it here. Sorry!

## Notes

Please tell me if it is better to move these typed dict classes in a subfolder like `types` or something, since these types will grown once the python library will add more things to match the node version