### PR TITLE
docs: fix broken link to commonRedisOptions keyPrefix

### DIFF
--- a/docs/gitbook/guide/connections.md
+++ b/docs/gitbook/guide/connections.md
@@ -35,7 +35,7 @@ const myWorker = new Worker('myqueue', async (job)=>{}, { connection });
 Note that in the second example, even though the ioredis instance is being reused, the worker will create a duplicated connection that it needs internally to make blocking connections. Consult the [ioredis](https://github.com/luin/ioredis/blob/master/API.md) documentation to learn how to properly create an instance of `IORedis.`
 
 {% hint style="danger" %}
-When using ioredis connections, be careful not to use the "keyPrefix" option in [ioredis](https://luin.github.io/ioredis/interfaces/CommonRedisOptions.html#keyPrefix) as this option is not compatible with BullMQ, which provides its own key prefixing mechanism.
+When using ioredis connections, be careful not to use the "keyPrefix" option in [ioredis](https://redis.github.io/ioredis/interfaces/CommonRedisOptions.html#keyPrefix) as this option is not compatible with BullMQ, which provides its own key prefixing mechanism.
 {% endhint %}
 
 If you can afford many connections, by all means just use them. Redis connections have quite low overhead, so you should not need to care about reusing connections unless your service provider imposes hard limitations.


### PR DESCRIPTION
[connection docs](https://docs.bullmq.io/guide/connections) have a link leading to a 404.