### PR TITLE
chore(python queue): add JobOptions to add method

### DIFF
--- a/python/bullmq/queue.py
+++ b/python/bullmq/queue.py
@@ -1,5 +1,5 @@
 from bullmq.scripts import Scripts
-from bullmq.job import Job
+from bullmq.job import Job, JobOptions
 from bullmq.redis_connection import RedisConnection
 from typing import TypedDict
 
@@ -39,7 +39,7 @@ class Queue:
         self.prefix = opts.get("prefix", "bull")
         self.scripts = Scripts(self.prefix, name, self.redisConnection.conn)
 
-    async def add(self, name: str, data, opts: dict = {}):
+    async def add(self, name: str, data, opts: JobOptions = {}):
         """
         Adds a new job to the queue.
 


### PR DESCRIPTION
## Changelog

This PR follows #1797 and #1796, adding the typed dict class `JobOptions` to the `add` method of the `Queue` class