### PR TITLE
fix(sandbox): serialize sandboxed job error

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -213,13 +213,7 @@ export const parseObjectValues = (obj: {
 };
 
 export const errorToJSON = (value: any): Record<string, any> => {
-  const error: Record<string, any> = {};
-
-  Object.getOwnPropertyNames(value).forEach(function (propName: string) {
-    error[propName] = value[propName];
-  });
-
-  return error;
+  return JSON.parse(JSON.stringify(value, Object.getOwnPropertyNames(value)));
 };
 
 const INFINITY = 1 / 0;


### PR DESCRIPTION
This change preserves the original error when throwing from a sandboxed job with a circular reference or I think a function in the object.

The TypeError is reproducible with worker threads off and a [simple circular reference](https://github.com/LEI/bullmq-sandbox):
```
Worker failed TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'Object'
    --- property 'ref' closes the circle
    at stringify (<anonymous>)
    at writeChannelMessage (node:internal/child_process/serialization:159:20)
    at target._send (node:internal/child_process:851:17)
    at target.send (node:internal/child_process:751:19)
    at ./node_modules/bullmq/dist/cjs/utils.js:134:18
    at new Promise (<anonymous>)
    at asyncSend (./node_modules/bullmq/dist/cjs/utils.js:132:12)
    at childSend (./node_modules/bullmq/dist/cjs/utils.js:152:56)
    at ChildProcessor.send (./node_modules/bullmq/dist/cjs/classes/main.js:9:57)
    at ./node_modules/bullmq/dist/cjs/classes/child-processor.js:77:28
```

The DataCloneError occurs with axios errors and `useWorkerThreads: true`, see [this branch](https://github.com/LEI/bullmq-sandbox/tree/axios):
```
Worker failed DataCloneError: function transformRequest(data, headers) {
    const contentType = headers.getContentType() || '';
    const ha...<omitted>... } could not be cloned.
    at new DOMException (node:internal/per_context/domexception:53:5)
    at ChildProcessor.send (./node_modules/bullmq/dist/cjs/classes/main-worker.js:9:69)
    at ./node_modules/bullmq/dist/cjs/classes/child-processor.js:77:28
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

Initially attempted to check the value type ignoring "function" and serializing only "object", but using the stringify/parse method on the whole object seems more consistent and fixed all cases.