### PR TITLE
Fix Redis config typo in going-to-production.md

### DIFF
--- a/docs/gitbook/guide/going-to-production.md
+++ b/docs/gitbook/guide/going-to-production.md
@@ -10,7 +10,7 @@ Even though persistence is very fast, it will have some effect on performance, s
 
 ### Max memory policy
 
-Redis is used quite often as a cache, meaning that it will remove keys according to some defined policy when it reaches several levels of memory consumption. BullMQ on the other hand cannot work properly if Redis evicts keys arbitrarily. **Therefore is very important to configure the `maxmemory` setting to `noeviction`.** This is the **only** setting that guarantees the correct behavior of the queues.
+Redis is used quite often as a cache, meaning that it will remove keys according to some defined policy when it reaches several levels of memory consumption. BullMQ on the other hand cannot work properly if Redis evicts keys arbitrarily. **Therefore is very important to configure the `maxmemory-policy` setting to `noeviction`.** This is the **only** setting that guarantees the correct behavior of the queues.
 
 ### Automatic reconnections
 


### PR DESCRIPTION
Fix typo - change `maxmemory` to `maxmemory-policy` which is the correct configuration that should be referenced.


See docs:
> The exact behavior Redis follows when the maxmemory limit is reached is configured using the maxmemory-policy configuration directive.

https://redis.io/docs/latest/develop/reference/eviction/