### PR TITLE
docs(job): clarify per-queue scoping of Job Ids

### DIFF
--- a/docs/gitbook/guide/jobs/job-ids.md
+++ b/docs/gitbook/guide/jobs/job-ids.md
@@ -4,6 +4,10 @@ All jobs in BullMQ need to have a unique job id. This id is used to construct a 
 
 By default, job ids are generated automatically as an increasing counter, however it is also possible to specify a _custom id_.
 
+{% hint style="info" %}
+The uniqueness requirement is scoped by queue, i.e. you can have the same job id in different queues without any issues. The counter for automatically generated ids is also scoped by queue.
+{% endhint %}
+
 The main reason to be able to specify a custom id is in cases when you want to avoid duplicated jobs. Since ids must be unique, if you add a job with an existing id then that job will just be ignored and not added to the queue at all.
 
 {% hint style="danger" %}


### PR DESCRIPTION
This adds a clarification to the docs that Job Id scoping is per queue, not globally.

We came across this question in a recent PR in one of our apps and research in the docs yielded no clear explanation, which required us to dig into the code and actually experiment with it, so I thought it was worth a contribution.