### PR TITLE
fix(python backoff): fix bug when using builtin backoff type

### DIFF
--- a/python/bullmq/backoffs.py
+++ b/python/bullmq/backoffs.py
@@ -31,7 +31,7 @@ class Backoffs:
 def lookup_strategy(backoff: BackoffOptions, custom_strategy):
     backoff_type = backoff.get("type")
     if backoff_type in Backoffs.builtin_strategies:
-        Backoffs.builtin_strategies[backoff_type](backoff.delay)
+        Backoffs.builtin_strategies[backoff_type](backoff.get("delay"))
     elif custom_strategy:
         return custom_strategy
     else:

--- a/python/bullmq/backoffs.py
+++ b/python/bullmq/backoffs.py
@@ -24,14 +24,13 @@ class Backoffs:
     async def calculate(backoff: BackoffOptions, attempts_made: int, err, job, customStrategy):
         if backoff:
             strategy = lookup_strategy(backoff, customStrategy)
-
             return strategy(attempts_made, backoff.get("type"), err, job)
 
 
 def lookup_strategy(backoff: BackoffOptions, custom_strategy):
     backoff_type = backoff.get("type")
     if backoff_type in Backoffs.builtin_strategies:
-        Backoffs.builtin_strategies[backoff_type](backoff.get("delay"))
+        return Backoffs.builtin_strategies[backoff_type](backoff.get("delay"))
     elif custom_strategy:
         return custom_strategy
     else:

--- a/python/bullmq/backoffs.py
+++ b/python/bullmq/backoffs.py
@@ -31,8 +31,8 @@ class Backoffs:
 def lookup_strategy(backoff: BackoffOptions, custom_strategy):
     backoff_type = backoff.get("type")
     if backoff_type in Backoffs.builtin_strategies:
-        Backoffs.builtin_strategies[backoff.type](backoff.delay)
+        Backoffs.builtin_strategies[backoff_type](backoff.delay)
     elif custom_strategy:
         return custom_strategy
     else:
-        raise Exception(f"Unknown backoff strategy {backoff_type}.If a custom backoff strategy is used, specify it when the queue is created.")
+        raise Exception(f"Unknown backoff strategy {backoff_type}. If a custom backoff strategy is used, specify it when the queue is created.")

--- a/python/tests/worker_tests.py
+++ b/python/tests/worker_tests.py
@@ -221,13 +221,13 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
 
         start = round(time.time() * 1000)
         await queue.add("test", { "foo": "bar" },
-                {"attempts": 3, "backoff": {"type": "fixed", "delay": 3000}})
+                {"attempts": 3, "backoff": {"type": "fixed", "delay": 1000}})
 
         completed_events = Future()
 
         def completing(job: Job, result):
             elapse = round(time.time() * 1000) - start
-            self.assertGreater(elapse, 3000)
+            self.assertGreater(elapse, 2000)
             completed_events.set_result(None)
 
         worker.on("completed", completing)


### PR DESCRIPTION
When a builtin backoff type is used, the lookup was expecting and object with a property type, but the passed value from the job is a dict. This fixes the lookup and adds a test for it.

Before the fix, an exception would be thrown: 

```
Error moving job to failed 'dict' object has no attribute 'type'
```