### PR TITLE
Remove Mentions of outdated 

### DIFF
--- a/docs/gitbook/guide/queues/auto-removal-of-jobs.md
+++ b/docs/gitbook/guide/queues/auto-removal-of-jobs.md
@@ -4,21 +4,6 @@ By default, when your queue jobs are completed (or failed), they are stored in t
 
 BullMQ supports different strategies for auto-removing finalized jobs. These strategies are configured on the Job's options [`removeOnComplete`](https://api.docs.bullmq.io/interfaces/v5.BaseJobOptions.html#removeOnComplete) and [`removeOnFail`](https://api.docs.bullmq.io/interfaces/v5.BaseJobOptions.html#removeOnFail).
 
-### Remove all finalized jobs
-
-The simplest option is to set `removeOnComplete`/`removeOnFail` to `true`, in this case, all jobs will be removed automatically as soon as they are finalized:
-
-```typescript
-await myQueue.add(
-  'test',
-  { foo: 'bar' },
-  { removeOnComplete: true, removeOnFail: true },
-);
-```
-
-{% hint style="warning" %}
-Jobs will be deleted regardless of their names.
-{% endhint %}
 
 ### Keep a certain number of jobs
 
@@ -28,7 +13,15 @@ It is also possible to specify a maximum number of jobs to keep. A good practice
 await myQueue.add(
   'test',
   { foo: 'bar' },
-  { removeOnComplete: 1000, removeOnFail: 5000 },
+  {
+    removeOnComplete: {
+      age: 3600, // keep up to 1 hour
+      count: 1000, // keep up to 1000 jobs
+    },
+    removeOnFail: {
+      count: 5000 // keep up to 1000 jo
+    },
+  },
 );
 ```
 


### PR DESCRIPTION
I'm not sure what the desired behaviour is so I just updated the docs to reference the current behaviour.

Basically, because the type for [removeOnComplete and removeOnFail](https://github.com/taskforcesh/bullmq/blob/master/src/interfaces/worker-options.ts#L61C1-L73C27) is [`KeepJobs`](https://github.com/taskforcesh/bullmq/blob/master/src/interfaces/keep-jobs.ts#L8)

The docs were no longer true.

If you want to create the expected behaviour of `removeOnComplete/removeOnFail = true` then you can do 

`removeOnComplete/removeOnFail = { count: 0 }` as far as my testing has gone.

I haven't really looked into this all that much but thought I would contribute back. Best of luck!