### PR TITLE
fix: narrow the BackoffOptions "type" union

### DIFF
--- a/src/interfaces/backoff-options.ts
+++ b/src/interfaces/backoff-options.ts
@@ -7,7 +7,7 @@ export interface BackoffOptions {
   /**
    * Name of the backoff strategy.
    */
-  type: 'fixed' | 'exponential' | (string & {});
+  type: 'fixed' | 'exponential' | 'custom';
   /**
    * Delay in milliseconds.
    */


### PR DESCRIPTION
Seems the ability to define custom-named backoff strategies has been dropped, so we can narrow the `type` type.

Related:
https://github.com/taskforcesh/bullmq/pull/2275