### PR TITLE
fix: forward skipVersionCheck to blockingConnection

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -282,6 +282,9 @@ export class Worker<
       isRedisInstance(opts.connection)
         ? (<Redis>opts.connection).duplicate({ connectionName })
         : { ...opts.connection, connectionName },
+      false,
+      true,
+      opts.skipVersionCheck,
     );
     this.blockingConnection.on('error', error => this.emit('error', error));
     this.blockingConnection.on('ready', () =>


### PR DESCRIPTION
Hi,

It seems that #2149 missed a spot when passing around this flag, as workers still emit this warning even with a true flag.