### PR TITLE
feat(worker.ts): adds new sequential job fetch mode

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -223,6 +223,7 @@ export class Worker<
       stalledInterval: 30000,
       autorun: true,
       runRetryDelay: 15000,
+      jobFetchMode: 'concurrent',
       ...this.opts,
     };
 
@@ -409,6 +410,9 @@ export class Worker<
               this.opts.runRetryDelay,
             ),
           );
+          if (this.opts.jobFetchMode === 'sequential') {
+            break;
+          }
         }
 
         const job = await asyncFifoQueue.fetch();

--- a/src/interfaces/worker-options.ts
+++ b/src/interfaces/worker-options.ts
@@ -137,6 +137,19 @@ export interface WorkerOptions extends QueueBaseOptions {
    * @default false
    */
   useWorkerThreads?: boolean;
+
+  /**
+   * Worker jobs fetch mode.
+   *
+   * In concurrent mode, jobs are fetched concurrently up to `concurrency` in
+   * parallel. This makes queue processing faster, but also puts more pressure
+   * on the redis server.
+   * In sequential mode, jobs are fetched sequentially. This does not mean that
+   * jobs are processed sequentially!
+   *
+   * @default "concurrent"
+   */
+  jobFetchMode?: 'concurrent' | 'sequential';
 }
 
 export interface GetNextJobOptions {


### PR DESCRIPTION
Workers with high concurrency can end up in state where they execute `getNextJob` X times for every new added job. Where X is concurrency number. This is causing excessive load on Redis.

This can be remediated by lowering concurrency, but there are use cases where we want to keep concurrency high to ensure few slow jobs don't block the queue.

This PR tries to solve this by adding extra setting `jobFetchMode`. If explicitly setting this setting to `sequential`, worker does not issue `concurrency` fetch jobs queries to Redis in parallel, and instead loads them sequentially. This does not mean that jobs are processed sequentially!

fix #2157