### PR TITLE
fix(worker): get dirname by fileURLToPath

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 import { Redis } from 'ioredis';
 import * as path from 'path';
 import { v4 } from 'uuid';
@@ -260,7 +260,7 @@ export class Worker<
         }
 
         // Separate paths so that bundling tools can resolve dependencies easier
-        const dirname = path.dirname(module.filename || __filename);
+        const dirname = path.dirname(fileURLToPath(import.meta.url) || __filename);
         const workerThreadsMainFile = path.join(dirname, 'main-worker.js');
         const spawnProcessMainFile = path.join(dirname, 'main.js');
 


### PR DESCRIPTION
@roggervalf tried to fix an issue with running sandboxed jobs in ESM environments by using `module.filename` (see https://github.com/taskforcesh/bullmq/pull/2296), but `module.filename` returns undefined and main.js path cannot be resolved.

Changing to `fileURLToPath(import.meta.url)` fixes the issue.

Context: We're trying to run sandboxed jobs with Next.js and getting the following error:

```zsh
ENOENT: no such file or directory, stat '/xxx/nextjs/dist/cjs/classes/main.js'
    at Object.statSync (node:fs:1658:25)
    at new Worker (webpack-internal:///(instrument)/./node_modules/bullmq/dist/esm/classes/worker.js:114:53)
    at emailWorker (webpack-internal:///(instrument)/./src/jobs/email.ts:44:25)
    at Module.register (webpack-internal:///(instrument)/./src/instrumentation.ts:17:9)
    at async DevServer.runInstrumentationHookIfAvailable (/xxx/nextjs/node_modules/next/dist/server/dev/next-dev-server.js:437:17)
    at async Span.traceAsyncFn (/xxx/nextjs/node_modules/next/dist/trace/trace.js:154:20)
    at async DevServer.prepareImpl (/xxx/nextjs/node_modules/next/dist/server/dev/next-dev-server.js:214:9)
    at async NextServer.prepare (/xxx/nextjs/node_modules/next/dist/server/next.js:161:13)
    at async initializeImpl (/xxx/nextjs/node_modules/next/dist/server/lib/render-server.js:98:5)
    at async initialize (/xxx/nextjs/node_modules/next/dist/server/lib/router-server.js:423:22)
    at async Server.<anonymous> (/xxx/nextjs/node_modules/next/dist/server/lib/start-server.js:249:36) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'stat',
  path: '/xxx/nextjs/dist/cjs/classes/main.js'
}