### PR TITLE
fix: max event limit when removing jobs

### DIFF
--- a/src/commands/removeJob-1.lua
+++ b/src/commands/removeJob-1.lua
@@ -55,7 +55,9 @@ local function removeJob( prefix, jobId, parentKey, removeChildren)
 
     rcall("DEL", jobKey, jobKey .. ":logs", jobKey .. ":dependencies", jobKey .. ":processed")
 
-    rcall("XADD", prefix .. "events", "*", "event", "removed", "jobId", jobId, "prev", prev);
+    local maxEvents = rcall("HGET", prefix .. "meta", "opts.maxLenEvents") or 10000
+
+    rcall("XADD", prefix .. "events", "MAXLEN", "~", maxEvents, "*", "event", "removed", "jobId", jobId, "prev", prev);
 end
 
 local prefix = KEYS[1]


### PR DESCRIPTION
Impose the configured max length of events limit when adding events for job removal. This prevents unbounded event creation on this stream which can lead to unexpected runaway memory usage.