### PR TITLE
feat(worker): add getNextRateLimitTTLPerName method

### DIFF
--- a/src/commands/includes/removeLock.lua
+++ b/src/commands/includes/removeLock.lua
@@ -1,3 +1,6 @@
+--[[
+  Function to remove lock.
+]]
 local function removeLock(jobKey, stalledKey, token, jobId)
   if token ~= "0" then
     local lockKey = jobKey .. ':lock'


### PR DESCRIPTION
sometimes there are more than one rate limit rule that jobs can reach, for that purpose we can move those jobs to delayed instead of rate limiting the entire queue. But how we can determine the most accurate ttl for those jobs, this is where getNextRateLimitTTLPerName can be used 