### PR TITLE
fix(job-scheduler): avoid duplicates when upserting in a quick sequence

### DIFF
--- a/src/commands/removeJobScheduler-3.lua
+++ b/src/commands/removeJobScheduler-3.lua
@@ -1,6 +1,6 @@
 
 --[[
-  Removes a repeatable job
+  Removes a job scheduler and its next scheduled job.
   Input:
     KEYS[1] job schedulers key
     KEYS[2] delayed jobs key

--- a/tests/test_job_scheduler.ts
+++ b/tests/test_job_scheduler.ts
@@ -206,11 +206,10 @@ describe('Job Scheduler', function () {
   });
 
   describe('when job schedulers are upserted in quick succession', function () {
-    let worker: Worker;
-    beforeEach(async function () {
+    it('should create only one job scheduler and one delayed job', async function () {
       const date = new Date('2017-02-07 9:24:00');
       this.clock.setSystemTime(date);
-      worker = new Worker(
+      const worker = new Worker(
         queueName,
         async () => {
           await this.clock.tickAsync(1);
@@ -222,11 +221,7 @@ describe('Job Scheduler', function () {
         },
       );
       await worker.waitUntilReady();
-    });
-    afterEach(async function () {
-      await worker.close();
-    });
-    it('should create only one job scheduler and one delayed job', async function () {
+
       const jobSchedulerId = 'test';
       await queue.upsertJobScheduler(jobSchedulerId, {
         every: ONE_MINUTE * 5,
@@ -249,6 +244,8 @@ describe('Job Scheduler', function () {
       await this.clock.tickAsync(ONE_MINUTE);
       const delayed = await queue.getDelayed();
       expect(delayed).to.have.length(1);
+
+      await worker.close();
     });
   });
 

--- a/tests/test_job_scheduler.ts
+++ b/tests/test_job_scheduler.ts
@@ -205,6 +205,53 @@ describe('Job Scheduler', function () {
     });
   });
 
+  describe('when job schedulers are upserted in quick succession', function () {
+    let worker: Worker;
+    beforeEach(async function () {
+      const date = new Date('2017-02-07 9:24:00');
+      this.clock.setSystemTime(date);
+      worker = new Worker(
+        queueName,
+        async () => {
+          await this.clock.tickAsync(1);
+        },
+        {
+          connection,
+          prefix,
+          concurrency: 1,
+        },
+      );
+      await worker.waitUntilReady();
+    });
+    afterEach(async function () {
+      await worker.close();
+    });
+    it('should create only one job scheduler and one delayed job', async function () {
+      const jobSchedulerId = 'test';
+      await queue.upsertJobScheduler(jobSchedulerId, {
+        every: ONE_MINUTE * 5,
+      });
+      await this.clock.tickAsync(1);
+      await queue.upsertJobScheduler(jobSchedulerId, {
+        every: ONE_MINUTE * 5,
+      });
+
+      await queue.upsertJobScheduler(jobSchedulerId, {
+        every: ONE_MINUTE * 5,
+      });
+
+      await queue.upsertJobScheduler(jobSchedulerId, {
+        every: ONE_MINUTE * 5,
+      });
+
+      const repeatableJobs = await queue.getJobSchedulers();
+      expect(repeatableJobs.length).to.be.eql(1);
+      await this.clock.tickAsync(ONE_MINUTE);
+      const delayed = await queue.getDelayed();
+      expect(delayed).to.have.length(1);
+    });
+  });
+
   describe('when clocks are slightly out of sync', function () {
     it('should create only one delayed job', async function () {
       const date = new Date('2017-02-07 9:24:00');
@@ -1684,13 +1731,17 @@ describe('Job Scheduler', function () {
 
       await processingAfterFailing;
 
+      const failedCountAfterProcessing = await queue.getFailedCount();
+      expect(failedCountAfterProcessing).to.be.equal(0);
+
       await worker.close();
 
-      const delayedCount2 = await queue.getDelayedCount();
-      expect(delayedCount2).to.be.equal(1);
-
       const waitingCount = await queue.getWaitingCount();
-      expect(waitingCount).to.be.equal(0);
+      const delayedCount2 = await queue.getDelayedCount();
+
+      // Due to asynchronicities, the next job could be already in waiting state
+      // We just check that both are 1, as it should only exist 1 job in either waiting or delayed state
+      expect(waitingCount + delayedCount2).to.be.equal(1);
     });
 
     it('should not create a new delayed job if the failed job is retried with Job.retry()', async function () {
@@ -2250,7 +2301,7 @@ describe('Job Scheduler', function () {
     delayStub.restore();
   });
 
-  it('should repeat every 2 seconds with a startDate in the future', async function () {
+  it('should repeat every day with a startDate in the future', async function () {
     this.timeout(10000);
 
     // Set the initial system time


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
This PR fixes this issue: https://github.com/taskforcesh/bullmq/issues/2988
### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
This PR makes sure that the "nextMillis" portion of every repeatable jobs is always calculated on well defined so called "time slots". The offset is only used to calculate the "delay" option of the repeatable job so that it repeats at the appropriate time, but is not used for the "nextMillis" calculation anymore.
