### PR TITLE
feat: support pending state

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -38,6 +38,7 @@ import type { QueueEvents } from './queue-events';
 const logger = debuglog('bull');
 
 const optsDecodeMap = {
+  pen: 'pending',
   de: 'debounce',
   fpof: 'failParentOnFailure',
   idof: 'ignoreDependencyOnFailure',

--- a/src/classes/queue-keys.ts
+++ b/src/classes/queue-keys.ts
@@ -8,6 +8,7 @@ export class QueueKeys {
     [
       '',
       'active',
+      'pending',
       'wait',
       'waiting-children',
       'paused',

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -60,6 +60,7 @@ export class Scripts {
       undefined,
       undefined,
       undefined,
+      undefined,
     ];
   }
 
@@ -111,6 +112,7 @@ export class Scripts {
       queueKeys.active,
       queueKeys.events,
       queueKeys.pc,
+      queueKeys.pending,
     ];
 
     keys.push(pack(args), job.data, encodedOpts);
@@ -153,6 +155,7 @@ export class Scripts {
       queueKeys.active,
       queueKeys.events,
       queueKeys.marker,
+      queueKeys.pending,
     ];
 
     keys.push(pack(args), job.data, encodedOpts);
@@ -467,6 +470,7 @@ export class Scripts {
     keys[11] = this.queue.toKey(job.id ?? '');
     keys[12] = metricsKey;
     keys[13] = this.queue.keys.marker;
+    keys[14] = this.queue.keys.pending;
 
     const keepJobs = this.getKeepJobs(shouldRemove, workerKeepJobs);
 
@@ -843,6 +847,7 @@ export class Scripts {
       this.queue.keys.active,
       this.queue.keys.pc,
       this.queue.keys.marker,
+      this.queue.keys.pending,
     ];
 
     return keys.concat([
@@ -870,6 +875,7 @@ export class Scripts {
       queueKeys.events,
       queueKeys.meta,
       queueKeys.stalled,
+      queueKeys.pending,
     ];
 
     return keys.concat([
@@ -907,6 +913,7 @@ export class Scripts {
       'waiting-children',
       jobId,
       'stalled',
+      'pending',
     ].map(name => {
       return this.queue.toKey(name);
     });
@@ -921,7 +928,11 @@ export class Scripts {
 
   isMaxedArgs(): string[] {
     const queueKeys = this.queue.keys;
-    const keys: string[] = [queueKeys.meta, queueKeys.active];
+    const keys: string[] = [
+      queueKeys.meta,
+      queueKeys.active,
+      queueKeys.pending,
+    ];
 
     return keys;
   }
@@ -1042,6 +1053,7 @@ export class Scripts {
       this.queue.keys.pc,
       this.queue.keys.marker,
       this.queue.keys.stalled,
+      this.queue.keys.pending,
     ];
 
     const pushCmd = (lifo ? 'R' : 'L') + 'PUSH';
@@ -1068,6 +1080,7 @@ export class Scripts {
       this.queue.toKey('paused'),
       this.queue.keys.meta,
       this.queue.keys.active,
+      this.queue.keys.pending,
       this.queue.keys.marker,
     ];
 
@@ -1124,6 +1137,7 @@ export class Scripts {
       this.queue.keys.paused,
       this.queue.keys.active,
       this.queue.keys.marker,
+      this.queue.keys.pending,
     ];
 
     const args = [
@@ -1164,6 +1178,7 @@ export class Scripts {
       queueKeys.meta,
       queueKeys.pc,
       queueKeys.marker,
+      queueKeys.pending,
     ];
 
     const args: (string | number | boolean | Buffer)[] = [
@@ -1196,6 +1211,7 @@ export class Scripts {
       this.queue.keys.active,
       this.queue.keys.pc,
       this.queue.keys.events,
+      this.queue.keys.pending,
       this.queue.keys.marker,
     ];
 
@@ -1222,6 +1238,7 @@ export class Scripts {
       this.queue.keys['stalled-check'],
       this.queue.keys.meta,
       this.queue.keys.paused,
+      this.queue.keys.pending,
       this.queue.keys.marker,
       this.queue.keys.events,
     ];
@@ -1275,6 +1292,7 @@ export class Scripts {
       this.queue.keys.limiter,
       this.queue.keys.prioritized,
       this.queue.keys.marker,
+      this.queue.keys.pending,
       this.queue.keys.events,
     ];
 

--- a/src/commands/addPrioritizedJob-9.lua
+++ b/src/commands/addPrioritizedJob-9.lua
@@ -1,28 +1,19 @@
 --[[
-  Adds a job to the queue by doing the following:
+  Adds a priotitized job to the queue by doing the following:
     - Increases the job counter if needed.
     - Creates a new job key with the job data.
-
-    - if delayed:
-      - computes timestamp.
-      - adds to delayed zset.
-      - Emits a global event 'delayed' if the job is delayed.
-    - if not delayed
-      - Adds the jobId to the wait/paused list in one of three ways:
-         - LIFO
-         - FIFO
-         - prioritized.
-      - Adds the job to the "added" list so that workers gets notified.
+    - Adds the job to the "added" list so that workers gets notified.
 
     Input:
-      KEYS[1] 'wait',
-      KEYS[2] 'paused'
-      KEYS[3] 'meta'
-      KEYS[4] 'id'
+      KEYS[1] 'marker',
+      KEYS[2] 'meta'
+      KEYS[3] 'id'
+      KEYS[4] 'prioritized'
       KEYS[5] 'completed'
       KEYS[6] 'active'
       KEYS[7] events stream key
-      KEYS[8] marker key
+      KEYS[8] 'pc' priority counter
+      KEYS[9] 'pending'
 
       ARGV[1] msgpacked arguments array
             [1]  key prefix,
@@ -42,8 +33,15 @@
       Output:
         jobId  - OK
         -5     - Missing parent key
-]]
+]] 
+local metaKey = KEYS[2]
+local idKey = KEYS[3]
+local priorityKey = KEYS[4]
+
+local completedKey = KEYS[5]
+local activeKey = KEYS[6]
 local eventsKey = KEYS[7]
+local priorityCounterKey = KEYS[8]
 
 local jobId
 local jobIdKey
@@ -61,12 +59,12 @@ local debounceKey = args[10]
 local parentData
 
 -- Includes
---- @include "includes/addJobInTargetList"
+--- @include "includes/addJobWithPriority"
 --- @include "includes/debounceJob"
---- @include "includes/getOrSetMaxEvents"
---- @include "includes/getTargetQueueList"
---- @include "includes/handleDuplicatedJob"
 --- @include "includes/storeJob"
+--- @include "includes/getOrSetMaxEvents"
+--- @include "includes/handleDuplicatedJob"
+--- @include "includes/isQueuePausedOrMaxed"
 
 if parentKey ~= nil then
     if rcall("EXISTS", parentKey) ~= 1 then return -5 end
@@ -74,9 +72,8 @@ if parentKey ~= nil then
     parentData = cjson.encode(parent)
 end
 
-local jobCounter = rcall("INCR", KEYS[4])
+local jobCounter = rcall("INCR", idKey)
 
-local metaKey = KEYS[3]
 local maxEvents = getOrSetMaxEvents(metaKey)
 
 local parentDependenciesKey = args[7]
@@ -89,7 +86,7 @@ else
     jobIdKey = args[1] .. jobId
     if rcall("EXISTS", jobIdKey) == 1 then
         return handleDuplicatedJob(jobIdKey, jobId, parentKey, parent,
-            parentData, parentDependenciesKey, KEYS[5], eventsKey,
+            parentData, parentDependenciesKey, completedKey, eventsKey,
             maxEvents, timestamp)
     end
 end
@@ -101,14 +98,13 @@ if debouncedJobId then
 end
 
 -- Store the job.
-storeJob(eventsKey, jobIdKey, jobId, args[3], ARGV[2], opts, timestamp,
-         parentKey, parentData, repeatJobKey)
+local delay, priority = storeJob(eventsKey, jobIdKey, jobId, args[3], ARGV[2],
+                                 opts, timestamp, parentKey, parentData,
+                                 repeatJobKey)
 
-local target, isPausedOrMaxed = getTargetQueueList(metaKey, KEYS[6], KEYS[1], KEYS[2])
-
--- LIFO or FIFO
-local pushCmd = opts['lifo'] and 'RPUSH' or 'LPUSH'
-addJobInTargetList(target, KEYS[8], pushCmd, isPausedOrMaxed, jobId)
+-- Add the job to the prioritized set
+local isPausedOrMaxed = isQueuePausedOrMaxed(metaKey, activeKey, KEYS[9])
+addJobWithPriority( KEYS[1], priorityKey, priority, jobId, priorityCounterKey, isPausedOrMaxed)
 
 -- Emit waiting event
 rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event", "waiting",

--- a/src/commands/addStandardJob-9.lua
+++ b/src/commands/addStandardJob-9.lua
@@ -1,18 +1,29 @@
 --[[
-  Adds a priotitized job to the queue by doing the following:
+  Adds a job to the queue by doing the following:
     - Increases the job counter if needed.
     - Creates a new job key with the job data.
-    - Adds the job to the "added" list so that workers gets notified.
+
+    - if delayed:
+      - computes timestamp.
+      - adds to delayed zset.
+      - Emits a global event 'delayed' if the job is delayed.
+    - if not delayed
+      - Adds the jobId to the wait/paused list in one of three ways:
+         - LIFO
+         - FIFO
+         - prioritized.
+      - Adds the job to the "added" list so that workers gets notified.
 
     Input:
-      KEYS[1] 'marker',
-      KEYS[2] 'meta'
-      KEYS[3] 'id'
-      KEYS[4] 'prioritized'
+      KEYS[1] 'wait',
+      KEYS[2] 'paused'
+      KEYS[3] 'meta'
+      KEYS[4] 'id'
       KEYS[5] 'completed'
       KEYS[6] 'active'
       KEYS[7] events stream key
-      KEYS[8] 'pc' priority counter
+      KEYS[8] marker key
+      KEYS[9] pending key
 
       ARGV[1] msgpacked arguments array
             [1]  key prefix,
@@ -32,15 +43,8 @@
       Output:
         jobId  - OK
         -5     - Missing parent key
-]] 
-local metaKey = KEYS[2]
-local idKey = KEYS[3]
-local priorityKey = KEYS[4]
-
-local completedKey = KEYS[5]
-local activeKey = KEYS[6]
+]]
 local eventsKey = KEYS[7]
-local priorityCounterKey = KEYS[8]
 
 local jobId
 local jobIdKey
@@ -58,12 +62,12 @@ local debounceKey = args[10]
 local parentData
 
 -- Includes
---- @include "includes/addJobWithPriority"
+--- @include "includes/addJobInTargetList"
 --- @include "includes/debounceJob"
---- @include "includes/storeJob"
 --- @include "includes/getOrSetMaxEvents"
+--- @include "includes/getTargetQueueList"
 --- @include "includes/handleDuplicatedJob"
---- @include "includes/isQueuePausedOrMaxed"
+--- @include "includes/storeJob"
 
 if parentKey ~= nil then
     if rcall("EXISTS", parentKey) ~= 1 then return -5 end
@@ -71,8 +75,9 @@ if parentKey ~= nil then
     parentData = cjson.encode(parent)
 end
 
-local jobCounter = rcall("INCR", idKey)
+local jobCounter = rcall("INCR", KEYS[4])
 
+local metaKey = KEYS[3]
 local maxEvents = getOrSetMaxEvents(metaKey)
 
 local parentDependenciesKey = args[7]
@@ -85,7 +90,7 @@ else
     jobIdKey = args[1] .. jobId
     if rcall("EXISTS", jobIdKey) == 1 then
         return handleDuplicatedJob(jobIdKey, jobId, parentKey, parent,
-            parentData, parentDependenciesKey, completedKey, eventsKey,
+            parentData, parentDependenciesKey, KEYS[5], eventsKey,
             maxEvents, timestamp)
     end
 end
@@ -97,13 +102,14 @@ if debouncedJobId then
 end
 
 -- Store the job.
-local delay, priority = storeJob(eventsKey, jobIdKey, jobId, args[3], ARGV[2],
-                                 opts, timestamp, parentKey, parentData,
-                                 repeatJobKey)
+storeJob(eventsKey, jobIdKey, jobId, args[3], ARGV[2], opts, timestamp,
+         parentKey, parentData, repeatJobKey)
 
--- Add the job to the prioritized set
-local isPausedOrMaxed = isQueuePausedOrMaxed(metaKey, activeKey)
-addJobWithPriority( KEYS[1], priorityKey, priority, jobId, priorityCounterKey, isPausedOrMaxed)
+local target, isPausedOrMaxed = getTargetQueueList(metaKey, KEYS[6], KEYS[1], KEYS[2], KEYS[9])
+
+-- LIFO or FIFO
+local pushCmd = opts['lifo'] and 'RPUSH' or 'LPUSH'
+addJobInTargetList(target, KEYS[8], pushCmd, isPausedOrMaxed, jobId)
 
 -- Emit waiting event
 rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event", "waiting",

--- a/src/commands/changePriority-8.lua
+++ b/src/commands/changePriority-8.lua
@@ -8,6 +8,7 @@
     KEYS[5] 'active'
     KEYS[6] 'pc' priority counter
     KEYS[7] 'marker'
+    KEYS[8] 'pending'
 
     ARGV[1] priority value
     ARGV[2] job key
@@ -46,11 +47,11 @@ end
 
 if rcall("EXISTS", jobKey) == 1 then
     local metaKey = KEYS[3]
-    local target, isPausedOrMaxed = getTargetQueueList(metaKey, KEYS[5], KEYS[1], KEYS[2])
+    local target, isPausedOrMaxed = getTargetQueueList(metaKey, KEYS[5], KEYS[1], KEYS[2], KEYS[8])
     local prioritizedKey = KEYS[4]
     local priorityCounterKey = KEYS[6]
     local markerKey = KEYS[7]
-    
+
     -- Re-add with the new priority
     if rcall("ZREM", KEYS[4], jobId) > 0 then
         reAddJobWithNewPriority( prioritizedKey, markerKey, target,

--- a/src/commands/includes/addPendingJobIfNeeded.lua
+++ b/src/commands/includes/addPendingJobIfNeeded.lua
@@ -1,0 +1,9 @@
+--[[
+  Function to add job into pending state.
+]]
+
+local function addPendingJobIfNeeded(isPending, pendingKey, jobId, timestamp)
+  if isPending then
+    rcall("ZADD", pendingKey, timestamp, jobId)
+  end
+end

--- a/src/commands/includes/getTargetQueueList.lua
+++ b/src/commands/includes/getTargetQueueList.lua
@@ -3,7 +3,7 @@
   (since an empty list and !EXISTS are not really the same).
 ]]
 
-local function getTargetQueueList(queueMetaKey, activeKey, waitKey, pausedKey)
+local function getTargetQueueList(queueMetaKey, activeKey, waitKey, pausedKey, pendingKey)
   local queueAttributes = rcall("HMGET", queueMetaKey, "paused", "concurrency")
 
   if queueAttributes[1] then
@@ -11,7 +11,8 @@ local function getTargetQueueList(queueMetaKey, activeKey, waitKey, pausedKey)
   else
     if queueAttributes[2] then
       local activeCount = rcall("LLEN", activeKey)
-      if activeCount >= tonumber(queueAttributes[2]) then
+      local pendingCount = rcall("ZCARD", pendingKey)
+      if (activeCount + pendingCount) >= tonumber(queueAttributes[2]) then
         return waitKey, true
       else
         return waitKey, false

--- a/src/commands/includes/isQueueMaxed.lua
+++ b/src/commands/includes/isQueueMaxed.lua
@@ -1,12 +1,13 @@
 --[[
   Function to check if queue is maxed or not.
 ]]
-local function isQueueMaxed(queueMetaKey, activeKey)
+local function isQueueMaxed(queueMetaKey, activeKey, pendingKey)
   local maxConcurrency = rcall("HGET", queueMetaKey, "concurrency")
 
   if maxConcurrency then
     local activeCount = rcall("LLEN", activeKey)
-    if activeCount >= tonumber(maxConcurrency) then
+    local pendingCount = rcall("ZCARD", pendingKey)
+    if (activeCount + pendingCount) >= tonumber(maxConcurrency) then
       return true
     end
   end

--- a/src/commands/includes/isQueuePausedOrMaxed.lua
+++ b/src/commands/includes/isQueuePausedOrMaxed.lua
@@ -3,7 +3,7 @@
   (since an empty list and !EXISTS are not really the same).
 ]]
 
-local function isQueuePausedOrMaxed(queueMetaKey, activeKey)
+local function isQueuePausedOrMaxed(queueMetaKey, activeKey, pendingKey)
   local queueAttributes = rcall("HMGET", queueMetaKey, "paused", "concurrency")
 
   if queueAttributes[1] then
@@ -11,7 +11,8 @@ local function isQueuePausedOrMaxed(queueMetaKey, activeKey)
   else
     if queueAttributes[2] then
       local activeCount = rcall("LLEN", activeKey)
-      return activeCount >= tonumber(queueAttributes[2])
+      local pendingCount = rcall("ZCARD", pendingKey)
+      return (activeCount + pendingCount) >= tonumber(queueAttributes[2])
     end
   end
   return false

--- a/src/commands/includes/removeParentDependencyKey.lua
+++ b/src/commands/includes/removeParentDependencyKey.lua
@@ -12,7 +12,7 @@
 
 local function moveParentToWait(parentPrefix, parentId, emitEvent)
   local parentTarget, isPausedOrMaxed = getTargetQueueList(parentPrefix .. "meta", parentPrefix .. "active",
-    parentPrefix .. "wait", parentPrefix .. "paused")
+    parentPrefix .. "wait", parentPrefix .. "paused", parentPrefix .. "pending")
   addJobInTargetList(parentTarget, parentPrefix .. "marker", "RPUSH", isPausedOrMaxed, parentId)
 
   if emitEvent then

--- a/src/commands/includes/storeJob.lua
+++ b/src/commands/includes/storeJob.lua
@@ -7,7 +7,8 @@ local function storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp,
     local delay = opts['delay'] or 0
     local priority = opts['priority'] or 0
     local debounceId = opts['de'] and opts['de']['id']
-    
+    local pending = opts['pen']
+
     local optionalValues = {}
     if parentKey ~= nil then
         table.insert(optionalValues, "parentKey")
@@ -24,6 +25,11 @@ local function storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp,
     if debounceId then
         table.insert(optionalValues, "deid")
         table.insert(optionalValues, debounceId)
+    end
+
+    if pending then
+        table.insert(optionalValues, "pen")
+        table.insert(optionalValues, 1)
     end
 
     rcall("HMSET", jobIdKey, "name", name, "data", data, "opts", jsonOpts,

--- a/src/commands/isMaxed-3.lua
+++ b/src/commands/isMaxed-3.lua
@@ -4,6 +4,7 @@
   Input:
     KEYS[1] meta key
     KEYS[2] active key
+    KEYS[3] pending key
 
   Output:
     1 if element found in the list.
@@ -14,4 +15,4 @@ local rcall = redis.call
 -- Includes
 --- @include "includes/isQueueMaxed"
 
-return isQueueMaxed(KEYS[1], KEYS[2])
+return isQueueMaxed(KEYS[1], KEYS[2], KEYS[3])

--- a/src/commands/moveJobFromActiveToWait-11.lua
+++ b/src/commands/moveJobFromActiveToWait-11.lua
@@ -11,7 +11,8 @@
     KEYS[7]  limiter key
     KEYS[8]  prioritized key
     KEYS[9]  marker key
-    KEYS[10] event key
+    KEYS[10] pending key
+    KEYS[11] event key
 
     ARGV[1] job id
     ARGV[2] lock token
@@ -35,7 +36,7 @@ if lockToken == token then
   local metaKey = KEYS[6]
   local removed = rcall("LREM", KEYS[1], 1, jobId)
   if removed > 0 then
-    local target, isPausedOrMaxed = getTargetQueueList(metaKey, KEYS[1], KEYS[2], KEYS[5])
+    local target, isPausedOrMaxed = getTargetQueueList(metaKey, KEYS[1], KEYS[2], KEYS[5], KEYS[10])
 
     rcall("SREM", KEYS[3], jobId)
 
@@ -52,7 +53,7 @@ if lockToken == token then
     local maxEvents = getOrSetMaxEvents(metaKey)
 
     -- Emit waiting event
-    rcall("XADD", KEYS[10], "MAXLEN", "~", maxEvents, "*", "event", "waiting",
+    rcall("XADD", KEYS[11], "MAXLEN", "~", maxEvents, "*", "event", "waiting",
       "jobId", jobId)
   end
 end

--- a/src/commands/moveJobsToWait-9.lua
+++ b/src/commands/moveJobsToWait-9.lua
@@ -11,7 +11,8 @@
     KEYS[5] 'paused'
     KEYS[6] 'meta'
     KEYS[7] 'active'
-    KEYS[8] 'marker'
+    KEYS[8] 'pendings'
+    KEYS[9] 'marker'
 
     ARGV[1] count
     ARGV[2] timestamp
@@ -33,7 +34,7 @@ local rcall = redis.call;
 --- @include "includes/getTargetQueueList"
 
 local metaKey = KEYS[6]
-local target, isPausedOrMaxed = getTargetQueueList(metaKey, KEYS[7], KEYS[4], KEYS[5])
+local target, isPausedOrMaxed = getTargetQueueList(metaKey, KEYS[7], KEYS[4], KEYS[5], KEYS[8])
 
 local jobs = rcall('ZRANGEBYSCORE', KEYS[3], 0, timestamp, 'LIMIT', 0, maxCount)
 if (#jobs > 0) then
@@ -63,7 +64,7 @@ if (#jobs > 0) then
         rcall("LPUSH", target, unpack(jobs, from, to))
     end
 
-    addBaseMarkerIfNeeded(KEYS[8], isPausedOrMaxed)
+    addBaseMarkerIfNeeded(KEYS[9], isPausedOrMaxed)
 end
 
 maxCount = maxCount - #jobs

--- a/src/commands/moveStalledJobsToWait-10.lua
+++ b/src/commands/moveStalledJobsToWait-10.lua
@@ -2,15 +2,16 @@
   Move stalled jobs to wait.
 
     Input:
-      KEYS[1] 'stalled' (SET)
-      KEYS[2] 'wait',   (LIST)
-      KEYS[3] 'active', (LIST)
-      KEYS[4] 'failed', (ZSET)
-      KEYS[5] 'stalled-check', (KEY)
-      KEYS[6] 'meta', (KEY)
-      KEYS[7] 'paused', (LIST)
-      KEYS[8] 'marker'
-      KEYS[9] 'event stream' (STREAM)
+      KEYS[1]  'stalled' (SET)
+      KEYS[2]  'wait',   (LIST)
+      KEYS[3]  'active', (LIST)
+      KEYS[4]  'failed', (ZSET)
+      KEYS[5]  'stalled-check', (KEY)
+      KEYS[6]  'meta', (KEY)
+      KEYS[7]  'paused', (LIST)
+      KEYS[8]  'pending' (ZSET)
+      KEYS[9]  'marker'
+      KEYS[10] 'event stream' (STREAM)
 
       ARGV[1]  Max stalled job count
       ARGV[2]  queue.toKey('')
@@ -42,8 +43,8 @@ local failedKey = KEYS[4]
 local stalledCheckKey = KEYS[5]
 local metaKey = KEYS[6]
 local pausedKey = KEYS[7]
-local markerKey = KEYS[8]
-local eventStreamKey = KEYS[9]
+local markerKey = KEYS[9]
+local eventStreamKey = KEYS[10]
 local maxStalledJobCount = ARGV[1]
 local queueKeyPrefix = ARGV[2]
 local timestamp = ARGV[3]
@@ -147,7 +148,7 @@ if (#stalling > 0) then
                         table.insert(failed, jobId)
                     else
                         local target, isPausedOrMaxed=
-                            getTargetQueueList(metaKey, activeKey, waitKey, pausedKey)
+                            getTargetQueueList(metaKey, activeKey, waitKey, pausedKey, KEYS[8])
 
                         -- Move the job back to the wait queue, to immediately be picked up by a waiting worker.
                         addJobInTargetList(target, markerKey, "RPUSH", isPausedOrMaxed, jobId)

--- a/src/commands/moveToActive-12.lua
+++ b/src/commands/moveToActive-12.lua
@@ -7,23 +7,24 @@
   so that no other worker picks this job again.
 
   Input:
-    KEYS[1] wait key
-    KEYS[2] active key
-    KEYS[3] prioritized key
-    KEYS[4] stream events key
-    KEYS[5] stalled key
+    KEYS[1]  wait key
+    KEYS[2]  active key
+    KEYS[3]  prioritized key
+    KEYS[4]  stream events key
+    KEYS[5]  stalled key
 
     -- Rate limiting
-    KEYS[6] rate limiter key
-    KEYS[7] delayed key
+    KEYS[6]  rate limiter key
+    KEYS[7]  delayed key
 
     -- Delayed jobs
-    KEYS[8] paused key
-    KEYS[9] meta key
+    KEYS[8]  paused key
+    KEYS[9]  meta key
     KEYS[10] pc priority counter
 
     -- Marker
     KEYS[11] marker key
+    KEYS[12] pending key
 
     -- Arguments
     ARGV[1] key prefix
@@ -50,12 +51,12 @@ local opts = cmsgpack.unpack(ARGV[3])
 --- @include "includes/prepareJobForProcessing"
 --- @include "includes/promoteDelayedJobs"
 
-local target, isPausedOrMaxed = getTargetQueueList(KEYS[9], activeKey, waitKey, KEYS[8])
+local target, isPausedOrMaxed = getTargetQueueList(KEYS[9], activeKey, waitKey, KEYS[8], KEYS[12])
 
 -- Check if there are delayed jobs that we can move to wait.
 local markerKey = KEYS[11]
 promoteDelayedJobs(delayedKey, markerKey, target, KEYS[3], eventStreamKey, ARGV[1],
-                   ARGV[2], KEYS[10], isPausedOrMaxed)
+                   ARGV[2], KEYS[10], isPausedOrMaxed, KEYS[12])
 
 local maxJobs = tonumber(opts['limiter'] and opts['limiter']['max'])
 local expireTime = getRateLimitTTL(maxJobs, rateLimiterKey)

--- a/src/commands/moveToFinished-15.lua
+++ b/src/commands/moveToFinished-15.lua
@@ -23,6 +23,7 @@
       KEYS[12] jobId key
       KEYS[13] metrics key
       KEYS[14] marker key
+      KEYS[15] pending key
 
       ARGV[1]  jobId
       ARGV[2]  timestamp
@@ -205,11 +206,11 @@ if rcall("EXISTS", jobIdKey) == 1 then -- // Make sure job exists
     -- and not rate limited.
     if (ARGV[6] == "1") then
 
-        local target, isPausedOrMaxed = getTargetQueueList(metaKey, KEYS[2], KEYS[1], KEYS[8])
+        local target, isPausedOrMaxed = getTargetQueueList(metaKey, KEYS[2], KEYS[1], KEYS[8], KEYS[15])
 
         -- Check if there are delayed jobs that can be promoted
         promoteDelayedJobs(KEYS[7], KEYS[14], target, KEYS[3], eventStreamKey, prefix,
-                           timestamp, KEYS[10], isPausedOrMaxed)
+                           timestamp, KEYS[10], isPausedOrMaxed, KEYS[15])
 
         local maxJobs = tonumber(opts['limiter'] and opts['limiter']['max'])
         -- Check if we are rate limited first.

--- a/src/commands/moveToWaitingChildren-6.lua
+++ b/src/commands/moveToWaitingChildren-6.lua
@@ -7,6 +7,7 @@
     KEYS[3] waitChildrenKey key
     KEYS[4] job key
     KEYS[5] stalled key
+    KEYS[6] pending key
 
     ARGV[1] token
     ARGV[2] child key
@@ -22,12 +23,14 @@
 ]]
 local rcall = redis.call
 local stalledKey = KEYS[5]
+local jobKey = KEYS[4]
 
 --- Includes
+--- @include "includes/addPendingJobIfNeeded"
 --- @include "includes/removeLock"
 
-local function moveToWaitingChildren (activeKey, waitingChildrenKey, jobId,
-    timestamp)
+local function moveToWaitingChildren (activeKey, waitingChildrenKey, pendingKey,
+    jobKey, jobId, timestamp)
   local score = tonumber(timestamp)
 
   local numRemovedElements = rcall("LREM", activeKey, -1, jobId)
@@ -36,29 +39,32 @@ local function moveToWaitingChildren (activeKey, waitingChildrenKey, jobId,
     return -3
   end
 
+  local isPending = rcall("HGET", jobKey, "pen")
+  addPendingJobIfNeeded(isPending, pendingKey, jobId, timestamp)
+
   rcall("ZADD", waitingChildrenKey, score, jobId)
 
   return 0
 end
 
-if rcall("EXISTS", KEYS[4]) == 1 then
+if rcall("EXISTS", jobKey) == 1 then
   if ARGV[2] ~= "" then
-    if rcall("SISMEMBER", KEYS[4] .. ":dependencies", ARGV[2]) ~= 0 then
-      local errorCode = removeLock(KEYS[4], stalledKey, ARGV[1], ARGV[4])
+    if rcall("SISMEMBER", jobKey .. ":dependencies", ARGV[2]) ~= 0 then
+      local errorCode = removeLock(jobKey, stalledKey, ARGV[1], ARGV[4])
       if errorCode < 0 then
         return errorCode
       end
-      return moveToWaitingChildren(KEYS[2], KEYS[3], ARGV[4], ARGV[3])
+      return moveToWaitingChildren(KEYS[2], KEYS[3], KEYS[6], jobKey, ARGV[4], ARGV[3])
     end
 
     return 1
   else
-    if rcall("SCARD", KEYS[4] .. ":dependencies") ~= 0 then 
-      local errorCode = removeLock(KEYS[4], stalledKey, ARGV[1], ARGV[4])
+    if rcall("SCARD", jobKey .. ":dependencies") ~= 0 then 
+      local errorCode = removeLock(jobKey, stalledKey, ARGV[1], ARGV[4])
       if errorCode < 0 then
         return errorCode
       end
-      return moveToWaitingChildren(KEYS[2], KEYS[3], ARGV[4], ARGV[3])
+      return moveToWaitingChildren(KEYS[2], KEYS[3], KEYS[6], jobKey, ARGV[4], ARGV[3])
     end
 
     return 1

--- a/src/commands/promote-10.lua
+++ b/src/commands/promote-10.lua
@@ -2,15 +2,16 @@
   Promotes a job that is currently "delayed" to the "waiting" state
 
     Input:
-      KEYS[1] 'delayed'
-      KEYS[2] 'wait'
-      KEYS[3] 'paused'
-      KEYS[4] 'meta'
-      KEYS[5] 'prioritized'
-      KEYS[6] 'active'
-      KEYS[7] 'pc' priority counter
-      KEYS[8] 'event stream'
-      KEYS[9] 'marker'
+      KEYS[1]  'delayed'
+      KEYS[2]  'wait'
+      KEYS[3]  'paused'
+      KEYS[4]  'meta'
+      KEYS[5]  'prioritized'
+      KEYS[6]  'active'
+      KEYS[7]  'pc' priority counter
+      KEYS[8]  'event stream'
+      KEYS[9]  'pending'
+      KEYS[10] 'marker'
 
       ARGV[1]  queue.toKey('')
       ARGV[2]  jobId
@@ -32,22 +33,28 @@ local jobId = ARGV[2]
 
 if rcall("ZREM", KEYS[1], jobId) == 1 then
     local jobKey = ARGV[1] .. jobId
-    local priority = tonumber(rcall("HGET", jobKey, "priority")) or 0
+    local jobAttributes = rcall("HMGET", jobKey, "priority", "pen")
+    local priority = tonumber(jobAttributes[1]) or 0
     local metaKey = KEYS[4]
-    local markerKey = KEYS[9]
+    local markerKey = KEYS[10]
 
-    -- Remove delayed "marker" from the wait list if there is any.
+    -- TODO: Remove delayed "marker" from the wait list if there is any.
     -- Since we are adding a job we do not need the marker anymore.
     -- Markers in waitlist DEPRECATED in v5: Remove in v6.
     local target, isPausedOrMaxed = getTargetQueueList(metaKey, KEYS[6], KEYS[2], KEYS[3])
     local marker = rcall("LINDEX", target, 0)
     if marker and string.sub(marker, 1, 2) == "0:" then rcall("LPOP", target) end
 
-    if priority == 0 then
-        -- LIFO or FIFO
-        addJobInTargetList(target, markerKey, "LPUSH", isPausedOrMaxed, jobId)
+    if jobAttributes[2] then
+      rcall("ZREM", KEYS[9], jobId)
+      addJobInTargetList(target, markerKey, "RPUSH", isPausedOrMaxed, jobId)
     else
-        addJobWithPriority(markerKey, KEYS[5], priority, jobId, KEYS[7], isPausedOrMaxed)
+      if priority == 0 then
+          -- LIFO or FIFO
+          addJobInTargetList(target, markerKey, "LPUSH", isPausedOrMaxed, jobId)
+      else
+          addJobWithPriority(markerKey, KEYS[5], priority, jobId, KEYS[7], isPausedOrMaxed)
+      end
     end
 
     -- Emit waiting event (wait..ing@token)

--- a/src/commands/reprocessJob-9.lua
+++ b/src/commands/reprocessJob-9.lua
@@ -10,6 +10,7 @@
     KEYS[6] paused key
     KEYS[7] active key
     KEYS[8] marker key
+    KEYS[9] pending key
 
     ARGV[1] job.id
     ARGV[2] (job.opts.lifo ? 'R' : 'L') + 'PUSH'
@@ -33,7 +34,7 @@ if rcall("EXISTS", KEYS[1]) == 1 then
   if (rcall("ZREM", KEYS[3], jobId) == 1) then
     rcall("HDEL", KEYS[1], "finishedOn", "processedOn", ARGV[3])
 
-    local target, isPausedOrMaxed = getTargetQueueList(KEYS[5], KEYS[7], KEYS[4], KEYS[6])
+    local target, isPausedOrMaxed = getTargetQueueList(KEYS[5], KEYS[7], KEYS[4], KEYS[6], KEYS[9])
     addJobInTargetList(target, KEYS[8], ARGV[2], isPausedOrMaxed, jobId)
 
     local maxEvents = getOrSetMaxEvents(KEYS[5])

--- a/src/types/job-options.ts
+++ b/src/types/job-options.ts
@@ -17,6 +17,11 @@ export type JobsOptions = BaseJobOptions & {
   ignoreDependencyOnFailure?: boolean;
 
   /**
+   * Consider job as pending since it's move to active for the first time.
+   */
+  pending?: boolean;
+
+  /**
    * If true, removes the job from its parent dependencies when it fails after all attempts.
    */
   removeDependencyOnFailure?: boolean;
@@ -45,6 +50,11 @@ export type RedisJobOptions = BaseJobOptions & {
    * Maximum amount of log entries that will be preserved
    */
   kl?: number;
+
+  /**
+   * Consider job as pending since it's move to active for the first time.
+   */
+  pen?: string;
 
   /**
    * If true, removes the job from its parent dependencies when it fails after all attempts.


### PR DESCRIPTION
similar as https://github.com/taskforcesh/bullmq/pull/2465. In this pr it's introduced a new state called pending (not active but it's being considered when checking if a queue is maxed). While a job is moved to active for the first time and it has this pending option, a reference in pending zset is added only when this job is moved to delayed or waiting-children. Pending reference will be present as long as the job is still in delayed or waiting-children, then removed when job is moved back to waiting (it's readded into waiting at the head of the queue).
DRAFT:
TODO:
- Consider removal: clean, obliterate, removeJob