### PR TITLE
perf(worker.ts): lowering the threshold at which blocking redis operation is used to fetch next job

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -603,8 +603,8 @@ export class Worker<
           0,
         );
 
-        // Blocking for less than 50ms is useless.
-        if (blockTimeout > 0.05) {
+        // Blocking for less than 10ms is useless.
+        if (blockTimeout > this.opts.settings?.blockTimeoutThreshold ?? 0.01) {
           blockTimeout = this.blockingConnection.capabilities.canDoubleTimeout
             ? blockTimeout
             : Math.ceil(blockTimeout);

--- a/src/interfaces/advanced-options.ts
+++ b/src/interfaces/advanced-options.ts
@@ -18,4 +18,14 @@ export interface AdvancedOptions extends AdvancedRepeatOptions {
    * A custom backoff strategy.
    */
   backoffStrategy?: BackoffStrategy;
+
+  /**
+   * Minimum blocking operation timeout in seconds used when fetching next job.
+   * If timeout would be smaller than this defined threshold - because of next
+   * delayed job would be available to be processed sooner - blocking operation
+   * will not be used.
+   *
+   * @defaultValue 0.01
+   */
+  blockTimeoutThreshold?: number;
 }


### PR DESCRIPTION
With constant delayed jobs in highly used queue (mostly processing at least one job all the time), it can happen calculated `blockTimeout` is mostly smaller then current hardcoded threshold of 50ms.

If this happens, worker run loop ends up looping with no awaits, causing high CPU usage on Redis and runtime itself.

Lowering default to 10ms solved the problem for our use case. This PR also exposes this setting as advanced setting if further tweaks are needed.