### PR TITLE
feat(worker): add support for naming workers

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -147,6 +147,11 @@ export class Job<
    */
   token?: string;
 
+  /**
+   * The worker name that is processing or processed this job.
+   */
+  processedBy?: string;
+
   protected toKey: (type: string) => string;
 
   protected discarded: boolean;
@@ -336,6 +341,10 @@ export class Job<
 
     if (json.parent) {
       job.parent = JSON.parse(json.parent);
+    }
+
+    if (json.pb) {
+      job.processedBy = json.pb;
     }
 
     return job;

--- a/src/classes/queue-events.ts
+++ b/src/classes/queue-events.ts
@@ -236,7 +236,7 @@ export class QueueEvents extends QueueBase {
         this.running = true;
         const client = await this.client;
 
-        // Planed for deprecation as it has no really a use case
+        // TODO: Planed for deprecation as it has no really a use case
         try {
           await client.client('SETNAME', this.clientName(QUEUE_EVENT_SUFFIX));
         } catch (err) {

--- a/src/classes/queue-events.ts
+++ b/src/classes/queue-events.ts
@@ -236,6 +236,7 @@ export class QueueEvents extends QueueBase {
         this.running = true;
         const client = await this.client;
 
+        // Planed for deprecation as it has no really a use case
         try {
           await client.client('SETNAME', this.clientName(QUEUE_EVENT_SUFFIX));
         } catch (err) {

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -943,7 +943,7 @@ export class Scripts {
     }
   }
 
-  async moveToActive(client: RedisClient, token: string) {
+  async moveToActive(client: RedisClient, token: string, name?: string) {
     const opts = this.queue.opts as WorkerOptions;
 
     const queueKeys = this.queue.keys;
@@ -968,6 +968,7 @@ export class Scripts {
         token,
         lockDuration: opts.lockDuration,
         limiter: opts.limiter,
+        name,
       }),
     ];
 

--- a/src/commands/includes/prepareJobForProcessing.lua
+++ b/src/commands/includes/prepareJobForProcessing.lua
@@ -29,6 +29,11 @@ local function prepareJobForProcessing(keyPrefix, rateLimiterKey, eventStreamKey
     rcall("SET", lockKey, opts['token'], "PX", opts['lockDuration'])
   end
 
+  if opts['name'] then
+    -- Set "processedBy" field to the worker name
+    rcall("HSET", jobKey, "pb", opts['name'])
+  end
+
   rcall("XADD", eventStreamKey, "*", "event", "active", "jobId", jobId, "prev", "waiting")
   rcall("HSET", jobKey, "processedOn", processedOn)
   rcall("HINCRBY", jobKey, "ats", 1)

--- a/src/interfaces/job-json.ts
+++ b/src/interfaces/job-json.ts
@@ -18,6 +18,7 @@ export interface JobJson {
   parent?: ParentKeys;
   parentKey?: string;
   repeatJobKey?: string;
+  processedBy?: string;
 }
 
 export interface JobJsonRaw {
@@ -39,4 +40,5 @@ export interface JobJsonRaw {
   rjk?: string;
   atm?: string;
   ats?: string;
+  pb?: string; // Worker name
 }

--- a/src/interfaces/worker-options.ts
+++ b/src/interfaces/worker-options.ts
@@ -15,6 +15,13 @@ export type Processor<T = any, R = any, N extends string = string> = (
 
 export interface WorkerOptions extends QueueBaseOptions {
   /**
+   * Optional worker name. The name will be stored on every job
+   * processed by this worker instance, and can be used to monitor
+   * which worker is processing or has processed a given job.
+   */
+  name?: string;
+
+  /**
    * Condition to start processor at instance creation.
    *
    * @default true

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -212,6 +212,4 @@ export const errorToJSON = (value: any): Record<string, any> => {
   return error;
 };
 
-export const WORKER_SUFFIX = '';
-
 export const QUEUE_EVENT_SUFFIX = ':qe';


### PR DESCRIPTION
This PR adds a new optional property to jobs, processedBy, as well as the possibility to pass a unique name to the workers. This allows to create a mapping between processed jobs and the workers that actually processed them. Furthermore, a new "rawname" property is added to the data structure returned by ```getWorkers``` that includes the worker name.
