### PR TITLE
fix(flow): fail parent on failure by default

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -39,7 +39,7 @@ const logger = debuglog('bull');
 
 const optsDecodeMap = {
   de: 'debounce',
-  fpof: 'failParentOnFailure',
+  fpof: 'failParentOnFailure', // TODO: deprecate it in next breaking change
   idof: 'ignoreDependencyOnFailure',
   kl: 'keepLogs',
   rdof: 'removeDependencyOnFailure',
@@ -1208,12 +1208,6 @@ export class Job<
 
     if (this.opts.delay && this.opts.repeat && !this.opts.repeat?.count) {
       throw new Error(`Delay and repeat options could not be used together`);
-    }
-
-    if (this.opts.removeDependencyOnFailure && this.opts.failParentOnFailure) {
-      throw new Error(
-        `RemoveDependencyOnFailure and failParentOnFailure options can not be used together`,
-      );
     }
 
     if (`${parseInt(this.id, 10)}` === this.id) {

--- a/src/commands/moveToFinished-14.lua
+++ b/src/commands/moveToFinished-14.lua
@@ -40,7 +40,7 @@
       opts - maxMetricsSize
       opts - fpof - fail parent on fail
       opts - idof - ignore dependency on fail
-      opts - rdof - remove dependency on fail
+      opts - rdof - remove dependency on fail TODO: remove it in next breaking change
 
     Output:
       0 OK
@@ -140,11 +140,7 @@ if rcall("EXISTS", jobIdKey) == 1 then -- // Make sure job exists
                                          ARGV[4], timestamp)
             end
         else
-            if opts['fpof'] then
-                moveParentFromWaitingChildrenToFailed(parentQueueKey, parentKey,
-                                                      parentId, jobIdKey,
-                                                      timestamp)
-            elseif opts['idof'] or opts['rdof'] then
+            if opts['idof'] or opts['rdof'] then
                 local dependenciesSet = parentKey .. ":dependencies"
                 if rcall("SREM", dependenciesSet, jobIdKey) == 1 then
                     moveParentToWaitIfNeeded(parentQueueKey, dependenciesSet,
@@ -154,6 +150,10 @@ if rcall("EXISTS", jobIdKey) == 1 then -- // Make sure job exists
                         rcall("HSET", failedSet, jobIdKey, ARGV[4])
                     end
                 end
+            else
+                moveParentFromWaitingChildrenToFailed(parentQueueKey, parentKey,
+                                                      parentId, jobIdKey,
+                                                      timestamp)
             end
         end
     end

--- a/tests/test_getters.ts
+++ b/tests/test_getters.ts
@@ -809,20 +809,25 @@ describe('Jobs getters', function () {
         });
       });
 
+      await queue.add('test', {});
       const flow = new FlowProducer({ connection, prefix });
       await flow.add({
         name: 'parent-job',
         queueName,
         data: {},
         children: [
-          { name: 'child-1', data: { idx: 0, foo: 'bar' }, queueName },
+          {
+            name: 'child-1',
+            data: { idx: 0, foo: 'bar' },
+            queueName,
+            opts: { delay: 6000 },
+          },
           { name: 'child-2', data: { idx: 1, foo: 'baz' }, queueName },
           { name: 'child-3', data: { idx: 2, foo: 'bac' }, queueName },
           { name: 'child-4', data: { idx: 3, foo: 'bad' }, queueName },
         ],
       });
 
-      await queue.add('test', { idx: 2 }, { delay: 5000 });
       await queue.add('test', { idx: 3 }, { priority: 5 });
 
       await completing;

--- a/tests/test_job.ts
+++ b/tests/test_job.ts
@@ -139,19 +139,6 @@ describe('Job', function () {
       });
     });
 
-    describe('when removeDependencyOnFailure and failParentOnFailure options are provided', () => {
-      it('throws an error', async () => {
-        const data = { foo: 'bar' };
-        const opts = {
-          removeDependencyOnFailure: true,
-          failParentOnFailure: true,
-        };
-        await expect(Job.create(queue, 'test', data, opts)).to.be.rejectedWith(
-          'RemoveDependencyOnFailure and failParentOnFailure options can not be used together',
-        );
-      });
-    });
-
     describe('when priority option is provided as float', () => {
       it('throws an error', async () => {
         const data = { foo: 'bar' };


### PR DESCRIPTION
our current behavior keeps parent in waiting-children state when regular children fail, instead we should fail parent directly as regular children must be considered as hard dependencies. For soft dependencies we have other options like removeDependencyOnFailure or ignoreDependencyOnFailure.
fixes https://github.com/taskforcesh/bullmq/issues/800