### PR TITLE
fix: typo in docstring for `moveToDelayed`

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -1147,7 +1147,7 @@ export class Job<
   /**
    * Moves the job to the delay set.
    *
-   * @param timestamp - timestamp where the job should be moved back to "wait"
+   * @param timestamp - timestamp when the job should be moved back to "wait"
    * @param token - token to check job is locked by current worker
    * @returns
    */


### PR DESCRIPTION
Thanks for the awesome project!

Just spotted a typo via the editor intellisense and figured this would be a quick fix.

Keep up the good work :)