### PR TITLE
fix(python): increase redis retry strategy backoff

### DIFF
--- a/python/bullmq/redis_connection.py
+++ b/python/bullmq/redis_connection.py
@@ -24,7 +24,7 @@ class RedisConnection:
 
     def __init__(self, redisOpts: dict | str | redis.Redis = {}):
         self.version = None
-        retry = Retry(ExponentialBackoff(), 3)
+        retry = Retry(ExponentialBackoff(20, 1), 20)
         retry_errors = [BusyLoadingError, ConnectionError, TimeoutError]
 
         if isinstance(redisOpts, redis.Redis):

--- a/python/bullmq/redis_connection.py
+++ b/python/bullmq/redis_connection.py
@@ -24,7 +24,7 @@ class RedisConnection:
 
     def __init__(self, redisOpts: dict | str | redis.Redis = {}):
         self.version = None
-        retry = Retry(ExponentialBackoff(20, 1), 20)
+        retry = Retry(ExponentialBackoff(cap=20, base=1), 20)
         retry_errors = [BusyLoadingError, ConnectionError, TimeoutError]
 
         if isinstance(redisOpts, redis.Redis):


### PR DESCRIPTION
As you can see in the [redis-py docs](https://redis.readthedocs.io/en/stable/backoff.html#redis.backoff.ExponentialBackoff) the `ExponentialBackoff` starts with 8**ms** and ramps up to only 512**ms**. Paired with only three retries this makes it fail very quickly.

I increased the values to start with 1**s** and ramp up to 20**s**. Also, increased the retries to 20. I think this brings it closer to the JavaScript library.

Related to my issue: #2542 