### PR TITLE
chore(python): replace is operator

### DIFF
--- a/python/bullmq/scripts.py
+++ b/python/bullmq/scripts.py
@@ -149,16 +149,16 @@ class Scripts:
         keys.append(metricsKey)
 
         def getKeepJobs(shouldRemove: bool | dict | int | None):
-            if shouldRemove is True:
-                return {"count": 0}
-
             if type(shouldRemove) == int:
                 return {"count": shouldRemove}
 
             if type(shouldRemove) == dict:
                 return shouldRemove
 
-            if shouldRemove is False or shouldRemove is None:
+            if shouldRemove:
+                return {"count": 0}
+
+            if not shouldRemove or shouldRemove is None:
                 return {"count": -1}
 
         def getMetricsSize(opts: dict):


### PR DESCRIPTION
## Changelog

Please, in Python you should not compare `True` and `False` with the `is` operator. 

You can find recomendations for this in the [PEP 8](https://peps.python.org/pep-0008/#programming-recommendations).

> Don’t compare boolean values to True or False using ==:
> 
> Correct:
> ```py
> if greeting:
> ```
> 
> Wrong:
> ```py
> if greeting == True:
> ```
> Worse:
> ```py
> if greeting is True:
> ```

