### PR TITLE
fix(connection): allow passing connection string into IORedis

### DIFF
--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -211,7 +211,8 @@ export class RedisConnection extends EventEmitter {
 
   private async init() {
     if (!this._client) {
-      this._client = new IORedis(this.opts);
+      const { url, ...rest } = this.opts;
+      this._client = url ? new IORedis(url, rest) : new IORedis(rest);
     }
 
     increaseMaxListeners(this._client, 3);

--- a/src/interfaces/redis-options.ts
+++ b/src/interfaces/redis-options.ts
@@ -2,6 +2,7 @@ import type * as IORedis from 'ioredis';
 
 export interface BaseOptions {
   skipVersionCheck?: boolean;
+  url?: string;
 }
 
 export type RedisOptions = IORedis.RedisOptions & BaseOptions;


### PR DESCRIPTION
Allow option to use/pass connection URL into ioredis directly without having to create connection manually and consequently maintaining it, fixes #1220.

It does not intentionally parse the url (as per #1220 requirement) and delegates URL parsing to ioredis using appropriate constructor. Thus added tests only check established connections, leaving rest up to ioredis.


