### PR TITLE
refactor(job): add deprecated warning in discard method

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -186,6 +186,9 @@ export class Job<
 
   protected toKey: (type: string) => string;
 
+  /**
+   * @deprecated use UnrecoverableError
+   */
   protected discarded: boolean;
 
   protected scripts: Scripts;
@@ -1228,6 +1231,7 @@ export class Job<
 
   /**
    * Marks a job to not be retried if it fails (even if attempts has been configured)
+   * @deprecated use UnrecoverableError
    */
   discard(): void {
     this.discarded = true;

--- a/tests/test_bulk.ts
+++ b/tests/test_bulk.ts
@@ -120,7 +120,7 @@ describe('bulk jobs', () => {
     await removeAllQueueData(new IORedis(redisHost), parentQueueName);
   });
 
-  it('should keep workers busy', async () => {
+  it.only('should keep workers busy', async () => {
     const numJobs = 6;
     const queueEvents = new QueueEvents(queueName, { connection, prefix });
     await queueEvents.waitUntilReady();
@@ -142,8 +142,15 @@ describe('bulk jobs', () => {
     await worker.waitUntilReady();
     await worker2.waitUntilReady();
 
-    const completed = new Promise(resolve => {
-      queueEvents.on('completed', afterNumExecutions(numJobs, resolve));
+    let counter = 0;
+    const completed = new Promise<void>(resolve => {
+      queueEvents.on('completed', ({ jobId})=> {
+        counter++;
+        console.log('completed', jobId, Date.now());
+        if (counter === numJobs) {
+          resolve();
+        }
+      });
     });
 
     const jobs = Array.from(Array(numJobs).keys()).map(index => ({

--- a/tests/test_bulk.ts
+++ b/tests/test_bulk.ts
@@ -120,7 +120,7 @@ describe('bulk jobs', () => {
     await removeAllQueueData(new IORedis(redisHost), parentQueueName);
   });
 
-  it.only('should keep workers busy', async () => {
+  it('should keep workers busy', async () => {
     const numJobs = 6;
     const queueEvents = new QueueEvents(queueName, { connection, prefix });
     await queueEvents.waitUntilReady();
@@ -144,7 +144,7 @@ describe('bulk jobs', () => {
 
     let counter = 0;
     const completed = new Promise<void>(resolve => {
-      queueEvents.on('completed', ({ jobId})=> {
+      queueEvents.on('completed', ({ jobId }) => {
         counter++;
         console.log('completed', jobId, Date.now());
         if (counter === numJobs) {

--- a/tests/test_bulk.ts
+++ b/tests/test_bulk.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { default as IORedis } from 'ioredis';
-import { after as afterNumExecutions } from 'lodash';
 import { after, beforeEach, describe, it, before } from 'mocha';
 import { v4 } from 'uuid';
 import { Queue, QueueEvents, Worker, Job } from '../src/classes';
@@ -144,9 +143,8 @@ describe('bulk jobs', () => {
 
     let counter = 0;
     const completed = new Promise<void>(resolve => {
-      queueEvents.on('completed', ({ jobId }) => {
+      queueEvents.on('completed', () => {
         counter++;
-        console.log('completed', jobId, Date.now());
         if (counter === numJobs) {
           resolve();
         }


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
  1. Why is this change necessary? discard method is not working. Instead we can use UnrecoverableError
  2. What problem does it solve or improve? Avoid confusion as it's not working as intended, job is not moved to failed as in bull legacy code.
  3. Link to any relevant issues, if applicable.
_Enter your explanation here._

### How
  1. How did you implement this? Add deprecated warning for now to remember to remove it in next breaking change
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
