### PR TITLE
chore(python): move types into a subfolder

### DIFF
--- a/python/bullmq/job.py
+++ b/python/bullmq/job.py
@@ -1,5 +1,6 @@
 from redis import Redis
-from typing import List, Any, TypedDict
+from typing import List, Any
+from bullmq.types import JobOptions
 
 import json
 import time
@@ -11,77 +12,6 @@ optsDecodeMap = {
 }
 
 optsEncodeMap = {v: k for k, v in optsDecodeMap.items()}
-
-
-class KeepJobs(TypedDict, total=False):
-    """
-    Specify which jobs to keep after finishing. If both age and count are
-    specified, then the jobs kept will be the ones that satisfies both
-    properties.
-    """
-
-    age: int
-    """
-    Maximum age in seconds for job to be kept.
-    """
-
-    count: int
-    """
-    Maximum count of jobs to be kept.
-    """
-
-
-class JobOptions(TypedDict, total=False):
-    jobId: str
-    """
-    Override the job ID - by default, the job ID is a unique
-    integer, but you can use this setting to override it.
-
-    If you use this option, it is up to you to ensure the
-    jobId is unique. If you attempt to add a job with an id that
-    already exists, it will not be added.
-    """
-
-    timestamp: int
-    """
-    Timestamp when the job was created.
-
-    @defaultValue round(time.time() * 1000)
-    """
-
-    delay: int
-    """
-    An amount of milliseconds to wait until this job can be processed.
-    Note that for accurate delays, worker and producers
-    should have their clocks synchronized.
-
-    @defaultValue 0
-    """
-
-    attempts: int
-    """
-    The total number of attempts to try the job until it completes.
-
-    @defaultValue 0
-    """
-
-    removeOnComplete: bool | int | KeepJobs
-    """
-    If true, removes the job when it successfully completes
-    When given a number, it specifies the maximum amount of
-    jobs to keep, or you can provide an object specifying max
-    age and/or count to keep. It overrides whatever setting is used in the worker.
-    Default behavior is to keep the job in the completed set.
-    """
-
-    removeOnFail: bool | int | KeepJobs
-    """
-    If true, removes the job when it fails after all attempts.
-    When given a number, it specifies the maximum amount of
-    jobs to keep, or you can provide an object specifying max
-    age and/or count to keep. It overrides whatever setting is used in the worker.
-    Default behavior is to keep the job in the failed set.
-    """
 
 
 class Job:

--- a/python/bullmq/queue.py
+++ b/python/bullmq/queue.py
@@ -1,24 +1,7 @@
 from bullmq.scripts import Scripts
 from bullmq.job import Job, JobOptions
 from bullmq.redis_connection import RedisConnection
-from typing import TypedDict
-
-
-class RetryJobsOpts(TypedDict):
-    state: str
-    count: int
-    timestamp: int
-
-
-class QueueOptions(TypedDict, total=False):
-    """
-    Options for the Queue class.
-    """
-
-    prefix: str
-    """
-    Prefix for all queue keys.
-    """
+from bullmq.types import QueueOptions, RetryJobsOptions
 
 
 class Queue:
@@ -98,7 +81,7 @@ class Queue:
             if cursor is None or cursor == 0 or cursor == "0":
                 break
 
-    async def retryJobs(self, opts: RetryJobsOpts = {}):
+    async def retryJobs(self, opts: RetryJobsOptions = {}):
         """
         Retry all the failed jobs.
         """
@@ -137,7 +120,7 @@ class Queue:
     def sanitizeJobTypes(self, types):
         current_types = list(types)
 
-        if len(types) > 0 :
+        if len(types) > 0:
             sanitized_types = current_types.copy()
 
             try:

--- a/python/bullmq/scripts.py
+++ b/python/bullmq/scripts.py
@@ -86,7 +86,8 @@ class Scripts:
 
     def getCounts(self, types):
         keys = self.getKeys([''])
-        transformed_types = list(map(lambda type: 'wait' if type == 'waiting' else type, types))
+        transformed_types = list(
+            map(lambda type: 'wait' if type == 'waiting' else type, types))
 
         return self.commands["getCounts"](keys=keys, args=transformed_types)
 
@@ -117,7 +118,8 @@ class Scripts:
         Remove a queue completely
         """
         current_state = state or 'failed'
-        keys = self.getKeys(['', 'events', current_state, 'wait', 'paused', 'meta'])
+        keys = self.getKeys(
+            ['', 'events', current_state, 'wait', 'paused', 'meta'])
         result = await self.commands["retryJobs"](keys=keys, args=[count or 1000, timestamp or round(time.time()*1000), current_state])
         return result
 

--- a/python/bullmq/types/__init__.py
+++ b/python/bullmq/types/__init__.py
@@ -1,0 +1,6 @@
+
+from bullmq.types.keep_jobs import KeepJobs
+from bullmq.types.job_options import JobOptions
+from bullmq.types.queue_options import QueueOptions
+from bullmq.types.worker_options import WorkerOptions
+from bullmq.types.retry_job_options import RetryJobsOptions

--- a/python/bullmq/types/job_options.py
+++ b/python/bullmq/types/job_options.py
@@ -1,0 +1,55 @@
+from typing import TypedDict
+from bullmq.types import KeepJobs
+
+
+class JobOptions(TypedDict, total=False):
+    jobId: str
+    """
+    Override the job ID - by default, the job ID is a unique
+    integer, but you can use this setting to override it.
+
+    If you use this option, it is up to you to ensure the
+    jobId is unique. If you attempt to add a job with an id that
+    already exists, it will not be added.
+    """
+
+    timestamp: int
+    """
+    Timestamp when the job was created.
+
+    @defaultValue round(time.time() * 1000)
+    """
+
+    delay: int
+    """
+    An amount of milliseconds to wait until this job can be processed.
+    Note that for accurate delays, worker and producers
+    should have their clocks synchronized.
+
+    @defaultValue 0
+    """
+
+    attempts: int
+    """
+    The total number of attempts to try the job until it completes.
+
+    @defaultValue 0
+    """
+
+    removeOnComplete: bool | int | KeepJobs
+    """
+    If true, removes the job when it successfully completes
+    When given a number, it specifies the maximum amount of
+    jobs to keep, or you can provide an object specifying max
+    age and/or count to keep. It overrides whatever setting is used in the worker.
+    Default behavior is to keep the job in the completed set.
+    """
+
+    removeOnFail: bool | int | KeepJobs
+    """
+    If true, removes the job when it fails after all attempts.
+    When given a number, it specifies the maximum amount of
+    jobs to keep, or you can provide an object specifying max
+    age and/or count to keep. It overrides whatever setting is used in the worker.
+    Default behavior is to keep the job in the failed set.
+    """

--- a/python/bullmq/types/keep_jobs.py
+++ b/python/bullmq/types/keep_jobs.py
@@ -1,0 +1,19 @@
+from typing import TypedDict
+
+
+class KeepJobs(TypedDict, total=False):
+    """
+    Specify which jobs to keep after finishing. If both age and count are
+    specified, then the jobs kept will be the ones that satisfies both
+    properties.
+    """
+
+    age: int
+    """
+    Maximum age in seconds for job to be kept.
+    """
+
+    count: int
+    """
+    Maximum count of jobs to be kept.
+    """

--- a/python/bullmq/types/queue_options.py
+++ b/python/bullmq/types/queue_options.py
@@ -1,0 +1,13 @@
+
+from typing import TypedDict
+
+
+class QueueOptions(TypedDict, total=False):
+    """
+    Options for the Queue class.
+    """
+
+    prefix: str
+    """
+    Prefix for all queue keys.
+    """

--- a/python/bullmq/types/retry_job_options.py
+++ b/python/bullmq/types/retry_job_options.py
@@ -1,0 +1,8 @@
+
+from typing import TypedDict
+
+
+class RetryJobsOptions(TypedDict, total=False):
+    state: str
+    count: int
+    timestamp: int

--- a/python/bullmq/types/worker_options.py
+++ b/python/bullmq/types/worker_options.py
@@ -1,0 +1,56 @@
+
+from typing import TypedDict, Any
+
+
+class WorkerOptions(TypedDict, total=False):
+    autorun: bool
+    """
+    Condition to start processor at instance creation
+
+    @default true
+    """
+
+    concurrency: int
+    """
+    Amount of jobs that a single worker is allowed to work on
+    in parallel.
+
+    @default 1
+    @see https://docs.bullmq.io/guide/workers/concurrency
+    """
+
+    maxStalledCount: int
+    """
+    Amount of times a job can be recovered from a stalled state
+    to the `wait` state. If this is exceeded, the job is moved
+    to `failed`.
+
+    @default 1
+    """
+
+    stalledInterval: int
+    """
+    Number of milliseconds between stallness checks.
+
+    @default 30000
+    """
+
+    lockDuration: int
+    """
+    Duration of the lock for the job in milliseconds. The lock represents that
+    a worker is processing the job. If the lock is lost, the job will be eventually
+    be picked up by the stalled checker and move back to wait so that another worker
+    can process it again.
+
+    @default 30000
+    """
+
+    prefix: str
+    """
+    Prefix for all queue keys.
+    """
+
+    connection: dict[str, Any]
+    """
+    Options for connecting to a Redis instance.
+    """

--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -1,68 +1,15 @@
-from typing import Callable, TypedDict, Any, List
+from typing import Callable
 from uuid import uuid4
 from bullmq.scripts import Scripts
 from bullmq.redis_connection import RedisConnection
 from bullmq.event_emitter import EventEmitter
 from bullmq.job import Job
 from bullmq.timer import Timer
+from bullmq.types import WorkerOptions
 
 import asyncio
 import traceback
 import time
-
-
-class WorkerOptions(TypedDict, total=False):
-    autorun: bool
-    """
-    Condition to start processor at instance creation
-
-    @default true
-    """
-
-    concurrency: int
-    """
-    Amount of jobs that a single worker is allowed to work on
-    in parallel.
-
-    @default 1
-    @see https://docs.bullmq.io/guide/workers/concurrency
-    """
-
-    maxStalledCount: int
-    """
-    Amount of times a job can be recovered from a stalled state
-    to the `wait` state. If this is exceeded, the job is moved
-    to `failed`.
-
-    @default 1
-    """
-
-    stalledInterval: int
-    """
-    Number of milliseconds between stallness checks.
-
-    @default 30000
-    """
-
-    lockDuration: int
-    """
-    Duration of the lock for the job in milliseconds. The lock represents that
-    a worker is processing the job. If the lock is lost, the job will be eventually
-    be picked up by the stalled checker and move back to wait so that another worker
-    can process it again.
-
-    @default 30000
-    """
-
-    prefix: str
-    """
-    Prefix for all queue keys.
-    """
-
-    connection: dict[str, Any]
-    """
-    Options for connecting to a Redis instance.
-    """
 
 
 class Worker(EventEmitter):


### PR DESCRIPTION
## Changelog

This PR moves the first types we introduced into a subfolder called `types`.

## Notes

I used the name `types` and not `typing` since python already has a builtin library called `typing`.

Sure, we could just do `bullmq.typing`, I don't have any strong opinion about this, feel free to tell me if you think another name will be better.