### PR TITLE
Turning into an "always waiting" worker

### DIFF
--- a/python/bullmq/job.py
+++ b/python/bullmq/job.py
@@ -166,16 +166,16 @@ def optsFromJSON(rawOpts):
     # opts = json.loads(rawOpts)
     opts = rawOpts
 
-    optionEntries = opts.items()
+    option_entries = opts.items()
 
     options = {}
-    for item in optionEntries:
-        attributeName = item[0]
+    for item in option_entries:
+        attribute_name = item[0]
         value = item[1]
-        if attributeName in optsDecodeMap:
-            options[optsDecodeMap[attributeName]] = value
+        if attribute_name in optsDecodeMap:
+            options[optsDecodeMap[attribute_name]] = value
         else:
-            options[attributeName] = value
+            options[attribute_name] = value
 
     return options
 

--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -118,7 +118,7 @@ class Worker(EventEmitter):
                 job, pending = await getFirstCompleted(self.processing)
                 self.processing = pending
 
-                if job == None or len(self.processing) == 0 and self.closing:
+                if (job == None or len(self.processing) == 0) and self.closing:
                     # We are done processing so we can close the queue
                     break
 


### PR DESCRIPTION
The current implementation is always halting the Worker loop right after the first processed message. It is happening bc this small Python or/and precedence issue. After the fix, the Worker will keep processing messages till it's explicitly closed.