### PR TITLE
perf(metrics): save zeros as much as max data points

### DIFF
--- a/src/commands/includes/collectMetrics.lua
+++ b/src/commands/includes/collectMetrics.lua
@@ -17,7 +17,7 @@ local function collectMetrics(metaKey, dataPointsList, maxDataPoints,
         return
     end
 
-    local N = math.floor((timestamp - prevTS) / 60000)
+    local N = math.min(math.floor((timestamp - prevTS) / 60000), tonumber(maxDataPoints))
 
     if N > 0 then
         local delta = count - rcall("HGET", metaKey, "prevCount")


### PR DESCRIPTION
don't need to save more zeros than max data points