### PR TITLE
fix(python): job getReturnValue not returning returnvalue

### DIFF
--- a/python/bullmq/job.py
+++ b/python/bullmq/job.py
@@ -226,6 +226,6 @@ def optsFromJSON(rawOpts: dict) -> dict:
 
 def getReturnValue(value: Any):
     try:
-        json.loads(value)
+        return json.loads(value)
     except Exception as err:
         return value


### PR DESCRIPTION
function getReturnValue() for json loading the string returnvalue from a completed Job is not returning the value