### PR TITLE
Add link to Gitbook Summary for flows/remove-dependency.md

### DIFF
--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -35,6 +35,7 @@
   * [Adding flows in bulk](guide/flows/adding-bulks.md)
   * [Get Flow Tree](guide/flows/get-flow-tree.md)
   * [Fail Parent](guide/flows/fail-parent.md)
+  * [Remove Dependency](guide/flows/remove-dependency.md)
 * [Metrics](guide/metrics/metrics.md)
 * [Rate limiting](guide/rate-limiting.md)
 * [Retrying failing jobs](guide/retrying-failing-jobs.md)


### PR DESCRIPTION
The `removeDependencyOnFailure` option added in #1953 is hard to find, it seems the documentation is not publicly linked.

This PR suggests to add it to *Gitbook Summary* same as its siblings.
