### PR TITLE
fix(python): make sure json.dumps return JSON compliant JSON (python)

### DIFF
--- a/python/bullmq/job.py
+++ b/python/bullmq/job.py
@@ -203,7 +203,7 @@ class Job:
                 self.stacktrace = self.stacktrace[-(stackTraceLimit-1):stackTraceLimit]
 
         keys, args = self.scripts.saveStacktraceArgs(
-            self.id, json.dumps(self.stacktrace, separators=(',', ':')), err)
+            self.id, json.dumps(self.stacktrace, separators=(',', ':'), allow_nan=False), err)
 
         await self.scripts.commands["saveStacktrace"](keys=keys, args=args, client=pipe)
 

--- a/python/bullmq/scripts.py
+++ b/python/bullmq/scripts.py
@@ -90,7 +90,7 @@ class Scripts:
         #  ARGV[1] msgpacked arguments array
         #         [9]  repeat job key
 
-        jsonData = json.dumps(job.data, separators=(',', ':'))
+        jsonData = json.dumps(job.data, separators=(',', ':'), allow_nan=False)
         packedOpts = msgpack.packb(job.opts)
 
         parent = job.parent
@@ -378,7 +378,7 @@ class Scripts:
 
     async def updateData(self, job_id: str, data):
         keys = [self.toKey(job_id)]
-        data_json = json.dumps(data, separators=(',', ':'))
+        data_json = json.dumps(data, separators=(',', ':'), allow_nan=False)
         args = [data_json]
 
         result = await self.commands["updateData"](keys=keys, args=args)
@@ -486,7 +486,7 @@ class Scripts:
 
     async def updateProgress(self, job_id: str, progress):
         keys = [self.toKey(job_id), self.keys['events'], self.keys['meta']]
-        progress_json = json.dumps(progress, separators=(',', ':'))
+        progress_json = json.dumps(progress, separators=(',', ':'), allow_nan=False)
         args = [job_id, progress_json]
         result = await self.commands["updateProgress"](keys=keys, args=args)
 
@@ -497,7 +497,7 @@ class Scripts:
 
     def moveToFinishedArgs(self, job: Job, val: Any, propVal: str, shouldRemove, target, token: str,
                            opts: dict, fetchNext=True) -> list[Any] | None:
-        transformed_value = json.dumps(val, separators=(',', ':'))
+        transformed_value = json.dumps(val, separators=(',', ':'), allow_nan=False)
         timestamp = round(time.time() * 1000)
         metricsKey = self.toKey('metrics:' + target)
 

--- a/python/tests/job_tests.py
+++ b/python/tests/job_tests.py
@@ -72,6 +72,14 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
 
         await queue.close()
 
+    async def test_job_data_json_compliant(self):
+        queue = Queue(queueName)
+        job = await queue.add("test", {"foo": "bar"}, {})
+        with self.assertRaises(ValueError):
+            await job.updateData({"baz": float('nan')})
+
+        await queue.close()
+
     async def test_update_job_data_when_is_removed(self):
         queue = Queue(queueName)
         job = await queue.add("test", {"foo": "bar"}, {})

--- a/python/tests/worker_tests.py
+++ b/python/tests/worker_tests.py
@@ -107,6 +107,36 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         await worker.close(force=True)
         await queue.close()
 
+    async def test_process_job_fail_with_nan_as_return_value(self):
+        queue = Queue(queueName)
+        data = {"foo": "bar"}
+        job = await queue.add("test-job", data, {"removeOnComplete": False})
+
+        failedReason = "Out of range float values are not JSON compliant"
+
+        async def process(job: Job, token: str):
+            print("Processing job", job)
+            return float('nan')
+
+        worker = Worker(queueName, process)
+
+        processing = Future()
+        worker.on("failed", lambda job, result: processing.set_result(None))
+        await processing
+        failedJob = await Job.fromId(queue, job.id)
+
+
+        self.assertEqual(failedJob.id, job.id)
+        self.assertEqual(failedJob.attemptsMade, 1)
+        self.assertEqual(failedJob.data, data)
+        self.assertEqual(failedJob.failedReason, f'"{failedReason}"')
+        self.assertEqual(len(failedJob.stacktrace), 1)
+        self.assertEqual(failedJob.returnvalue, None)
+        self.assertNotEqual(failedJob.finishedOn, None)
+        
+        await worker.close(force=True)
+        await queue.close()
+
     async def test_process_jobs_fail(self):
         queue = Queue(queueName)
         data = {"foo": "bar"}


### PR DESCRIPTION
The Python version can return a non-JSON-compliant value to Redis, which breaks when trying to retrieve the value using the Node version of the library.

By adding "allow_nan=True", we raise an error before sending the value to Redis, which prevents having bad JSON in the job's return value.