### PR TITLE
fix(worker): return minimumBlockTimeout depending on redis version (python)

### DIFF
--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -170,7 +170,7 @@ class Worker(EventEmitter):
             block_timeout = None
             block_delay = block_until - int(time.time() * 1000)
             if block_delay < self.minimumBlockTimeout * 1000:
-                block_timeout = minimum_block_timeout
+                return self.minimumBlockTimeout
             else:
                 block_timeout = block_delay / 1000
             # We restrict the maximum block timeout to 10 second to avoid

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -660,7 +660,7 @@ export class Worker<
       const blockDelay = blockUntil - Date.now();
       // when we reach the time to get new jobs
       if (blockDelay < this.minimumBlockTimeout * 1000) {
-        blockTimeout = minimumBlockTimeout;
+        return this.minimumBlockTimeout;
       } else {
         blockTimeout = blockDelay / 1000;
       }


### PR DESCRIPTION
ref https://github.com/taskforcesh/bullmq/issues/2466
there was an issue when resolving merge conflicts from https://github.com/taskforcesh/bullmq/pull/2515/commits/917ff96d49b24ae3891005934a7d47b72c67cef1