### PR TITLE
fix(worker): use named import

### DIFF
--- a/src/classes/child.ts
+++ b/src/classes/child.ts
@@ -2,7 +2,7 @@ import { ChildProcess, fork } from 'child_process';
 import { Worker } from 'worker_threads';
 import { AddressInfo, createServer } from 'net';
 import { ChildCommand, ParentCommand } from '../';
-import * as EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 /**
  * @see https://nodejs.org/api/process.html#process_exit_codes


### PR DESCRIPTION
As of the [3.13.2](https://github.com/taskforcesh/bullmq/releases/tag/v3.13.2), this library no longer builds when using `@types/node` version >= `13.6` due to removed support for importing `EventEmitter` via default export.

See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41353#issuecomment-579381008 for more details

This PR fixes this by importing via named export instead of default export.