### PR TITLE
feat(python): makes `RedisConnection`'s close method async, use `aclose` when possible

### DIFF
--- a/python/bullmq/flow_producer.py
+++ b/python/bullmq/flow_producer.py
@@ -134,8 +134,8 @@ class FlowProducer:
 
         return result
 
-    def close(self):
+    async def close(self):
         """
         Close the flow instance.
         """
-        return self.redisConnection.close()
+        return await self.redisConnection.close()

--- a/python/bullmq/queue.py
+++ b/python/bullmq/queue.py
@@ -308,11 +308,11 @@ class Queue:
             'waiting-children'
         ]
 
-    def close(self):
+    async def close(self):
         """
         Close the queue instance.
         """
-        return self.redisConnection.close()
+        return await self.redisConnection.close()
 
     def remove(self, job_id: str, opts: dict = {}):
         return self.scripts.remove(job_id, opts.get("removeChildren", True))

--- a/python/bullmq/redis_connection.py
+++ b/python/bullmq/redis_connection.py
@@ -1,6 +1,3 @@
-import re
-
-import redis as _redis
 import redis.asyncio as redis
 from redis.backoff import ExponentialBackoff
 from redis.asyncio.retry import Retry

--- a/python/bullmq/redis_connection.py
+++ b/python/bullmq/redis_connection.py
@@ -1,3 +1,6 @@
+import re
+
+import redis as _redis
 import redis.asyncio as redis
 from redis.backoff import ExponentialBackoff
 from redis.asyncio.retry import Retry
@@ -50,11 +53,14 @@ class RedisConnection:
         """
         return self.conn.disconnect()
 
-    def close(self):
+    async def close(self):
         """
         Close the connection
         """
-        return self.conn.close()
+        try:
+            return await self.conn.aclose()
+        except AttributeError:
+            return self.conn.close()
 
     async def getRedisVersion(self):
         if self.version is not None:


### PR DESCRIPTION
`redis.asyncio.client.Redis.close` has been deprecated in Version `5.0.1` of `redis`. Therefore, `RedisConnection.close` now uses `redis.asyncio.client.Redis.aclose` whenever possible. To ensure backwards compatibility, `close` is still used if `aclose` is not available. 

More importantly, `self.conn.aclose()` will be awaited (resulting in `RedisConnection.close` needing to be async). In fact, this fixes `RuntimeError: Event loop stopped before Future completed.` errors I get in certain situations when trying to gracefully stop a worker by running `worker.close()`.