### PR TITLE
feat(python): accept redis options as string

### DIFF
--- a/python/bullmq/queue.py
+++ b/python/bullmq/queue.py
@@ -26,7 +26,7 @@ class Queue:
     Instantiate a Queue object
     """
 
-    def __init__(self, name: str, redisOpts: dict = {}, opts: QueueOptions = {}):
+    def __init__(self, name: str, redisOpts: dict | str = {}, opts: QueueOptions = {}):
         """
         Initialize a connection
         """

--- a/python/bullmq/redis_connection.py
+++ b/python/bullmq/redis_connection.py
@@ -6,14 +6,17 @@ class RedisConnection:
     RedisConnection class
     """
 
-    def __init__(self, redisOpts: dict = {}):
-        host = redisOpts.get("host") or "localhost"
-        port = redisOpts.get("port") or 6379
-        db = redisOpts.get("db") or 0
-        password = redisOpts.get("password") or None
+    def __init__(self, redisOpts: dict | str = {}):
+        if isinstance(redisOpts, dict):
+            host = redisOpts.get("host") or "localhost"
+            port = redisOpts.get("port") or 6379
+            db = redisOpts.get("db") or 0
+            password = redisOpts.get("password") or None
 
-        self.conn = redis.Redis(
-            host=host, port=port, db=db, password=password, decode_responses=True)
+            self.conn = redis.Redis(
+                host=host, port=port, db=db, password=password, decode_responses=True)
+        else:
+            self.conn = redis.from_url(redisOpts, decode_responses=True)
 
     def disconnect(self):
         """

--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -59,7 +59,7 @@ class WorkerOptions(TypedDict, total=False):
     Prefix for all queue keys.
     """
 
-    connection: dict[str, Any]
+    connection: dict[str, Any] | str
     """
     Options for connecting to a Redis instance.
     """


### PR DESCRIPTION
Like `BullMQ` for typescript, we can pass the connection options of the Redis as string.

- [Reference for redis.from_url](https://redis-py.readthedocs.io/en/stable/connections.html#redis.Redis.from_url)
