### PR TITLE
fix key typo in rate limit example

### DIFF
--- a/docs/gitbook/bullmq-pro/groups/rate-limiting.md
+++ b/docs/gitbook/bullmq-pro/groups/rate-limiting.md
@@ -19,7 +19,7 @@ const worker = new WorkerPro('myQueue', processFn, {
     group: {
       limit: {
         max: 100,  // Limit to 100 jobs per second per group
-        duration 1000,
+        duration: 1000,
       }
     },
     connection


### PR DESCRIPTION
There was a `:` missing in this example