### PR TITLE
fix(worker): Ensure DelayedError is checked for for Sandboxed Processors

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -760,7 +760,7 @@ will never work with more accuracy than 1ms. */
 
           if (
             err instanceof DelayedError ||
-            err.message == 'DelayedError' ||
+            err.name == 'DelayedError' ||
             err instanceof WaitingChildrenError ||
             err.name == 'WaitingChildrenError'
           ) {


### PR DESCRIPTION
Use of .message rather than .name (introduced in https://github.com/taskforcesh/bullmq/commit/4c4559b3c678313b3727c9781a6d3f963bcfda4e) causes Sandboxed job processes to not correctly check for this error. It results in 'Missing lock for job 2. failed'.

Also created issue for this: https://github.com/taskforcesh/bullmq/issues/2566

fixes #2566