### PR TITLE
fix(python): introduction doc

### DIFF
--- a/docs/gitbook/python/introduction.md
+++ b/docs/gitbook/python/introduction.md
@@ -42,7 +42,7 @@ In order to consume the jobs from the queue you need to use the Worker class, pr
 ```python
 from bullmq import Worker
 
-async def process(job):
+async def process(job, job_token):
     # job.data will include the data added to the queue
     return doSomethingAsync(job)
 


### PR DESCRIPTION
`job_token` is a required parameter for the process function otherwise the function breaks. 

Another solution would be to use `*args` but I am not sure if it's worth being in the documentation