### PR TITLE
fix(flow): parent job cannot be replaced

### DIFF
--- a/python/bullmq/error_code.py
+++ b/python/bullmq/error_code.py
@@ -8,3 +8,4 @@ class ErrorCode(Enum):
     JobPendingDependencies = -4
     ParentJobNotExist = -5
     JobLockMismatch = -6
+    ParentJobCannotBeReplaced = -7

--- a/python/bullmq/scripts.py
+++ b/python/bullmq/scripts.py
@@ -573,6 +573,8 @@ class Scripts:
             return TypeError(f"Missing key for parent job {jobId}.{command}")
         elif code == ErrorCode.JobLockMismatch.value:
             return TypeError(f"Lock mismatch for job {jobId}. Cmd {command} from {state}")
+        elif code == ErrorCode.ParentJobCannotBeReplaced.value:
+            return TypeError(f"The parent job of job {jobId} cannot be replaced. {command}")
         else:
             return TypeError(f"Unknown code {str(code)} error for {jobId}.{command}")
 

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -446,7 +446,7 @@ export class Scripts {
         );
       case ErrorCode.ParentJobCannotBeReplaced:
         return new Error(
-          `Parent job from job ${jobId} cannot be replaced. ${command}`,
+          `The parent job of job ${jobId} cannot be replaced. ${command}`,
         );
       default:
         return new Error(`Unknown code ${code} error for ${jobId}. ${command}`);

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -444,6 +444,10 @@ export class Scripts {
         return new Error(
           `Lock mismatch for job ${jobId}. Cmd ${command} from ${state}`,
         );
+      case ErrorCode.ParentJobCannotBeReplaced:
+        return new Error(
+          `Parent job from job ${jobId} cannot be replaced. ${command}`,
+        );
       default:
         return new Error(`Unknown code ${code} error for ${jobId}. ${command}`);
     }

--- a/src/commands/addDelayedJob-6.lua
+++ b/src/commands/addDelayedJob-6.lua
@@ -81,9 +81,17 @@ else
     jobId = args[2]
     jobIdKey = args[1] .. jobId
     if rcall("EXISTS", jobIdKey) == 1 then
-        updateExistingJobsParent(parentKey, parent, parentData,
-                                 parentDependenciesKey, completedKey, jobIdKey,
-                                 jobId, timestamp)
+        local existedParentKey = rcall("HGET", jobIdKey, "parentKey")
+        if( (type(existedParentKey) == "string") and existedParentKey ~= "" then
+            if parentKey ~= nil and parentKey ~= existedParentKey
+                and (rcall("EXISTS", existedParentKey) == 1)) then
+                return -7
+            else
+                updateExistingJobsParent(parentKey, parent, parentData,
+                    parentDependenciesKey, completedKey, jobIdKey,
+                    jobId, timestamp)
+            end
+        end
         rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event",
               "duplicated", "jobId", jobId)
 

--- a/src/commands/addDelayedJob-6.lua
+++ b/src/commands/addDelayedJob-6.lua
@@ -57,6 +57,7 @@ local parentData
 -- Includes
 --- @include "includes/addDelayMarkerIfNeeded"
 --- @include "includes/getOrSetMaxEvents"
+--- @include "includes/handleDuplicatedJob"
 --- @include "includes/isQueuePaused"
 --- @include "includes/storeJob"
 --- @include "includes/updateExistingJobsParent"
@@ -77,25 +78,12 @@ if args[2] == "" then
     jobId = jobCounter
     jobIdKey = args[1] .. jobId
 else
-    -- Refactor to: handleDuplicateJob.lua
     jobId = args[2]
     jobIdKey = args[1] .. jobId
     if rcall("EXISTS", jobIdKey) == 1 then
-        local existedParentKey = rcall("HGET", jobIdKey, "parentKey")
-        if( (type(existedParentKey) == "string") and existedParentKey ~= "" then
-            if parentKey ~= nil and parentKey ~= existedParentKey
-                and (rcall("EXISTS", existedParentKey) == 1)) then
-                return -7
-            else
-                updateExistingJobsParent(parentKey, parent, parentData,
-                    parentDependenciesKey, completedKey, jobIdKey,
-                    jobId, timestamp)
-            end
-        end
-        rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event",
-              "duplicated", "jobId", jobId)
-
-        return jobId .. "" -- convert to string
+        return handleDuplicatedJob(jobIdKey, jobId, parentKey, parent,
+            parentData, parentDependenciesKey, completedKey, eventsKey,
+            maxEvents, timestamp)
     end
 end
 

--- a/src/commands/addParentJob-4.lua
+++ b/src/commands/addParentJob-4.lua
@@ -49,9 +49,10 @@ local parent = args[8]
 local parentData
 
 -- Includes
+--- @include "includes/getOrSetMaxEvents"
+--- @include "includes/handleDuplicatedJob"
 --- @include "includes/storeJob"
 --- @include "includes/updateExistingJobsParent"
---- @include "includes/getOrSetMaxEvents"
 
 if parentKey ~= nil then
     if rcall("EXISTS", parentKey) ~= 1 then return -5 end
@@ -72,13 +73,9 @@ else
     jobId = args[2]
     jobIdKey = args[1] .. jobId
     if rcall("EXISTS", jobIdKey) == 1 then
-        updateExistingJobsParent(parentKey, parent, parentData,
-                                 parentDependenciesKey, completedKey, jobIdKey,
-                                 jobId, timestamp)
-        rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event",
-              "duplicated", "jobId", jobId)
-
-        return jobId .. "" -- convert to string
+        return handleDuplicatedJob(jobIdKey, jobId, parentKey, parent,
+            parentData, parentDependenciesKey, completedKey, eventsKey,
+            maxEvents, timestamp)
     end
 end
 

--- a/src/commands/addPrioritizedJob-7.lua
+++ b/src/commands/addPrioritizedJob-7.lua
@@ -54,11 +54,12 @@ local parent = args[8]
 local parentData
 
 -- Includes
---- @include "includes/storeJob"
---- @include "includes/isQueuePaused"
 --- @include "includes/addJobWithPriority"
---- @include "includes/updateExistingJobsParent"
+--- @include "includes/storeJob"
 --- @include "includes/getOrSetMaxEvents"
+--- @include "includes/handleDuplicatedJob"
+--- @include "includes/isQueuePaused"
+--- @include "includes/updateExistingJobsParent"
 
 if parentKey ~= nil then
     if rcall("EXISTS", parentKey) ~= 1 then return -5 end
@@ -79,14 +80,9 @@ else
     jobId = args[2]
     jobIdKey = args[1] .. jobId
     if rcall("EXISTS", jobIdKey) == 1 then
-        updateExistingJobsParent(parentKey, parent, parentData,
-                                 parentDependenciesKey, completedKey, jobIdKey,
-                                 jobId, timestamp)
-
-        rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event",
-              "duplicated", "jobId", jobId)
-
-        return jobId .. "" -- convert to string
+        return handleDuplicatedJob(jobIdKey, jobId, parentKey, parent,
+            parentData, parentDependenciesKey, completedKey, eventsKey,
+            maxEvents, timestamp)
     end
 end
 

--- a/src/commands/addStandardJob-7.lua
+++ b/src/commands/addStandardJob-7.lua
@@ -61,6 +61,7 @@ local parentData
 --- @include "includes/addJobInTargetList"
 --- @include "includes/getOrSetMaxEvents"
 --- @include "includes/getTargetQueueList"
+--- @include "includes/handleDuplicatedJob"
 --- @include "includes/storeJob"
 --- @include "includes/updateExistingJobsParent"
 
@@ -84,14 +85,9 @@ else
     jobId = args[2]
     jobIdKey = args[1] .. jobId
     if rcall("EXISTS", jobIdKey) == 1 then
-        updateExistingJobsParent(parentKey, parent, parentData,
-                                 parentDependenciesKey, KEYS[5], jobIdKey,
-                                 jobId, timestamp)
-
-        rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event",
-              "duplicated", "jobId", jobId)
-
-        return jobId .. "" -- convert to string
+        return handleDuplicatedJob(jobIdKey, jobId, parentKey, parent,
+            parentData, parentDependenciesKey, KEYS[5], eventsKey,
+            maxEvents, timestamp)
     end
 end
 

--- a/src/commands/includes/handleDuplicatedJob.lua
+++ b/src/commands/includes/handleDuplicatedJob.lua
@@ -1,0 +1,26 @@
+--[[
+  Function to handle the case when job is duplicated.
+]]
+
+-- Includes
+--- @include "updateExistingJobsParent"
+
+local function handleDuplicatedJob(jobKey, jobId, currentParentKey, currentParent,
+  parentData, parentDependenciesKey, completedKey, eventsKey, maxEvents, timestamp)
+  local existedParentKey = rcall("HGET", jobKey, "parentKey")
+    
+  if not existedParentKey then
+    updateExistingJobsParent(currentParentKey, currentParent, parentData,
+      parentDependenciesKey, completedKey, jobKey,
+      jobId, timestamp)
+  else
+    if currentParentKey ~= nil and currentParentKey ~= existedParentKey
+      and (rcall("EXISTS", existedParentKey) == 1) then
+      return -7
+    end
+  end
+  rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event",
+    "duplicated", "jobId", jobId)
+
+  return jobId .. "" -- convert to string
+end

--- a/src/enums/error-code.ts
+++ b/src/enums/error-code.ts
@@ -5,4 +5,5 @@ export enum ErrorCode {
   JobPendingDependencies = -4,
   ParentJobNotExist = -5,
   JobLockMismatch = -6,
+  ParentJobCannotBeReplaced = -7,
 }

--- a/tests/test_flow.ts
+++ b/tests/test_flow.ts
@@ -1360,7 +1360,7 @@ describe('flows', () => {
             },
           ),
         ).to.be.rejectedWith(
-          `Parent job from job ${prefix}:${queueName}:wed cannot be replaced. addJob`,
+          `The parent job of job ${prefix}:${queueName}:wed cannot be replaced. addJob`,
         );
 
         await flow.close();


### PR DESCRIPTION
while adding a duplicated job, we can replace the parent job if this job had one, while replacing a parent value, we will end with an orphan parent, we must throw an error in this case