### PR TITLE
fix(connection): do not allow to set blockingConnection option

### DIFF
--- a/src/classes/queue-base.ts
+++ b/src/classes/queue-base.ts
@@ -28,6 +28,7 @@ export class QueueBase extends EventEmitter implements MinimalQueue {
   closing: Promise<void> | undefined;
 
   protected closed: boolean = false;
+  protected hasBlockingConnection: boolean = false;
   protected scripts: Scripts;
   protected connection: RedisConnection;
   public readonly qualifiedName: string;
@@ -43,9 +44,11 @@ export class QueueBase extends EventEmitter implements MinimalQueue {
     public readonly name: string,
     public opts: QueueBaseOptions = { connection: {} },
     Connection: typeof RedisConnection = RedisConnection,
+    hasBlockingConnection = false,
   ) {
     super();
 
+    this.hasBlockingConnection = hasBlockingConnection;
     this.opts = {
       prefix: 'bull',
       ...opts,
@@ -62,7 +65,7 @@ export class QueueBase extends EventEmitter implements MinimalQueue {
     this.connection = new Connection(
       opts.connection,
       isRedisInstance(opts.connection),
-      opts.blockingConnection,
+      hasBlockingConnection,
       opts.skipVersionCheck,
     );
 

--- a/src/classes/queue-events.ts
+++ b/src/classes/queue-events.ts
@@ -202,9 +202,9 @@ export class QueueEvents extends QueueBase {
         connection: isRedisInstance(connection)
           ? (<RedisClient>connection).duplicate()
           : connection,
-        blockingConnection: true,
       },
       Connection,
+      true,
     );
 
     this.opts = Object.assign(

--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -113,7 +113,6 @@ export class Queue<
     super(
       name,
       {
-        blockingConnection: false,
         ...opts,
       },
       Connection,

--- a/src/interfaces/queue-options.ts
+++ b/src/interfaces/queue-options.ts
@@ -19,6 +19,7 @@ export interface QueueBaseOptions {
 
   /**
    * Denotes commands should retry indefinitely.
+   * @deprecated
    */
   blockingConnection?: boolean;
 

--- a/tests/test_connection.ts
+++ b/tests/test_connection.ts
@@ -149,11 +149,10 @@ describe('connection', () => {
 
   describe('non-blocking', () => {
     it('should not override any redis options', async () => {
-      connection = new IORedis(redisHost, { maxRetriesPerRequest: 20 });
+      const connection2 = new IORedis(redisHost, { maxRetriesPerRequest: 20 });
 
-      const queue = new QueueBase(queueName, {
-        connection,
-        blockingConnection: false,
+      const queue = new Queue(queueName, {
+        connection: connection2,
       });
 
       const options = <RedisOptions>(await queue.client).options;
@@ -161,6 +160,7 @@ describe('connection', () => {
       expect(options.maxRetriesPerRequest).to.be.equal(20);
 
       await queue.close();
+      await connection2.quit();
     });
   });
 


### PR DESCRIPTION
blockingConnection is an internal property that must not be overwritten by users