### PR TITLE
fix: prefer custom backoff strategy to built-in if provided

### DIFF
--- a/src/classes/backoffs.ts
+++ b/src/classes/backoffs.ts
@@ -52,10 +52,10 @@ function lookupStrategy(
   backoff: BackoffOptions,
   customStrategy?: BackoffStrategy,
 ): BackoffStrategy {
-  if (backoff.type in Backoffs.builtinStrategies) {
-    return Backoffs.builtinStrategies[backoff.type](backoff.delay!);
-  } else if (customStrategy) {
+  if (customStrategy) {
     return customStrategy;
+  } else if (backoff.type in Backoffs.builtinStrategies) {
+    return Backoffs.builtinStrategies[backoff.type](backoff.delay!);
   } else {
     throw new Error(
       `Unknown backoff strategy ${backoff.type}.


### PR DESCRIPTION
This feels a bit easier to reason over to me, my thinking is...

1. A queue can define a built-in backoff strategy for use as an always-available default
     a. Queues no longer define their own custom strategies. Related to https://github.com/taskforcesh/bullmq/pull/2275 and https://github.com/taskforcesh/bullmq/pull/2276
2. A worker can define its own backoff strategy on that/any queue and the custom strategy will be preferred

Maybe a future piece could be to unify the backoff settings for both queues and workers. Or deciding one place to define it.