### PR TITLE
feat(python): support reusable redis connections

### DIFF
--- a/python/bullmq/redis_connection.py
+++ b/python/bullmq/redis_connection.py
@@ -21,12 +21,14 @@ class RedisConnection:
         "canDoubleTimeout": False
     }
 
-    def __init__(self, redisOpts: dict | str = {}):
+    def __init__(self, redisOpts: dict | str | redis.Redis = {}):
         self.version = None
         retry = Retry(ExponentialBackoff(), 3)
         retry_errors = [BusyLoadingError, ConnectionError, TimeoutError]
 
-        if isinstance(redisOpts, dict):
+        if isinstance(redisOpts, redis.Redis):
+            self.conn = redisOpts
+        elif isinstance(redisOpts, dict):
             defaultOpts = {
                 "host": "localhost",
                 "port": 6379,

--- a/python/bullmq/types/queue_options.py
+++ b/python/bullmq/types/queue_options.py
@@ -1,5 +1,6 @@
 
 from typing import TypedDict, Any
+import redis.asyncio as redis
 
 
 class QueueBaseOptions(TypedDict, total=False):
@@ -8,7 +9,7 @@ class QueueBaseOptions(TypedDict, total=False):
     """
 
     prefix: str
-    connection: dict[str, Any]
+    connection: dict[str, Any] | redis.Redis
     """
     Prefix for all queue keys.
     """

--- a/python/bullmq/types/worker_options.py
+++ b/python/bullmq/types/worker_options.py
@@ -1,5 +1,6 @@
 
 from typing import TypedDict, Any
+import redis.asyncio as redis
 
 
 class WorkerOptions(TypedDict, total=False):
@@ -50,7 +51,7 @@ class WorkerOptions(TypedDict, total=False):
     Prefix for all queue keys.
     """
 
-    connection: dict[str, Any]
+    connection: dict[str, Any] | redis.Redis
     """
     Options for connecting to a Redis instance.
     """

--- a/python/tests/queue_tests.py
+++ b/python/tests/queue_tests.py
@@ -5,6 +5,7 @@ https://bbc.github.io/cloudfit-public-docs/asyncio/testing.html
 """
 
 from asyncio import Future
+import redis.asyncio as redis
 from bullmq import Queue, Worker, Job
 from uuid import uuid4
 
@@ -419,6 +420,14 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
         job = await Job.fromId(queue, job.id)
         self.assertIsNone(job)
 
+        await queue.close()
+
+    async def test_reusable_redis(self):
+        conn = redis.Redis(decode_responses=True, host="localhost", port="6379", db=0)
+        queue = Queue(queueName, {"connection": conn})
+        job = await queue.add("test-job", {"foo": "bar"}, {})
+
+        self.assertEqual(job.id, "1")
         await queue.close()
 
 if __name__ == '__main__':

--- a/python/tests/worker_tests.py
+++ b/python/tests/worker_tests.py
@@ -5,6 +5,7 @@ https://bbc.github.io/cloudfit-public-docs/asyncio/testing.html
 """
 
 from asyncio import Future
+import redis.asyncio as redis
 from bullmq import Queue, Worker, Job, WaitingChildrenError
 from uuid import uuid4
 from enum import Enum
@@ -394,6 +395,34 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
 
         await queue.close()
         await worker.close()
+
+    async def test_reusable_redis(self):
+        conn = redis.Redis(decode_responses=True, host="localhost", port="6379", db=0)
+        queue = Queue(queueName, {"connection": conn})
+        data = {"foo": "bar"}
+        job = await queue.add("test-job", data, {"removeOnComplete": False})
+
+        async def process(job: Job, token: str):
+            print("Processing job", job)
+            return "done"
+
+        worker = Worker(queueName, process, {"connection": conn})
+
+        processing = Future()
+        worker.on("completed", lambda job, result: processing.set_result(None))
+
+        await processing
+
+        completedJob = await Job.fromId(queue, job.id)
+
+        self.assertEqual(completedJob.id, job.id)
+        self.assertEqual(completedJob.attemptsMade, 1)
+        self.assertEqual(completedJob.data, data)
+        self.assertEqual(completedJob.returnvalue, "done")
+        self.assertNotEqual(completedJob.finishedOn, None)
+
+        await worker.close(force=True)
+        await queue.close()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Like `BullMQ` for typescript, support reusing the same redis connection. This is helpful in environments with caps on connection count.