### PR TITLE
docs(prioritized.md): fix doc regarding jobs without a priority assigned

### DIFF
--- a/docs/gitbook/guide/jobs/prioritized.md
+++ b/docs/gitbook/guide/jobs/prioritized.md
@@ -8,7 +8,7 @@ Adding prioritized jobs is a slower operation than the other types of jobs, with
 
 Note that the priorities go from 1 to 2 097 152, whereas a lower number is always a higher priority than higher numbers.
 
-Jobs without a priority assigned will get the least priority.
+Jobs without a priority assigned will get the most priority.
 
 ```typescript
 import { Queue } from 'bullmq';


### PR DESCRIPTION
Jobs without a priority assigned now have the most priority, not the least. This PR updates the documentation to reflect that.

Reference: https://bullmq.io/news/062123/faster-priority-jobs/