### PR TITLE
fix(flows): update constructor and methods to match queue base

### DIFF
--- a/src/classes/flow-producer.ts
+++ b/src/classes/flow-producer.ts
@@ -95,7 +95,6 @@ export class FlowProducer extends EventEmitter {
   closing: Promise<void> | undefined;
   queueKeys: QueueKeys;
 
-  protected closed: boolean = false;
   protected connection: RedisConnection;
 
   constructor(
@@ -172,13 +171,6 @@ export class FlowProducer extends EventEmitter {
    */
   get client(): Promise<RedisClient> {
     return this.connection.client;
-  }
-
-  /**
-   * Returns the version of the Redis instance the client is connected to,
-   */
-  get redisVersion(): string {
-    return this.connection.redisVersion;
   }
 
   /**
@@ -487,7 +479,6 @@ export class FlowProducer extends EventEmitter {
       this.closing = this.connection.close();
     }
     await this.closing;
-    this.closed = true;
   }
 
   /**

--- a/src/classes/queue-base.ts
+++ b/src/classes/queue-base.ts
@@ -56,7 +56,7 @@ export class QueueBase extends EventEmitter implements MinimalQueue {
     if (!opts.connection) {
       console.warn(
         [
-          'BullMQ: DEPRECATION WARNING! Optional instantiation of Queue, Worker and QueueEvents',
+          'BullMQ: DEPRECATION WARNING! Optional instantiation of Queue, Worker, QueueEvents and FlowProducer',
           'without providing explicitly a connection or connection options is deprecated. This behaviour will',
           'be removed in the next major release',
         ].join(' '),

--- a/src/classes/queue-base.ts
+++ b/src/classes/queue-base.ts
@@ -141,7 +141,7 @@ export class QueueBase extends EventEmitter implements MinimalQueue {
 
   /**
    *
-   * @returns Closes the connection and returns a promise that resolves when the connection is closed.
+   * Closes the connection and returns a promise that resolves when the connection is closed.
    */
   async close(): Promise<void> {
     if (!this.closing) {


### PR DESCRIPTION
I noticed that the flow producer wasn't closing correctly which was leading to my application crashing when passing the flow Redis connection options.

After making the following changes, the flow can now close nicely. 