### PR TITLE
fix(worker-close): prevent setting timers after close() has been called

### DIFF
--- a/tests/test_worker.ts
+++ b/tests/test_worker.ts
@@ -110,6 +110,18 @@ describe('workers', function () {
       expect(count.active).to.be.eq(0);
       expect(count.completed).to.be.eq(1);
     });
+
+    it('do not open any timers after worker is closed', async () => {
+      const w = new Worker('test', async () => 'ok');
+      await w.close();
+      await delay(1000);
+
+      const stallCheckTimer = (w as any).stalledCheckTimer;
+      const retryTimer = (w as any).extendLocksTimer;
+
+      expect(stallCheckTimer).to.be.null;
+      expect(retryTimer).to.be.null;
+    });
   });
 
   describe('when sharing connection', () => {


### PR DESCRIPTION
This pull request should fix the following race condition: If `close()` is called very shortly after a Worker is created, its timers are not initialized yet, so `close()` thinks it does not need to close any timer. However, the timers will then be initialized **after** `close()`, leaking the timers and preventing a clean process exit. This issue is particularly relevant in test code that might spawn and close workers very quickly.

---

Regarding `startStalledCheckTimer`: Here we even do an async call to `runStalledJobsCheck` before setting the new timer, and in the meantime `close()` may be called. This could lead to the same problem even in a fully initialized worker (you'd have to be unlucky enough to call `close()` while the stalled jobs check is running)