### PR TITLE
feat(queue): refactor a protected addJob method allowing telemetry extensions

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -995,7 +995,7 @@ will never work with more accuracy than 1ms. */
    * This method waits for current jobs to finalize before returning.
    *
    * @param force - Use force boolean parameter if you do not want to wait for
-   * current jobs to be processed. When using telemetry, be mindful that it can 
+   * current jobs to be processed. When using telemetry, be mindful that it can
    * interfere with the proper closure of spans, potentially preventing them from being exported.
    *
    * @returns Promise that resolves when the worker has been closed.

--- a/tests/test_worker.ts
+++ b/tests/test_worker.ts
@@ -510,9 +510,17 @@ describe('workers', function () {
     await worker.close();
   });
 
-  it('do not call moveToActive more than number of jobs + 1', async () => {
+  it('do not call moveToActive more than number of jobs + 2', async () => {
     const numJobs = 50;
     let completedJobs = 0;
+
+    const jobs: Promise<Job>[] = [];
+    for (let i = 0; i < numJobs; i++) {
+      jobs.push(queue.add('test', { foo: 'bar' }));
+    }
+
+    await Promise.all(jobs);
+
     const worker = new Worker(
       queueName,
       async job => {
@@ -521,7 +529,6 @@ describe('workers', function () {
       },
       { connection, prefix, concurrency: 100 },
     );
-    await worker.waitUntilReady();
 
     // Add spy to worker.moveToActive
     const spy = sinon.spy(worker, 'moveToActive');
@@ -529,14 +536,9 @@ describe('workers', function () {
       await worker.blockingConnection.client,
       'bzpopmin',
     );
+    await worker.waitUntilReady();
 
-    for (let i = 0; i < numJobs; i++) {
-      const job = await queue.add('test', { foo: 'bar' });
-      expect(job.id).to.be.ok;
-      expect(job.data.foo).to.be.eql('bar');
-    }
-
-    expect(bclientSpy.callCount).to.be.equal(1);
+    expect(bclientSpy.callCount).to.be.equal(0);
 
     await new Promise<void>((resolve, reject) => {
       worker.on('completed', (job: Job, result: any) => {
@@ -547,9 +549,11 @@ describe('workers', function () {
       });
     });
 
+    expect(completedJobs).to.be.equal(numJobs);
+    expect(bclientSpy.callCount).to.be.equal(2);
+
     // Check moveToActive was called numJobs + 2 times
     expect(spy.callCount).to.be.equal(numJobs + 2);
-    expect(bclientSpy.callCount).to.be.equal(3);
 
     await worker.close();
   });


### PR DESCRIPTION
This PR is required by packages that extend the Queue class such as BullMQ Pro so that they can customise the telemetry data when adding jobs to the queue.