### PR TITLE
chore(python): revert upgrade semver to prevent warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ env:
 jobs:
   release:
     permissions:
-      id-token: write
       contents: write # for release publishing
 
     name: Release
@@ -52,14 +51,14 @@ jobs:
           flake8 ./python --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 ./python --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Python Semantic Release
+      - name: Release Python
         if: ${{ contains(env.commitmsg, '(python)') }}
-        uses: python-semantic-release/python-semantic-release@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish package distributions to PyPI
-        id: pypi-publish
-        if: ${{ contains(env.commitmsg, '(python)') }}
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          cd python
+          pip install packaging
+          git config --global user.email "manast@taskforce.sh"
+          git config --global user.name "manast"
+          export VERSION=$(semantic-release print-version)
+          if [ ! -z "$VERSION" ]; then
+            GH_TOKEN=${{ secrets.GITHUB_TOKEN }} PYPI_TOKEN=${{ secrets.PYPI_TOKEN }} semantic-release publish
+          fi

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,7 +22,7 @@ keywords = ["python", "bullmq", "queues"]
 dependencies = [
     "redis >= 4.5.0, < 5",
     "msgpack >= 1.0.0, < 2",
-    "semver >= 3.0.1"
+    "semver >= 2.13.0, < 3"
 ]
 
 [project.optional-dependencies]
@@ -30,6 +30,7 @@ dev = [
     "setuptools==68.0.0",
     "pre-commit==3.3.3",
     "build==0.8.0",
+    "python-semantic-release==7.28.1",
     "types-redis==4.6.0.2"
 ]
 
@@ -44,40 +45,11 @@ exclude = ["tests*"]
 bullmq = ["commands/*.lua", "types/*"]
 
 [tool.semantic_release]
-version_variables = ["bullmq/__init__.py:__version__"]
+branch = "master"
+version_variable = "bullmq/__init__.py:__version__"
 version_toml = "pyproject.toml:project.version"
 build_command = "python3 setup.py sdist"
 tag_format = "vpy{version}"
 version_source = "commit"
-upload_to_pypi = true
-
-[tool.semantic_release.commit_parser_options]
-allowed_tags = [
-  "build",
-  "chore",
-  "ci",
-  "docs",
-  "feat",
-  "fix",
-  "perf",
-  "style",
-  "refactor",
-  "test",
-]
-minor_tags = ["feat"]
-patch_tags = ["fix", "perf"]
-
-[tool.semantic_release.changelog]
 changelog_file = "../docs/gitbook/python/changelog.md"
-exclude_commit_patterns = ["^((?!python).)*$"]
-
-[tool.semantic_release.branches.master]
-match = "master"
-prerelease = false
-prerelease_token = "rc"
-
-[tool.semantic_release.remote]
-name = "origin"
-type = "github"
-ignore_token_for_push = false
-token = { env = "GH_TOKEN" }
+upload_to_pypi = true

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,8 +6,9 @@ msgpack==1.0.5
 pipenv==2023.7.4
 platformdirs==3.6.0
 pre-commit==3.3.3
+python-semantic-release==7.28.1
 redis==4.6.0
-semver==3.0.1
+semver==2.13.0
 six==1.16.0
 virtualenv==20.23.1
 virtualenv-clone==0.5.7


### PR DESCRIPTION
Reverts taskforcesh/bullmq#2074
Wait for this issue https://github.com/python-semantic-release/python-semantic-release/issues/645 and https://github.com/python-semantic-release/python-semantic-release/issues/652 to be fixed