### PR TITLE
feat(sandbox): add getChildrenValues method

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -20,6 +20,7 @@ import {
   JobJsonSandbox,
   MinimalQueue,
   RedisJobOptions,
+  ChildrenValues,
 } from '../types';
 import {
   errorObject,
@@ -826,7 +827,7 @@ export class Job<
    *
    * @returns Object mapping children job keys with their values.
    */
-  async getChildrenValues<CT = any>(): Promise<{ [jobKey: string]: CT }> {
+  async getChildrenValues<CT = any>(): Promise<ChildrenValues<CT>> {
     const client = await this.queue.client;
 
     const result = (await client.hgetall(
@@ -843,7 +844,7 @@ export class Job<
    *
    * @returns Object mapping children job keys with their failure values.
    */
-  async getFailedChildrenValues(): Promise<{ [jobKey: string]: string }> {
+  async getFailedChildrenValues(): Promise<ChildrenValues<string>> {
     const client = await this.queue.client;
 
     return client.hgetall(this.toKey(`${this.id}:failed`));

--- a/src/classes/sandbox.ts
+++ b/src/classes/sandbox.ts
@@ -12,9 +12,10 @@ const sandbox = <T, R, N extends string>(
     let msgHandler: any;
     let exitHandler: any;
 
+    const childrenValues = await job.getChildrenValues();
     await child.send({
       cmd: ChildCommand.Start,
-      job: job.asJSONSandbox(),
+      job: { ...job.asJSONSandbox(), childrenValues },
       token,
     });
 

--- a/src/interfaces/sandboxed-job.ts
+++ b/src/interfaces/sandboxed-job.ts
@@ -1,4 +1,4 @@
-import { JobJsonSandbox, JobsOptions } from '../types';
+import { ChildrenValues, JobJsonSandbox, JobsOptions } from '../types';
 
 /**
  * @see {@link https://docs.bullmq.io/guide/workers/sandboxed-processors}
@@ -11,5 +11,6 @@ export interface SandboxedJob<T = any, R = any>
   log: (row: any) => void;
   updateData: (data: any) => Promise<void>;
   updateProgress: (value: object | number) => Promise<void>;
+  getChildrenValues: <CT = any>() => ChildrenValues<CT>;
   returnValue: R;
 }

--- a/src/types/children-values.ts
+++ b/src/types/children-values.ts
@@ -1,0 +1,1 @@
+export type ChildrenValues<T = any> = { [jobKey: string]: T };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,3 +5,4 @@ export * from './job-json-sandbox';
 export * from './job-options';
 export * from './job-type';
 export * from './repeat-strategy';
+export * from './children-values';

--- a/src/types/job-json-sandbox.ts
+++ b/src/types/job-json-sandbox.ts
@@ -1,6 +1,12 @@
-import { JobJson, ParentKeys } from '../interfaces';
+import { JobJson } from '../interfaces';
+import { ChildrenValues } from './children-values';
 
 export type JobJsonSandbox = JobJson & {
   queueName: string;
   prefix: string;
+};
+
+// Maybe this is unnecessary? - Also, this is not a good name :(
+export type JobJsonSandBoxWithChildrenValues<T = any> = JobJsonSandbox & {
+  childrenValues: ChildrenValues<T>;
 };

--- a/tests/fixtures/fixture_processor_sandbox_getChildrenValues_child_1.js
+++ b/tests/fixtures/fixture_processor_sandbox_getChildrenValues_child_1.js
@@ -1,0 +1,9 @@
+/**
+ * A processor file to be used in tests.
+ *
+ */
+'use strict';
+
+module.exports = function (job) {
+  return { bar: 'oof' };
+};

--- a/tests/fixtures/fixture_processor_sandbox_getChildrenValues_child_2.js
+++ b/tests/fixtures/fixture_processor_sandbox_getChildrenValues_child_2.js
@@ -1,0 +1,9 @@
+/**
+ * A processor file to be used in tests.
+ *
+ */
+'use strict';
+
+module.exports = function (job) {
+  return { foo: 'bar' };
+};

--- a/tests/fixtures/fixture_processor_sandbox_getChildrenValues_parent.js
+++ b/tests/fixtures/fixture_processor_sandbox_getChildrenValues_parent.js
@@ -1,0 +1,9 @@
+/**
+ * A processor file to be used in tests.
+ *
+ */
+'use strict';
+
+module.exports = async function (job) {
+  return job.getChildrenValues();
+};


### PR DESCRIPTION
right before starting a child, get and pass children values along side other job data. This should be okay as the parent job runs only after all children have finished. We then use this data to implement `getChildrenValues` function for sanboxed jobs.

"fix  #1306", "fix #753".