### PR TITLE
fix(worker): use 0.002 as minimum timeout for redis version lower than 7.0.8

### DIFF
--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -24,6 +24,7 @@ const deprecationMessage =
 
 interface RedisCapabilities {
   canDoubleTimeout: boolean;
+  canBlockFor1Ms: boolean;
 }
 
 export interface RawCommand {
@@ -39,6 +40,7 @@ export class RedisConnection extends EventEmitter {
   closing: boolean;
   capabilities: RedisCapabilities = {
     canDoubleTimeout: false,
+    canBlockFor1Ms: true,
   };
 
   status: 'initializing' | 'ready' | 'closing' | 'closed' = 'initializing';
@@ -251,6 +253,7 @@ export class RedisConnection extends EventEmitter {
 
       this.capabilities = {
         canDoubleTimeout: !isRedisVersionLowerThan(this.version, '6.0.0'),
+        canBlockFor1Ms: !isRedisVersionLowerThan(this.version, '7.0.8'),
       };
 
       this.status = 'ready';

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -687,7 +687,6 @@ export class Worker<
   private updateDelays(limitUntil = 0, delayUntil = 0) {
     this.limitUntil = Math.max(limitUntil, 0) || 0;
     this.blockUntil = Math.max(delayUntil, 0) || 0;
-    console.log(this.limitUntil, this.blockUntil);
   }
 
   protected async nextJobFromJobData(

--- a/tests/test_queue.ts
+++ b/tests/test_queue.ts
@@ -387,6 +387,15 @@ describe('queues', function () {
     });
   });
 
+  describe('when 0.002 is used as blocktimeout', () => {
+    it('should not block forever', async () => {
+      const client = await queue.client;
+      await client.bzpopmin(`key`, 0.002);
+
+      expect(true).to.be.true;
+    });
+  });
+
   describe('.removeDeprecatedPriorityKey', () => {
     it('removes old priority key', async () => {
       const client = await queue.client;

--- a/tests/test_queue.ts
+++ b/tests/test_queue.ts
@@ -387,15 +387,6 @@ describe('queues', function () {
     });
   });
 
-  describe('when 0.002 is used as blocktimeout', () => {
-    it('should not block forever', async () => {
-      const client = await queue.client;
-      await client.bzpopmin(`key`, 0.002);
-
-      expect(true).to.be.true;
-    });
-  });
-
   describe('.removeDeprecatedPriorityKey', () => {
     it('removes old priority key', async () => {
       const client = await queue.client;

--- a/tests/test_worker.ts
+++ b/tests/test_worker.ts
@@ -816,6 +816,25 @@ describe('workers', function () {
     await worker.close();
   });
 
+  describe('when 0.002 is used as blocktimeout', () => {
+    it('should not block forever', async () => {
+      const worker = new Worker(queueName, async () => {}, {
+        connection,
+        prefix,
+      });
+      await worker.waitUntilReady();
+      const client = await worker.client;
+      if (isRedisVersionLowerThan(worker.redisVersion, '7.0.8')) {
+        await client.bzpopmin(`key`, 0.002);
+      } else {
+        await client.bzpopmin(`key`, 0.001);
+      }
+
+      expect(true).to.be.true;
+      await worker.close();
+    });
+  });
+
   describe('when closing a worker', () => {
     it('process a job that throws an exception after worker close', async () => {
       const jobError = new Error('Job Failed');


### PR DESCRIPTION
as this fix https://github.com/redis/redis/pull/11688 was introduced since version 7.0.8, redis users using a lower version are having issues where bzpopmin command blocks forever, this is happening because passing 0.001 is the same as using 0.
Fixes https://github.com/taskforcesh/bullmq/issues/2466