### PR TITLE
feat: add username option to redisOpts

### DIFF
--- a/python/bullmq/redis_connection.py
+++ b/python/bullmq/redis_connection.py
@@ -26,10 +26,11 @@ class RedisConnection:
             port = redisOpts.get("port") or 6379
             db = redisOpts.get("db") or 0
             password = redisOpts.get("password") or None
+            username = redisOpts.get("username") or None
 
             self.conn = redis.Redis(
                 host=host, port=port, db=db, password=password, decode_responses=True,
-                retry=retry, retry_on_error=retry_errors)
+                retry=retry, retry_on_error=retry_errors, username=username)
         else:
             self.conn = redis.from_url(redisOpts, decode_responses=True, retry=retry,
                 retry_on_error=retry_errors)


### PR DESCRIPTION
This change adds username option to redisOpts. currently, you're unable to set a custom username for the Redis connection.