### PR TITLE
feat: improve queue getters to use generic job type

### DIFF
--- a/src/classes/queue-getters.ts
+++ b/src/classes/queue-getters.ts
@@ -14,17 +14,9 @@ import { JobJsonRaw, Metrics } from '../interfaces';
  *
  * @description Provides different getters for different aspects of a queue.
  */
-export class QueueGetters<
-  DataType,
-  ResultType,
-  NameType extends string,
-> extends QueueBase {
-  getJob(
-    jobId: string,
-  ): Promise<Job<DataType, ResultType, NameType> | undefined> {
-    return this.Job.fromId(this, jobId) as Promise<
-      Job<DataType, ResultType, NameType>
-    >;
+export class QueueGetters<JobBase extends Job = Job> extends QueueBase {
+  getJob(jobId: string): Promise<JobBase | undefined> {
+    return this.Job.fromId(this, jobId) as Promise<JobBase>;
   }
 
   private commandByType(
@@ -251,10 +243,7 @@ export class QueueGetters<
    * @param start - zero based index from where to start returning jobs.
    * @param end - zero based index where to stop returning jobs.
    */
-  getWaiting(
-    start = 0,
-    end = -1,
-  ): Promise<Job<DataType, ResultType, NameType>[]> {
+  getWaiting(start = 0, end = -1): Promise<JobBase[]> {
     return this.getJobs(['waiting'], start, end, true);
   }
 
@@ -264,10 +253,7 @@ export class QueueGetters<
    * @param start - zero based index from where to start returning jobs.
    * @param end - zero based index where to stop returning jobs.
    */
-  getWaitingChildren(
-    start = 0,
-    end = -1,
-  ): Promise<Job<DataType, ResultType, NameType>[]> {
+  getWaitingChildren(start = 0, end = -1): Promise<JobBase[]> {
     return this.getJobs(['waiting-children'], start, end, true);
   }
 
@@ -276,10 +262,7 @@ export class QueueGetters<
    * @param start - zero based index from where to start returning jobs.
    * @param end - zero based index where to stop returning jobs.
    */
-  getActive(
-    start = 0,
-    end = -1,
-  ): Promise<Job<DataType, ResultType, NameType>[]> {
+  getActive(start = 0, end = -1): Promise<JobBase[]> {
     return this.getJobs(['active'], start, end, true);
   }
 
@@ -288,10 +271,7 @@ export class QueueGetters<
    * @param start - zero based index from where to start returning jobs.
    * @param end - zero based index where to stop returning jobs.
    */
-  getDelayed(
-    start = 0,
-    end = -1,
-  ): Promise<Job<DataType, ResultType, NameType>[]> {
+  getDelayed(start = 0, end = -1): Promise<JobBase[]> {
     return this.getJobs(['delayed'], start, end, true);
   }
 
@@ -300,10 +280,7 @@ export class QueueGetters<
    * @param start - zero based index from where to start returning jobs.
    * @param end - zero based index where to stop returning jobs.
    */
-  getPrioritized(
-    start = 0,
-    end = -1,
-  ): Promise<Job<DataType, ResultType, NameType>[]> {
+  getPrioritized(start = 0, end = -1): Promise<JobBase[]> {
     return this.getJobs(['prioritized'], start, end, true);
   }
 
@@ -312,10 +289,7 @@ export class QueueGetters<
    * @param start - zero based index from where to start returning jobs.
    * @param end - zero based index where to stop returning jobs.
    */
-  getCompleted(
-    start = 0,
-    end = -1,
-  ): Promise<Job<DataType, ResultType, NameType>[]> {
+  getCompleted(start = 0, end = -1): Promise<JobBase[]> {
     return this.getJobs(['completed'], start, end, false);
   }
 
@@ -324,10 +298,7 @@ export class QueueGetters<
    * @param start - zero based index from where to start returning jobs.
    * @param end - zero based index where to stop returning jobs.
    */
-  getFailed(
-    start = 0,
-    end = -1,
-  ): Promise<Job<DataType, ResultType, NameType>[]> {
+  getFailed(start = 0, end = -1): Promise<JobBase[]> {
     return this.getJobs(['failed'], start, end, false);
   }
 
@@ -422,18 +393,13 @@ export class QueueGetters<
     start = 0,
     end = -1,
     asc = false,
-  ): Promise<Job<DataType, ResultType, NameType>[]> {
+  ): Promise<JobBase[]> {
     const currentTypes = this.sanitizeJobTypes(types);
 
     const jobIds = await this.getRanges(currentTypes, start, end, asc);
 
     return Promise.all(
-      jobIds.map(
-        jobId =>
-          this.Job.fromId(this, jobId) as Promise<
-            Job<DataType, ResultType, NameType>
-          >,
-      ),
+      jobIds.map(jobId => this.Job.fromId(this, jobId) as Promise<JobBase>),
     );
   }
 

--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -95,7 +95,7 @@ export class Queue<
   DataType = any,
   ResultType = any,
   NameType extends string = string,
-> extends QueueGetters<DataType, ResultType, NameType> {
+> extends QueueGetters<Job<DataType, ResultType, NameType>> {
   token = v4();
   jobsOpts: BaseJobOptions;
   opts: QueueOptions;


### PR DESCRIPTION
This PR addresses an issue we have in BullMQ Pro, where the queue getters do not return jobs of type JobPro. The solution is to use a generic for the Job type, and define that type when subclassing QueueGetters.