### PR TITLE
fix(rate-limit): move job to wait even if ttl is 0

### DIFF
--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -222,9 +222,7 @@ export class Scripts {
     return <string>result;
   }
 
-  async pause(pause: boolean): Promise<void> {
-    const client = await this.queue.client;
-
+  protected pauseArgs(pause: boolean): (string | number)[] {
     let src = 'wait',
       dst = 'paused';
     if (!pause) {
@@ -242,7 +240,17 @@ export class Scripts {
       this.queue.keys.marker,
     );
 
-    return (<any>client).pause(keys.concat([pause ? 'paused' : 'resumed']));
+    const args = [pause ? 'paused' : 'resumed'];
+
+    return keys.concat(args);
+  }
+
+  async pause(pause: boolean): Promise<void> {
+    const client = await this.queue.client;
+
+    const args = this.pauseArgs(pause);
+
+    return (<any>client).pause(args);
   }
 
   private removeRepeatableArgs(
@@ -1034,6 +1042,7 @@ export class Scripts {
       this.queue.keys.meta,
       this.queue.keys.limiter,
       this.queue.keys.prioritized,
+      this.queue.keys.marker,
       this.queue.keys.events,
     ];
 

--- a/src/commands/moveJobFromActiveToWait-10.lua
+++ b/src/commands/moveJobFromActiveToWait-10.lua
@@ -44,7 +44,7 @@ if lockToken == token then
     if priority > 0 then
       pushBackJobWithPriority(KEYS[8], priority, jobId)
     else
-      addJobInTargetList(target, KEYS[9], "RPUSH", target, isPaused, jobId)
+      addJobInTargetList(target, KEYS[9], "RPUSH", isPaused, jobId)
     end
 
     rcall("DEL", lockKey)

--- a/src/commands/moveJobFromActiveToWait-10.lua
+++ b/src/commands/moveJobFromActiveToWait-10.lua
@@ -1,16 +1,17 @@
 --[[
   Function to move job from active state to wait.
   Input:
-    KEYS[1] active key
-    KEYS[2] wait key
+    KEYS[1]  active key
+    KEYS[2]  wait key
     
-    KEYS[3] stalled key
-    KEYS[4] job lock key
-    KEYS[5] paused key
-    KEYS[6] meta key
-    KEYS[7] limiter key
-    KEYS[8] prioritized key
-    KEYS[9] event key
+    KEYS[3]  stalled key
+    KEYS[4]  job lock key
+    KEYS[5]  paused key
+    KEYS[6]  meta key
+    KEYS[7]  limiter key
+    KEYS[8]  prioritized key
+    KEYS[9]  marker key
+    KEYS[10] event key
 
     ARGV[1] job id
     ARGV[2] lock token
@@ -19,7 +20,9 @@
 local rcall = redis.call
 
 -- Includes
+--- @include "includes/addJobInTargetList"
 --- @include "includes/pushBackJobWithPriority"
+--- @include "includes/getOrSetMaxEvents"
 --- @include "includes/getTargetQueueList"
 
 local jobId = ARGV[1]
@@ -28,10 +31,11 @@ local lockKey = KEYS[4]
 
 local lockToken = rcall("GET", lockKey)
 local pttl = rcall("PTTL", KEYS[7])
-if lockToken == token and pttl > 0 then
+if lockToken == token then
+  local metaKey = KEYS[6]
   local removed = rcall("LREM", KEYS[1], 1, jobId)
-  if (removed > 0) then
-    local target = getTargetQueueList(KEYS[6], KEYS[2], KEYS[5])
+  if removed > 0 then
+    local target, isPaused = getTargetQueueList(metaKey, KEYS[2], KEYS[5])
 
     rcall("SREM", KEYS[3], jobId)
 
@@ -40,13 +44,16 @@ if lockToken == token and pttl > 0 then
     if priority > 0 then
       pushBackJobWithPriority(KEYS[8], priority, jobId)
     else
-      rcall("RPUSH", target, jobId)
+      addJobInTargetList(target, KEYS[9], "RPUSH", target, isPaused, jobId)
     end
 
     rcall("DEL", lockKey)
 
+    local maxEvents = getOrSetMaxEvents(metaKey)
+
     -- Emit waiting event
-    rcall("XADD", KEYS[9], "*", "event", "waiting", "jobId", jobId)
+    rcall("XADD", KEYS[10], "MAXLEN", "~", maxEvents, "*", "event", "waiting",
+      "jobId", jobId)
   end
 end
 


### PR DESCRIPTION
When returning a rate limit error we must move the job from active to wait, independently of the ttl value, in case we don't move , the job will get stalled or could fail if we have maxStalledCount as 0