### PR TITLE
fix(worker): throw exception with NaN as concurrency

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -568,6 +568,8 @@ export class Worker<
       if (!this.closing) {
         await this.delay();
       }
+    } finally {
+      this.waiting = null;
     }
   }
 

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -350,8 +350,12 @@ export class Worker<
   }
 
   set concurrency(concurrency: number) {
-    if (typeof concurrency !== 'number' || concurrency < 1) {
-      throw new Error('concurrency must be a number greater than 0');
+    if (
+      typeof concurrency !== 'number' ||
+      concurrency < 1 ||
+      !isFinite(concurrency)
+    ) {
+      throw new Error('concurrency must be a finite number greater than 0');
     }
     this.opts.concurrency = concurrency;
   }
@@ -564,8 +568,6 @@ export class Worker<
       if (!this.closing) {
         await this.delay();
       }
-    } finally {
-      this.waiting = null;
     }
   }
 
@@ -595,6 +597,8 @@ export class Worker<
       }
     }
 
+    // Update limitUntil and delayUntil
+    // TODO: Refactor out of this function
     this.limitUntil = Math.max(limitUntil, 0) || 0;
     if (delayUntil) {
       this.blockUntil = Math.max(delayUntil, 0) || 0;

--- a/tests/test_worker.ts
+++ b/tests/test_worker.ts
@@ -1631,7 +1631,21 @@ describe('workers', function () {
         throw new Error('Should have thrown an exception');
       } catch (err) {
         expect(err.message).to.be.equal(
-          'concurrency must be a number greater than 0',
+          'concurrency must be a finite number greater than 0',
+        );
+      }
+    });
+
+    it('should thrown an exception if I specify a NaN concurrency', () => {
+      try {
+        const worker = new Worker(queueName, async () => {}, {
+          connection,
+          concurrency: NaN,
+        });
+        throw new Error('Should have thrown an exception');
+      } catch (err) {
+        expect(err.message).to.be.equal(
+          'concurrency must be a finite number greater than 0',
         );
       }
     });


### PR DESCRIPTION
I got hinted that if you use NaN as a concurrency value the worker goes bananas. Here is a fix for it.