### PR TITLE
fix:Batched unpack now uses range

### DIFF
--- a/src/commands/includes/removeZSetJobs.lua
+++ b/src/commands/includes/removeZSetJobs.lua
@@ -8,7 +8,7 @@ local function removeZSetJobs(keyName, hard, baseKey, max)
   local count = removeJobs(jobs, hard, baseKey, max)
   if(#jobs > 0) then
     for from, to in batches(#jobs, 7000) do
-      rcall("ZREM", keyName, unpack(jobs))
+      rcall("ZREM", keyName, unpack(jobs, from, to))
     end
   end
   return count


### PR DESCRIPTION
The `drain-4` command used in the `queue.drain()` function still used a non-batching variant of the `unpack` function in the `removeZSetJobs.lua` file. This resulted in the drain function failing when the unpack had too many values to unpack. 

This PR adds a range to the unpack function so that it has to unpack fewer values for each batched iteration.