### PR TITLE
fix(job): use MinimalQueueEvents in waitUntilFinished method

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -21,6 +21,7 @@ import {
   JobJsonSandbox,
   MinimalQueue,
   RedisJobOptions,
+  MinimalQueueEvents,
 } from '../types';
 import {
   errorObject,
@@ -917,7 +918,7 @@ export class Job<
    * @param ttl - Time in milliseconds to wait for job to finish before timing out.
    */
   async waitUntilFinished(
-    queueEvents: MinimalQueue,
+    queueEvents: MinimalQueueEvents,
     ttl?: number,
   ): Promise<ReturnType> {
     await this.queue.waitUntilReady();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 export * from './backoff-strategy';
 export * from './finished-status';
 export * from './minimal-queue';
+export * from './minimal-queue-events';
 export * from './job-json-sandbox';
 export * from './job-options';
 export * from './job-type';

--- a/src/types/minimal-queue-events.ts
+++ b/src/types/minimal-queue-events.ts
@@ -1,0 +1,22 @@
+import { QueueEvents } from '../classes/queue-events';
+
+export type MinimalQueueEvents = Pick<
+  QueueEvents,
+  | 'name'
+  | 'client'
+  | 'close'
+  | 'emit'
+  | 'toKey'
+  | 'keys'
+  | 'off'
+  | 'on'
+  | 'once'
+  | 'opts'
+  | 'closing'
+  | 'waitUntilReady'
+  | 'removeListener'
+  | 'emit'
+  | 'run'
+  | 'on'
+  | 'redisVersion'
+>;


### PR DESCRIPTION
In order to avoid confusion about adding Queue or QueueEvents instances into waitUntilFinished, and implement type helps on:
1. verify that we don't pass a queue as it does have all queueEvent methods
2. avoid adding circular references in our types