### PR TITLE
feat(common): add option to change repeatable jobs redis key hash algorithm

### DIFF
--- a/src/interfaces/advanced-options.ts
+++ b/src/interfaces/advanced-options.ts
@@ -5,6 +5,12 @@ export interface AdvancedRepeatOptions {
    * A custom cron strategy.
    */
   repeatStrategy?: RepeatStrategy;
+
+  /**
+   * A hash algorithm to be used when trying to create the job redis key.
+   * Default - md5
+   */
+  repeatKeyHashAlgorithm?: string;
 }
 
 export interface AdvancedOptions extends AdvancedRepeatOptions {


### PR DESCRIPTION
This PR enables to change the hash algorithm from the default (md5 - non fips complaint) to any string that represent a crypto supported hash algorithm. 

It addresses the issue https://github.com/taskforcesh/bullmq/issues/1932