### PR TITLE
fix(worker): properly cancel blocking command during disconnections

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -631,8 +631,7 @@ will never work with more accuracy than 1ms. */
           // due to issues in Redis and IORedis, so we will reconnect if we
           // don't get a response in the expected time.
           timeout = setTimeout(async () => {
-            await this.blockingConnection.disconnect();
-            await this.blockingConnection.reconnect();
+            bclient.disconnect(!this.closing);
           }, blockTimeout * 1000 + 1000);
 
           this.updateDelays(); // reset delays to avoid reusing same values in next iteration


### PR DESCRIPTION
The custom code for performing a disconnection and reconnection was proven to cause problems, whereas the IORedis builtin worked properly in all the scenarios that we know of.  This should fix issue #2466 