### PR TITLE
feat(worker): add support for conditional connection closure

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -807,7 +807,7 @@ export class Worker<
    *
    * @returns Promise that resolves when the worker has been closed.
    */
-  close(force = false): Promise<void> {
+  close(force = false, closeConnection = true): Promise<void> {
     if (this.closing) {
       return this.closing;
     }
@@ -841,8 +841,8 @@ export class Worker<
         })
         .finally(() => clearTimeout(this.extendLocksTimer))
         .finally(() => clearTimeout(this.stalledCheckTimer))
-        .finally(() => client && client.disconnect())
-        .finally(() => this.connection.close())
+        .finally(() => closeConnection && client && client.disconnect())
+        .finally(() => closeConnection && this.connection.close())
         .finally(() => this.emit('closed'));
       this.closed = true;
     })();


### PR DESCRIPTION
fixes #2437

In case application manages lifecycle of Redis connection itself, this provides an option of opting out of BullMQ automatic connection close.