### PR TITLE
fix(worker): make sure clearTimeout is always called after bzpopmin

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -617,6 +617,7 @@ will never work with more accuracy than 1ms. */
       return Infinity;
     }
 
+    let timeout: NodeJS.Timeout;
     try {
       if (!this.closing) {
         let blockTimeout = this.getBlockTimeout(blockUntil);
@@ -629,7 +630,7 @@ will never work with more accuracy than 1ms. */
           // We cannot trust that the blocking connection stays blocking forever
           // due to issues in Redis and IORedis, so we will reconnect if we
           // don't get a response in the expected time.
-          const timeout = setTimeout(async () => {
+          timeout = setTimeout(async () => {
             await this.blockingConnection.disconnect();
             await this.blockingConnection.reconnect();
           }, blockTimeout * 1000 + 1000);
@@ -639,7 +640,6 @@ will never work with more accuracy than 1ms. */
           // Markers should only be used for un-blocking, so we will handle them in this
           // function only.
           const result = await bclient.bzpopmin(this.keys.marker, blockTimeout);
-          clearTimeout(timeout);
 
           if (result) {
             const [_key, member, score] = result;
@@ -659,6 +659,8 @@ will never work with more accuracy than 1ms. */
       if (!this.closing) {
         await this.delay();
       }
+    } finally {
+      clearTimeout(timeout);
     }
     return Infinity;
   }


### PR DESCRIPTION
Potentially fix for https://github.com/taskforcesh/bullmq/issues/2552