### PR TITLE
Avoid importing from '..'

### DIFF
--- a/src/classes/child.ts
+++ b/src/classes/child.ts
@@ -1,7 +1,7 @@
 import { ChildProcess, fork } from 'child_process';
 import { Worker } from 'worker_threads';
 import { AddressInfo, createServer } from 'net';
-import { ChildCommand, ParentCommand } from '../';
+import { ChildCommand, ParentCommand } from '../commands';
 import { EventEmitter } from 'events';
 
 /**

--- a/src/classes/child.ts
+++ b/src/classes/child.ts
@@ -1,7 +1,7 @@
 import { ChildProcess, fork } from 'child_process';
 import { Worker } from 'worker_threads';
 import { AddressInfo, createServer } from 'net';
-import { ChildCommand, ParentCommand } from '../commands';
+import { ChildCommand, ParentCommand } from '../interfaces';
 import { EventEmitter } from 'events';
 
 /**


### PR DESCRIPTION
Import commands from their originating module, not from a re-export module.

This is important for compatibility with import-in-the-middle and other import-altering code, otherwise this results in a partially-loaded module being passed into instrumentation code.