### PR TITLE
fix: include custom backoff strategy in backoff strategy selection/calculation

### DIFF
--- a/src/classes/backoffs.ts
+++ b/src/classes/backoffs.ts
@@ -40,7 +40,7 @@ export class Backoffs {
     job: MinimalJob,
     customStrategy?: BackoffStrategy,
   ): Promise<number> | number | undefined {
-    if (backoff) {
+    if (backoff || customStrategy) {
       const strategy = lookupStrategy(backoff, customStrategy);
 
       return strategy(attemptsMade, backoff.type, err, job);


### PR DESCRIPTION
Looks like custom strategies are ignored in backoff selection if backoff setting is completely undefined. Seeing as the lookup function is able to handle custom strategy we should perform the lookup?

This combined with current evaluation order of lookup conditions (changed in https://github.com/taskforcesh/bullmq/pull/2277) means to use a custom backoff strategy, your queue must have a truthy `backoff` setting, but must not contain a `type`.


Related:
https://github.com/taskforcesh/bullmq/pull/2275
https://github.com/taskforcesh/bullmq/pull/2276
https://github.com/taskforcesh/bullmq/pull/2277