### PR TITLE
perf(worker): do not call bzpopmin when blockDelay is lower or equal 0

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -621,6 +621,10 @@ will never work with more accuracy than 1ms. */
       if (!this.closing) {
         let blockTimeout = this.getBlockTimeout(blockUntil);
 
+        if (blockTimeout <= 0) {
+          return 0;
+        }
+
         blockTimeout = this.blockingConnection.capabilities.canDoubleTimeout
           ? blockTimeout
           : Math.ceil(blockTimeout);
@@ -658,7 +662,9 @@ will never work with more accuracy than 1ms. */
     if (blockUntil) {
       const blockDelay = blockUntil - Date.now();
       // when we reach the time to get new jobs
-      if (blockDelay < this.minimumBlockTimeout * 1000) {
+      if (blockDelay <= 0) {
+        return blockDelay;
+      } else if (blockDelay < this.minimumBlockTimeout * 1000) {
         return this.minimumBlockTimeout;
       } else {
         // We restrict the maximum block timeout to 10 second to avoid

--- a/tests/test_worker.ts
+++ b/tests/test_worker.ts
@@ -949,7 +949,7 @@ describe('workers', function () {
 
     describe('when blockUntil is greater than 0', () => {
       describe('when blockUntil is lower than date now value', () => {
-        it('returns minimumBlockTimeout', async () => {
+        it('returns blockDelay value lower or equal 0', async () => {
           const worker = new Worker(queueName, async () => {}, {
             connection,
             prefix,
@@ -957,15 +957,9 @@ describe('workers', function () {
           });
           await worker.waitUntilReady();
 
-          if (isRedisVersionLowerThan(worker.redisVersion, '7.0.8')) {
-            expect(worker['getBlockTimeout'](Date.now() - 1)).to.be.equal(
-              0.002,
-            );
-          } else {
-            expect(worker['getBlockTimeout'](Date.now() - 1)).to.be.equal(
-              0.001,
-            );
-          }
+          expect(
+            worker['getBlockTimeout'](Date.now() - 1),
+          ).to.be.lessThanOrEqual(0);
           await worker.close();
         });
       });


### PR DESCRIPTION
it'll call directly moveToActive script
ref https://github.com/taskforcesh/bullmq/issues/2466