### PR TITLE
fix(python): use async Retry

### DIFF
--- a/python/bullmq/redis_connection.py
+++ b/python/bullmq/redis_connection.py
@@ -1,6 +1,6 @@
 import redis.asyncio as redis
 from redis.backoff import ExponentialBackoff
-from redis.retry import Retry
+from redis.asyncio.retry import Retry
 from redis.exceptions import (
    BusyLoadingError,
    ConnectionError,


### PR DESCRIPTION
After a lot of trial and error on why connection errors don't seem to get retried (#2542), I found this to be the culprit.

You can verify it with the following script. Start running it, then kill your redis instance.
- With `redis.asyncio.retry` it will not crash and restart pinging when redis comes back
- With `redis.retry` it will crash

```python
import os
import asyncio
import redis.asyncio as aioredis
from redis.backoff import ExponentialBackoff
# switch the following lines to test the behavior difference
# from redis.retry import Retry
from redis.asyncio.retry import Retry

from redis.exceptions import (BusyLoadingError, ConnectionError, TimeoutError)

retry = Retry(ExponentialBackoff(cap=20, base=1), 20)
retry_errors = [BusyLoadingError, ConnectionError, TimeoutError]
redis_connection = aioredis.from_url(os.environ.get('REDIS_URI', 'redis://localhost:6379'),
                                  decode_responses=True,
                                  retry=retry,
                                  retry_on_error=retry_errors,
                                  health_check_interval=30)

async def run():
    while True:
        print(await redis_connection.ping())
        await asyncio.sleep(1)

asyncio.run(run())
```

Unfortunately, there's no proper type checking for `kwargs` in `redis.from_url`. I only found out about the difference by playing with the `Redis` constructor and there it yelled at me that the types for `retry` are incompatible.