### PR TITLE
fix(utils): use EventEmitter as a type instead of a namespace to resolve type error

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ import { AbortController } from 'node-abort-controller';
 import { CONNECTION_CLOSED_ERROR_MSG } from 'ioredis/built/utils';
 import * as semver from 'semver';
 import { ChildMessage, RedisClient } from './interfaces';
-import * as EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 export const errorObject: { [index: string]: any } = { value: null };
 


### PR DESCRIPTION
## "Cannot use namespace 'EventEmitter' as a type"

### Summary
This pull request addresses a TypeScript error where `EventEmitter` was incorrectly used as a namespace rather than a type.

### Changes
- Updated imports to use `EventEmitter` as a type instead of a namespace.
- Ensured that all instances where `EventEmitter` is used are consistent with TypeScript's type usage standards.

### Impact
- Resolves the TypeScript compilation error.

### Screenshots
Attached is a screenshot highlighting the TypeScript error and the corrected code:
<img width="452" alt="Screenshot 2023-11-15 at 15 28 31" src="https://github.com/taskforcesh/bullmq/assets/24798543/2cb16e23-7ab2-4169-bc10-a6df9a46d6b1">


### Dependencies (Node 18.17.1)
```
  "dependencies": {
    "@fastify/static": "^6.10.2",
    "@nestjs/bullmq": "^10.0.1",
    "@nestjs/common": "^10.1.3",
    "@nestjs/config": "^3.0.0",
    "@nestjs/core": "^10.1.3",
    "@nestjs/jwt": "^10.1.0",
    "@nestjs/mongoose": "^10.0.1",
    "@nestjs/passport": "^10.0.0",
    "@nestjs/platform-express": "^10.1.3",
    "@nestjs/platform-fastify": "^10.1.3",
    "@nestjs/schedule": "^3.0.2",
    "@nestjs/swagger": "^7.1.6",
    "@ntegral/nestjs-sentry": "^4.0.0",
    "@sentry/node": "^7.61.1",
    "@sentry/tracing": "^7.61.1",
    "@supabase/supabase-js": "^2.31.0",
    "aws-sdk": "^2.1430.0",
    "axios": "^1.4.0",
    "bcrypt": "^5.1.0",
    "bullmq": "^4.13.2",
    "dd-trace": "^4.11.0",
    "dotenv": "^16.3.1",
    "form-data": "^4.0.0",
    "google-auth-library": "^9.0.0",
    "mixpanel": "^0.17.0",
    "moment": "^2.29.4",
    "mongoose": "^7.4.2",
    "passport": "^0.6.0",
    "passport-jwt": "^4.0.1",
    "passport-local": "^1.0.0",
    "qs": "^6.11.2",
    "reflect-metadata": "^0.1.13",
    "rimraf": "^5.0.1",
    "rxjs": "^7.8.1"
  },
  "devDependencies": {
    "@beta.limited/primelister": "^1.0.6",
    "@nestjs/cli": "^10.1.11",
    "@nestjs/schematics": "^10.0.1",
    "@nestjs/testing": "^10.1.3",
    "@types/bcrypt": "^5.0.0",
    "@types/cron": "^2.0.1",
    "@types/express": "^4.17.17",
    "@types/jest": "29.5.3",
    "@types/lodash": "^4.14.196",
    "@types/node": "^20.4.7",
    "@types/passport-jwt": "^3.0.9",
    "@types/passport-local": "^1.0.35",
    "@types/supertest": "^2.0.12",
    "@typescript-eslint/eslint-plugin": "^6.2.1",
    "@typescript-eslint/parser": "^6.2.1",
    "eslint": "^8.46.0",
    "eslint-config-prettier": "^8.10.0",
    "eslint-plugin-prettier": "^5.0.0",
    "jest": "29.6.2",
    "prettier": "^3.0.1",
    "source-map-support": "^0.5.21",
    "supertest": "^6.3.3",
    "ts-jest": "29.1.1",
    "ts-loader": "^9.4.4",
    "ts-node": "^10.9.1",
    "tsconfig-paths": "4.2.0",
    "typescript": "^5.1.6"
  }
```

## Additional Notes
This change is expected to merge without any breaking changes to the current system.

Please review the changes and provide your feedback.

Thank you!


