### PR TITLE
docs: fix type error in scheduled job example code

### DIFF
--- a/docs/gitbook/guide/jobs/delayed.md
+++ b/docs/gitbook/guide/jobs/delayed.md
@@ -21,7 +21,7 @@ If you want to process the job after a specific point in time, just add the time
 
 ```typescript
 const targetTime = new Date("03-07-2035 10:30");
-const delay = targetTime - new Date();
+const delay = (Number(targetTime) - Number(new Date()));
 
 await myQueue.add('house', { color: 'white' }, { delay });
 ```

--- a/docs/gitbook/guide/jobs/delayed.md
+++ b/docs/gitbook/guide/jobs/delayed.md
@@ -21,7 +21,7 @@ If you want to process the job after a specific point in time, just add the time
 
 ```typescript
 const targetTime = new Date("03-07-2035 10:30");
-const delay = (Number(targetTime) - Number(new Date()));
+const delay = Number(targetTime) - Number(new Date());
 
 await myQueue.add('house', { color: 'white' }, { delay });
 ```


### PR DESCRIPTION
Related: #1815

Fixed type issue in scheduled job example code (works in JS due to coercion, but not TS with sufficiently strict config).