### PR TITLE
test(job): do not save stacktrace when job key is missing

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -192,7 +192,7 @@ export class Worker<
 
   constructor(
     name: string,
-    processor?: string | Processor<DataType, ResultType, NameType>,
+    processor?: string | null | Processor<DataType, ResultType, NameType>,
     opts: WorkerOptions = {},
     Connection?: typeof RedisConnection,
   ) {

--- a/tests/test_repeat.ts
+++ b/tests/test_repeat.ts
@@ -931,7 +931,7 @@ describe('repeat', function () {
     );
     const delayStub = sinon.stub(worker, 'delay').callsFake(async () => {});
 
-    let counter = 10;
+    let counter = 25;
     let prev: Job;
     const completing = new Promise<void>((resolve, reject) => {
       worker.on('completed', async job => {


### PR DESCRIPTION
ref https://github.com/taskforcesh/bullmq/issues/1914