### PR TITLE
fix: type of queueEvents for waitUntilFinished

### DIFF
--- a/.madgerc
+++ b/.madgerc
@@ -1,0 +1,7 @@
+{
+  "detectiveOptions": {
+    "ts": {
+      "skipTypeImports": true
+    }
+  }
+}

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -33,6 +33,7 @@ import {
 import { Backoffs } from './backoffs';
 import { Scripts } from './scripts';
 import { UnrecoverableError } from './unrecoverable-error';
+import { QueueEvents } from "@src/classes/queue-events";
 
 const logger = debuglog('bull');
 
@@ -917,7 +918,7 @@ export class Job<
    * @param ttl - Time in milliseconds to wait for job to finish before timing out.
    */
   async waitUntilFinished(
-    queueEvents: MinimalQueue,
+    queueEvents: QueueEvents,
     ttl?: number,
   ): Promise<ReturnType> {
     await this.queue.waitUntilReady();

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -33,7 +33,7 @@ import {
 import { Backoffs } from './backoffs';
 import { Scripts } from './scripts';
 import { UnrecoverableError } from './unrecoverable-error';
-import { QueueEvents } from "@src/classes/queue-events";
+import type { QueueEvents } from '@src/classes/queue-events';
 
 const logger = debuglog('bull');
 


### PR DESCRIPTION
We were debugging this for around 3 days, for us to find out that `Queue`, which extends `MinimalQueue`, does not work and only `QueueEvents` does. 

You can also refer to your documentation: https://github.com/taskforcesh/bullmq/blob/master/docs/gitbook/api/bullmq.job.waituntilfinished.md