### PR TITLE
fix: extendlock,createbulk use pipeline no multi command

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -256,10 +256,10 @@ export class Job<
         new this<T, R, N>(queue, job.name, job.data, job.opts, job.opts?.jobId),
     );
 
-    const multi = client.multi();
+    const pipeline = client.pipeline();
 
     for (const job of jobInstances) {
-      job.addJob(<RedisClient>(multi as unknown), {
+      job.addJob(<RedisClient>(pipeline as unknown), {
         parentKey: job.parentKey,
         parentDependenciesKey: job.parentKey
           ? `${job.parentKey}:dependencies`
@@ -267,7 +267,7 @@ export class Job<
       });
     }
 
-    const results = (await multi.exec()) as [null | Error, string][];
+    const results = (await pipeline.exec()) as [null | Error, string][];
     for (let index = 0; index < results.length; ++index) {
       const [err, id] = results[index];
       if (err) {

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -1004,16 +1004,16 @@ will never work with more accuracy than 1ms. */
 
   protected async extendLocks(jobs: Job[]) {
     try {
-      const multi = (await this.client).multi();
+      const pipeline = (await this.client).pipeline();
       for (const job of jobs) {
         await this.scripts.extendLock(
           job.id,
           job.token,
           this.opts.lockDuration,
-          multi,
+          pipeline,
         );
       }
-      const result = (await multi.exec()) as [Error, string][];
+      const result = (await pipeline.exec()) as [Error, string][];
 
       for (const [err, jobId] of result) {
         if (err) {


### PR DESCRIPTION
client.multi() creates a transaction of multiple commands (all commands to exec call), to ensure atomicity of multiple commands.
As extendlock and createbulk do not require atomicity for multiple commands pipeline can be used to reduce the round trip.