### PR TITLE
feat(python): clarify/simplify test setup

### DIFF
--- a/python/copy_scripts.sh
+++ b/python/copy_scripts.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cp -r ../rawScripts/. ./bullmq/commands/ || echo "Raw scripts are not available. Create them by running ' yarn install'  and/or ' yarn generate:raw:scripts'"

--- a/python/flush_redis.py
+++ b/python/flush_redis.py
@@ -1,0 +1,11 @@
+import asyncio
+
+from bullmq.redis_connection import RedisConnection
+
+
+async def flush():
+    await RedisConnection().conn.flushall()
+
+
+if __name__ == '__main__':
+    asyncio.run(flush())

--- a/python/run_tests.sh
+++ b/python/run_tests.sh
@@ -1,8 +1,3 @@
 #!/bin/bash
-redis-cli flushall
-python3 -m unittest -v tests.bulk_tests
-python3 -m unittest -v tests.delay_tests
-python3 -m unittest -v tests.flow_tests
-python3 -m unittest -v tests.job_tests
-python3 -m unittest -v tests.queue_tests
-python3 -m unittest -v tests.worker_tests
+python flush_redis.py
+python -m unittest discover -s tests/ -p "*_tests.py" -t .


### PR DESCRIPTION
- Adds script to copy rawScripts to be used by the python package
- Simplify setting up the python tests
- `redis-cli` not needed in order to cleanup `redis` before starting tests