### PR TITLE
fix(job): stack trace limit (#2487)

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -1231,7 +1231,7 @@ export class Job<
     if (err?.stack) {
       this.stacktrace.push(err.stack);
       if (this.opts.stackTraceLimit) {
-        this.stacktrace = this.stacktrace.slice(0, this.opts.stackTraceLimit);
+        this.stacktrace = this.stacktrace.slice(-this.opts.stackTraceLimit);
       }
     }
 

--- a/tests/test_job.ts
+++ b/tests/test_job.ts
@@ -810,11 +810,18 @@ describe('Job', function () {
       const job = (await worker.getNextJob(token)) as Job;
       const isFailed = await job.isFailed();
       expect(isFailed).to.be.equal(false);
-      await job.moveToFailed(new Error('test error'), '0', true);
+      // first time failed.
+      await job.moveToFailed(new Error('failed once'), '0', true);
       const isFailed2 = await job.isFailed();
+      const stackTrace1 = job.stacktrace[0];
       expect(isFailed2).to.be.equal(true);
       expect(job.stacktrace).not.be.equal(null);
       expect(job.stacktrace.length).to.be.equal(stackTraceLimit);
+      // second time failed.
+      await job.moveToFailed(new Error('failed twice'), '0', true);
+      const stackTrace2 = job.stacktrace[0];
+      expect(job.stacktrace.length).to.be.equal(stackTraceLimit);
+      expect(stackTrace1).not.be.equal(stackTrace2);
       await worker.close();
     });
 

--- a/tests/test_job.ts
+++ b/tests/test_job.ts
@@ -803,24 +803,26 @@ describe('Job', function () {
       const stackTraceLimit = 1;
       await Job.create(
         queue,
-        'test',
+        'stackTraceLimit',
         { foo: 'bar' },
-        { stackTraceLimit: stackTraceLimit },
+        { stackTraceLimit: stackTraceLimit, attempts: 2 },
       );
       const job = (await worker.getNextJob(token)) as Job;
       const isFailed = await job.isFailed();
       expect(isFailed).to.be.equal(false);
       // first time failed.
-      await job.moveToFailed(new Error('failed once'), '0', true);
+      await job.moveToFailed(new Error('failed once'), '0', false);
       const isFailed2 = await job.isFailed();
       const stackTrace1 = job.stacktrace[0];
       expect(isFailed2).to.be.equal(true);
       expect(job.stacktrace).not.be.equal(null);
       expect(job.stacktrace.length).to.be.equal(stackTraceLimit);
       // second time failed.
-      await job.moveToFailed(new Error('failed twice'), '0', true);
-      const stackTrace2 = job.stacktrace[0];
-      expect(job.stacktrace.length).to.be.equal(stackTraceLimit);
+      const again = (await worker.getNextJob(token)) as Job;
+      await again.moveToFailed(new Error('failed twice'), '0', false);
+      const stackTrace2 = again.stacktrace[0];
+      expect(again.name).to.be.equal(job.name);
+      expect(again.stacktrace.length).to.be.equal(stackTraceLimit);
       expect(stackTrace1).not.be.equal(stackTrace2);
       await worker.close();
     });

--- a/tests/test_job.ts
+++ b/tests/test_job.ts
@@ -803,7 +803,7 @@ describe('Job', function () {
       const stackTraceLimit = 1;
       await Job.create(
         queue,
-        'stackTraceLimit',
+        'test',
         { foo: 'bar' },
         { stackTraceLimit: stackTraceLimit, attempts: 2 },
       );
@@ -811,16 +811,18 @@ describe('Job', function () {
       const isFailed = await job.isFailed();
       expect(isFailed).to.be.equal(false);
       // first time failed.
-      await job.moveToFailed(new Error('failed once'), '0', false);
-      const isFailed2 = await job.isFailed();
+      await job.moveToFailed(new Error('failed once'), '0', true);
+      const isFailed1 = await job.isFailed();
       const stackTrace1 = job.stacktrace[0];
-      expect(isFailed2).to.be.equal(true);
+      expect(isFailed1).to.be.false;
       expect(job.stacktrace).not.be.equal(null);
       expect(job.stacktrace.length).to.be.equal(stackTraceLimit);
       // second time failed.
       const again = (await worker.getNextJob(token)) as Job;
-      await again.moveToFailed(new Error('failed twice'), '0', false);
+      await again.moveToFailed(new Error('failed twice'), '0', true);
+      const isFailed2 = await again.isFailed();
       const stackTrace2 = again.stacktrace[0];
+      expect(isFailed2).to.be.true;
       expect(again.name).to.be.equal(job.name);
       expect(again.stacktrace.length).to.be.equal(stackTraceLimit);
       expect(stackTrace1).not.be.equal(stackTrace2);


### PR DESCRIPTION
Changed the array slice for the stacktrace.

Resolution is verified with our BullMQ implementation (via npm link).