### PR TITLE
Introducing BullMQ Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@
     <a href="https://github.com/semantic-release/semantic-release">
       <img src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg"/>
     </a>
+    <a href="https://gurubase.io/g/bullmq">
+      <img src="https://img.shields.io/badge/Gurubase-Ask%20BullMQ%20Guru-006BFF"/>
+    </a>
   </p>
   <p>
     <em>Follow <a href="https://twitter.com/manast">@manast</a> for *important* Bull/BullMQ/BullMQ-Pro news and updates!</em>


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [BullMQ Guru](https://gurubase.io/g/bullmq) to Gurubase. BullMQ Guru uses the data from this repo and data from the [docs](https://docs.bullmq.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "BullMQ Guru", which highlights that BullMQ now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable BullMQ Guru in Gurubase, just let me know that's totally fine.
