### PR TITLE
Fix 'install_requires' to include semver

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email='manast@taskforce.sh',
     license='MIT',
     packages=['bullmq'],
-    package_data={'bullmq': ['commands/*.lua']},
+    package_data={'bullmq': ['commands/*.lua', 'types/*']},
     install_requires=['redis',
                       'msgpack',            
                       ],

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,9 +20,11 @@ setup(
     license='MIT',
     packages=['bullmq'],
     package_data={'bullmq': ['commands/*.lua', 'types/*']},
-    install_requires=['redis',
-                      'msgpack',            
-                      ],
+    install_requires=[
+        'redis',
+        'msgpack',
+        'semver',
+    ],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
When installing version 4.0.1 on freshly configured python virtual environment, and when attempting to import bullmq module, I've noticed error message:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mtodoric/dev-in-progress/fapi_esalertmanager/esam_test/lib/python3.10/site-packages/bullmq/__init__.py", line 10, in <module>
    from bullmq.queue import Queue
  File "/home/mtodoric/dev-in-progress/fapi_esalertmanager/esam_test/lib/python3.10/site-packages/bullmq/queue.py", line 3, in <module>
    from bullmq.scripts import Scripts
  File "/home/mtodoric/dev-in-progress/fapi_esalertmanager/esam_test/lib/python3.10/site-packages/bullmq/scripts.py", line 9, in <module>
    from bullmq.utils import isRedisVersionLowerThan
  File "/home/mtodoric/dev-in-progress/fapi_esalertmanager/esam_test/lib/python3.10/site-packages/bullmq/utils.py", line 1, in <module>
    import semver
ModuleNotFoundError: No module named 'semver'
```

This PR should include semver as dependeny and fix this issue.
requirements.txt already seems to be updated.