### PR TITLE
fix(scripts): make sure jobs fields are not empty before unpack

### DIFF
--- a/src/commands/includes/updateJobFields.lua
+++ b/src/commands/includes/updateJobFields.lua
@@ -2,7 +2,7 @@
   Function to update a bunch of fields in a job.
 ]]
 local function updateJobFields(jobKey, msgpackedFields)
-    if msgpackedFields then
+    if msgpackedFields and #msgpackedFields > 0 then
         local fieldsToUpdate = cmsgpack.unpack(msgpackedFields)
         if fieldsToUpdate then
             redis.call("HMSET", jobKey, unpack(fieldsToUpdate))


### PR DESCRIPTION
Possibly fixes https://github.com/taskforcesh/bullmq/issues/2969
The theory is that in some LUA engines, empty strings are not handled like nil, but truethy instead, resulting in message pack failing trying to unpack an empty string, or maybe is that some LUA engines have a msgpack version that can unpack empty strings without crashing... in any case, better not to try to unpack empty strings.