### PR TITLE
fix(repeat): remove legacy cron option

### DIFF
--- a/src/classes/repeat.ts
+++ b/src/classes/repeat.ts
@@ -35,11 +35,7 @@ export class Repeat extends QueueBase {
     opts: JobsOptions,
     skipCheckExists?: boolean,
   ): Promise<Job<T, R, N> | undefined> {
-    // HACK: This is a temporary fix to enable easy migration from bullmq <3.0.0
-    // to >= 3.0.0. TODO: It should be removed when moving to 4.x.
-    const repeatOpts: RepeatOptions & { cron?: string } = { ...opts.repeat };
-    repeatOpts.pattern ??= repeatOpts.cron;
-    delete repeatOpts.cron;
+    const repeatOpts: RepeatOptions = { ...opts.repeat };
 
     const prevMillis = opts.prevMillis || 0;
     const currentCount = repeatOpts.count ? repeatOpts.count + 1 : 1;


### PR DESCRIPTION
pattern is the only option that must be used instead of cron