### PR TITLE
fix(redis): use version for naming loaded lua scripts

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -710,11 +710,13 @@ export class Job<
           token,
           delay,
         );
-        (<any>multi).moveToDelayed(args);
+        this.scripts.execCommand(multi, 'moveToDelayed', args);
         command = 'moveToDelayed';
       } else {
         // Retry immediately
-        (<any>multi).retryJob(
+        this.scripts.execCommand(
+          multi,
+          'retryJob',
           this.scripts.retryJobArgs(this.id, this.opts.lifo, token),
         );
         command = 'retryJob';
@@ -732,7 +734,8 @@ export class Job<
         token,
         fetchNext,
       );
-      (<any>multi).moveToFinished(args);
+
+      this.scripts.execCommand(multi, 'moveToFinished', args);
       finishedOn = args[this.scripts.moveToFinishedKeys.length + 1] as number;
       command = 'moveToFinished';
     }
@@ -1287,7 +1290,7 @@ export class Job<
       err?.message,
     );
 
-    (<any>multi).saveStacktrace(args);
+    this.scripts.execCommand(multi, 'saveStacktrace', args);
   }
 }
 


### PR DESCRIPTION
If you share a Redis connection between different queues and you happen to use different versions of BullMQ, then you may be using incompatible Lua scripts, as the last loaded script wins, replacing the previously loaded one. Note that this is only a problem if 1) you are reusing a ioredis connection, and 2) you are mixing different versions of the BullMQ library, in other words, not very common in most scenarios, but this PR fixes the issue by appending a version number to every command name.