### PR TITLE
Fix queue-events import in Job

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -33,7 +33,7 @@ import {
 import { Backoffs } from './backoffs';
 import { Scripts } from './scripts';
 import { UnrecoverableError } from './unrecoverable-error';
-import type { QueueEvents } from '@src/classes/queue-events';
+import type { QueueEvents } from './queue-events';
 
 const logger = debuglog('bull');
 


### PR DESCRIPTION
Following recently merged https://github.com/taskforcesh/bullmq/pull/1958
There is a path alias config in the `tsconfig.json` that make the alias work for the typescript compiler. However the output will still contain the alias and it breaks the import.

see this [SO](https://stackoverflow.com/questions/43324209/typescript-do-not-replace-non-relative-paths-defined-in-tsconfig) for another example