### PR TITLE
fix(python): uniyfing redis connection args for Queue and Worker

### DIFF
--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -42,6 +42,9 @@
 * [QueueScheduler](guide/queuescheduler.md)
 * [Redis™ Compatibility](guide/redis-tm-compatibility/README.md)
   * [Dragonfly](guide/redis-tm-compatibility/dragonfly.md)
+* [Redis™ hosting](guide/redis-tm-hosting/README.md)
+  * [AWS MemoryDB](guide/redis-tm-hosting/aws-memorydb.md)
+  * [AWS Elasticache](guide/redis-tm-hosting/aws-elasticache.md)
 * [Architecture](guide/architecture.md)
 * [NestJs](guide/nestjs/README.md)
   * [Producers](guide/nestjs/producers.md)
@@ -60,6 +63,7 @@
 * [Process Step Jobs](patterns/process-step-jobs.md)
 * [Failing fast when Redis is down](patterns/failing-fast-when-redis-is-down.md)
 * [Stop retrying jobs](patterns/stop-retrying-jobs.md)
+* [Redis Cluster](patterns/redis-cluster.md)
 
 ## BullMQ Pro
 

--- a/docs/gitbook/bull/patterns/redis-cluster.md
+++ b/docs/gitbook/bull/patterns/redis-cluster.md
@@ -4,11 +4,18 @@ Bull internals require atomic operations that span different keys. This behavior
 
 In summary, to make bull compatible with Redis cluster, use a queue prefix inside brackets. For example:
 
+You can use two approaches in order to make the Queues compatible with Cluster. Either define a queue prefix:
+
 ```typescript
 const queue = new Queue('cluster', {
   prefix: '{myprefix}'
 });
 ```
 
-If you use several queues in the same cluster, you should use different prefixes so that the queues are evenly placed in the cluster nodes.
+or prefix the queue name itself:
 
+```typescript
+const queue = new Queue('{cluster}');
+```
+
+Note that If you use several queues in the same cluster, you should use different prefixes so that the queues are evenly placed in the cluster nodes, potentially increasing performance and memory usage.

--- a/docs/gitbook/bull/patterns/redis-cluster.md
+++ b/docs/gitbook/bull/patterns/redis-cluster.md
@@ -12,7 +12,7 @@ const queue = new Queue('cluster', {
 });
 ```
 
-or prefix the queue name itself:
+or wrap the queue name itself:
 
 ```typescript
 const queue = new Queue('{cluster}');

--- a/docs/gitbook/guide/redis-tm-hosting/README.md
+++ b/docs/gitbook/guide/redis-tm-hosting/README.md
@@ -1,0 +1,8 @@
+---
+description: >-
+  For BullMQ you are going to need a proper Redis™ hosting solution. In this
+  section we provide instructions on how to use some of the most popular ones.
+---
+
+# Redis™ hosting
+

--- a/docs/gitbook/guide/redis-tm-hosting/aws-elasticache.md
+++ b/docs/gitbook/guide/redis-tm-hosting/aws-elasticache.md
@@ -1,0 +1,2 @@
+# AWS Elasticache
+

--- a/docs/gitbook/guide/redis-tm-hosting/aws-memorydb.md
+++ b/docs/gitbook/guide/redis-tm-hosting/aws-memorydb.md
@@ -1,0 +1,37 @@
+# AWS MemoryDB
+
+AWS provides a Redis™ 7 compatible managed database that is easy to use and is fully compatible with BullMQ.
+
+There are some considerations to take care when using MemoryDB though.
+
+* MemoryDB only works in Cluster mode. So you need to use "hash tags" so that the queues get attached to a given cluster node ([read more here](../../bull/patterns/redis-cluster.md)).
+* MemoryDB can only be accessed within an AWS VPC, so you cannot access the Redis™ cluster outside of AWS.
+
+The easiest way to use MemoryDB with BullMQ is to first instantiate a IORedis Cluster instance, and then use that connection as an option to your workers or queue instances, for example:
+
+```typescript
+import { Cluster } from "ioredis"
+import { Worker } from "bullmq"
+
+const connection = new Cluster(
+  [
+    {
+      host: "clustercfg.xxx.amazonaws.com",
+      port: 6379,
+    },
+  ],
+  {
+    tls: {},
+  }
+);
+
+const worker = new Worker("myqueue", async (job: Job) => {
+  // Do some usefull stuff
+}, { connection });
+
+// ...
+
+// Do not forget to close the connection as well as the worker when shutting down
+await worker.close();
+await connection.quit();
+```

--- a/docs/gitbook/patterns/redis-cluster.md
+++ b/docs/gitbook/patterns/redis-cluster.md
@@ -1,0 +1,2 @@
+# Redis Cluster
+

--- a/docs/gitbook/patterns/redis-cluster.md
+++ b/docs/gitbook/patterns/redis-cluster.md
@@ -1,2 +1,25 @@
+---
+description: Important considerations when using Redis™ Cluster mode.
+---
+
 # Redis Cluster
 
+Bull internals require atomic operations that span different keys. This behavior breaks Redis's rules for cluster configurations. However, it is still possible to use a cluster environment by using the proper bull prefix option as a cluster "hash tag". Hash tags are used to guarantee that certain keys are placed in the same hash slot, read more about hash tags in the [redis cluster tutorial](https://redis.io/topics/cluster-tutorial). A hash tag is defined with brackets. I.e. a key that has a substring inside brackets will use that substring to determine in which hash slot the key will be placed.
+
+In summary, to make bull compatible with Redis cluster, use a queue prefix inside brackets. For example:
+
+You can use two approaches in order to make the Queues compatible with Cluster. Either define a queue prefix:
+
+```typescript
+const queue = new Queue('cluster', {
+  prefix: '{myprefix}'
+});
+```
+
+or wrap the queue name itself:
+
+```typescript
+const queue = new Queue('{cluster}');
+```
+
+Note that If you use several queues in the same cluster, you should use different prefixes so that the queues are evenly placed in the cluster nodes, potentially increasing performance and memory usage.

--- a/python/bullmq/queue.py
+++ b/python/bullmq/queue.py
@@ -11,11 +11,12 @@ class Queue:
     Instantiate a Queue object
     """
 
-    def __init__(self, name: str, redisOpts: dict | str = {}, opts: QueueBaseOptions = {}):
+    def __init__(self, name: str, opts: QueueBaseOptions = {}):
         """
         Initialize a connection
         """
         self.name = name
+        redisOpts = opts.get("connection", {})
         self.redisConnection = RedisConnection(redisOpts)
         self.client = self.redisConnection.conn
         self.opts = opts

--- a/python/bullmq/types/queue_options.py
+++ b/python/bullmq/types/queue_options.py
@@ -1,5 +1,5 @@
 
-from typing import TypedDict
+from typing import TypedDict, Any
 
 
 class QueueBaseOptions(TypedDict, total=False):

--- a/python/bullmq/types/queue_options.py
+++ b/python/bullmq/types/queue_options.py
@@ -8,6 +8,8 @@ class QueueBaseOptions(TypedDict, total=False):
     """
 
     prefix: str
+    connection: dict[str, Any]
     """
     Prefix for all queue keys.
     """
+


### PR DESCRIPTION
Currently the NodeJS version has the same connection arguments for the worker and queue whereas python as two different format.

It's a breaking change but using the same format might prevent bugs in the future