### PR TITLE
feat: add getRepeatableJobByKey method to the queue - issue 1997

### DIFF
--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -307,6 +307,21 @@ export class Queue<
   }
 
   /**
+   * Gets a repeatable job from its key
+   *
+   * @param key - Job repeatable key
+   */
+  async getRepeatableJobByKey(
+    key: string,
+  ): Promise<Job<DataType, ResultType, NameType> | undefined> {
+    const repeatJobId = await (await this.repeat).getJobIdFromRepeatKey(key);
+
+    if (repeatJobId) {
+      return this.getJob(repeatJobId);
+    }
+  }
+
+  /**
    * Removes a repeatable job.
    *
    * Note: you need to use the exact same repeatOpts when deleting a repeatable job

--- a/src/classes/repeat.ts
+++ b/src/classes/repeat.ts
@@ -165,6 +165,15 @@ export class Repeat extends QueueBase {
     return this.scripts.removeRepeatable(repeatJobId, repeatJobKey);
   }
 
+  async getJobIdFromRepeatKey(repeatJobKey: string): Promise<string> {
+    const data = this.keyToData(repeatJobKey);
+    const nextMillis = await (
+      await this.client
+    ).zscore(this.keys.repeat, repeatJobKey);
+
+    return getRepeatJobId(data.name, nextMillis, md5(repeatJobKey), data.id);
+  }
+
   private keyToData(key: string, next?: number) {
     const data = key.split(':');
     const pattern = data.slice(4).join(':') || null;

--- a/tests/test_repeat.ts
+++ b/tests/test_repeat.ts
@@ -1057,6 +1057,14 @@ describe('repeat', function () {
     expect(repeatableJobsAfterRemove).to.have.length(0);
   });
 
+  it('retrieves repeatable job by key', async () => {
+    const repeat = { pattern: '*/2 * * * * *' };
+    const createdJob = await queue.add('remove', { foo: 'bar' }, { repeat });
+    const foundJob = await queue.getRepeatableJobByKey(createdJob.repeatJobKey);
+
+    expect(createdJob.id).deep.equals(foundJob.id);
+  });
+
   describe('when repeatable job does not exist', function () {
     it('returns false', async () => {
       const repeat = { pattern: '*/2 * * * * *' };


### PR DESCRIPTION
This PR adds the method `getRepeatableJobByKey` method to the Queue class to make it possible to retrieve repeatable job by key.

It addresses the issue #1977 