### PR TITLE
docs(connection): add decode_responses warning [python]

### DIFF
--- a/docs/gitbook/changelog.md
+++ b/docs/gitbook/changelog.md
@@ -82,7 +82,6 @@
 ### Bug Fixes
 
 * **job:** consider passing stackTraceLimit as 0 ([#2692](https://github.com/taskforcesh/bullmq/issues/2692)) ref [#2487](https://github.com/taskforcesh/bullmq/issues/2487) ([509a36b](https://github.com/taskforcesh/bullmq/commit/509a36baf8d8cf37176e406fd28e33f712229d27))
-* **job:** make sure json.dumps return JSON compliant JSON [python] ([#2683](https://github.com/taskforcesh/bullmq/issues/2683)) ([4441711](https://github.com/taskforcesh/bullmq/commit/4441711a986a9f6a326100308d639eb0a2ea8c8d))
 
 # [5.12.0](https://github.com/taskforcesh/bullmq/compare/v5.11.0...v5.12.0) (2024-08-01)
 

--- a/docs/gitbook/python/introduction.md
+++ b/docs/gitbook/python/introduction.md
@@ -75,3 +75,7 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 ```
+
+{% hint style="warning" %}
+If Redis responses are in binary format, you should pass (decode_responses)[https://redis-py.readthedocs.io/en/latest/examples/connection_examples.html#By-default-Redis-return-binary-responses,-to-decode-them-use-decode_responses=True] option as *True*.
+{% endhint %}


### PR DESCRIPTION
fixes https://github.com/taskforcesh/bullmq/pull/2695