### PR TITLE
fix(issue 1988): set redisVersion

### DIFF
--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -179,10 +179,10 @@ export class RedisConnection extends EventEmitter {
     this._client.on('ready', this.handleClientReady);
 
     await RedisConnection.waitUntilReady(this._client);
-    await this.loadCommands();
+    this.loadCommands();
 
+    this.version = await this.getRedisVersion();
     if (this.opts && this.opts.skipVersionCheck !== true && !this.closing) {
-      this.version = await this.getRedisVersion();
       if (
         isRedisVersionLowerThan(this.version, RedisConnection.minimumVersion)
       ) {


### PR DESCRIPTION
In the latest version redisVersion is needed in worker.ts, this PR move the setter of RedisConnection.version in init outside the if.