### PR TITLE
fix(marker): differentiate standard and delayed markers

### DIFF
--- a/src/commands/includes/addDelayMarkerIfNeeded.lua
+++ b/src/commands/includes/addDelayMarkerIfNeeded.lua
@@ -10,6 +10,6 @@ local function addDelayMarkerIfNeeded(markerKey, delayedKey)
     if nextTimestamp ~= nil then
         -- Replace the score of the marker with the newest known
         -- next timestamp.
-        rcall("ZADD", markerKey, nextTimestamp, "0")
+        rcall("ZADD", markerKey, nextTimestamp, "1")
     end
 end

--- a/tests/test_job.ts
+++ b/tests/test_job.ts
@@ -16,7 +16,6 @@ import { v4 } from 'uuid';
 import { Job, Queue, QueueEvents, Worker } from '../src/classes';
 import { JobsOptions } from '../src/types';
 import { delay, getParentKey, removeAllQueueData } from '../src/utils';
-import { SSL_OP_NO_TLSv1_2 } from 'constants';
 
 describe('Job', function () {
   const redisHost = process.env.REDIS_HOST || 'localhost';


### PR DESCRIPTION
a marker from a delayed job could override an existing marker from a standard job as both have the same member value, that cause that a worker picks the marker thinking that all the remaining jobs are in delayed status, so it wait the delay even having standard jobs. In order to avoid that we can just use a different member value for the delayed jobs and bzpopmin will pick the lower value (standard marker "0" with score 0) later it could pick marker "1" with delayed score