### PR TITLE
fix(job-scheduler): add next delayed job only when prevMillis matches with producerId

### DIFF
--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -378,6 +378,7 @@ export class Scripts {
       Date.now(),
       queueKeys[''],
       producerId ? this.queue.toKey(producerId) : '',
+      producerId,
     ];
 
     return this.execCommand(client, 'updateJobScheduler', keys.concat(args));

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -369,6 +369,7 @@ export class Scripts {
       queueKeys.delayed,
       queueKeys.events,
       queueKeys.repeat,
+      producerId ? this.queue.toKey(producerId) : '',
     ];
 
     const args = [
@@ -377,7 +378,6 @@ export class Scripts {
       pack(delayedJobOpts),
       Date.now(),
       queueKeys[''],
-      producerId ? this.queue.toKey(producerId) : '',
       producerId,
     ];
 

--- a/src/commands/updateJobScheduler-6.lua
+++ b/src/commands/updateJobScheduler-6.lua
@@ -1,23 +1,24 @@
 --[[
   Updates a job scheduler and adds next delayed job
 
-    Input:
-      KEYS[1] 'marker',
-      KEYS[2] 'meta'
-      KEYS[3] 'id'
-      KEYS[4] 'delayed'
-      KEYS[5] events stream key
-      KEYS[6] 'repeat' key
-      
-      ARGV[1] next milliseconds
-      ARGV[2] jobs scheduler id
-      ARGV[3] msgpacked delayed opts
-      ARGV[4] timestamp
-      ARGV[5] prefix key
-      ARGV[6] producer key
+  Input:
+    KEYS[1] 'marker',
+    KEYS[2] 'meta'
+    KEYS[3] 'id'
+    KEYS[4] 'delayed'
+    KEYS[5] events stream key
+    KEYS[6] 'repeat' key
 
-      Output:
-        next delayed job id  - OK
+    ARGV[1] next milliseconds
+    ARGV[2] jobs scheduler id
+    ARGV[3] msgpacked delayed opts
+    ARGV[4] timestamp
+    ARGV[5] prefix key
+    ARGV[6] producer key
+    ARGV[7] producer id
+
+    Output:
+      next delayed job id  - OK
 ]]
 local rcall = redis.call
 local repeatKey = KEYS[6]
@@ -38,24 +39,31 @@ local nextDelayedJobKey =  schedulerKey .. ":" .. nextMillis
 -- Validate that scheduler exists.
 local prevMillis = rcall("ZSCORE", repeatKey, jobSchedulerId)
 if prevMillis ~= false then
-    local schedulerAttributes = rcall("HMGET", schedulerKey, "name", "data")
+  local schedulerAttributes = rcall("HMGET", schedulerKey, "name", "data")
 
-    rcall("ZADD", repeatKey, nextMillis, jobSchedulerId)
-    
-    local eventsKey = KEYS[5]
-    local metaKey = KEYS[2]
-    local maxEvents = getOrSetMaxEvents(metaKey)
-    
-    rcall("INCR", KEYS[3])
-    
-    local delayedOpts = cmsgpack.unpack(ARGV[3])
-    
-    addDelayedJob(nextDelayedJobKey, nextDelayedJobId, delayedKey, eventsKey, schedulerAttributes[1],
-      schedulerAttributes[2] or "{}", delayedOpts, timestamp, jobSchedulerId, maxEvents, KEYS[1], nil, nil)
-    
-    if ARGV[6] ~= "" then
-      rcall("HSET", ARGV[6], "nrjid", nextDelayedJobId)
+  rcall("ZADD", repeatKey, nextMillis, jobSchedulerId)
+
+  local eventsKey = KEYS[5]
+  local metaKey = KEYS[2]
+  local maxEvents = getOrSetMaxEvents(metaKey)
+
+  rcall("INCR", KEYS[3])
+
+  local delayedOpts = cmsgpack.unpack(ARGV[3])
+  local producerId = ARGV[7]
+
+  if producerId then
+    local currentDelayedJobId =  "repeat:" .. jobSchedulerId .. ":" .. prevMillis
+
+    if producerId == currentDelayedJobId then
+      addDelayedJob(nextDelayedJobKey, nextDelayedJobId, delayedKey, eventsKey, schedulerAttributes[1],
+        schedulerAttributes[2] or "{}", delayedOpts, timestamp, jobSchedulerId, maxEvents, KEYS[1], nil, nil)
+  
+      if ARGV[6] ~= "" then
+        rcall("HSET", ARGV[6], "nrjid", nextDelayedJobId)
+      end
+
+      return nextDelayedJobId .. "" -- convert to string
     end
-    
-    return nextDelayedJobId .. "" -- convert to string    
+  end
 end

--- a/src/commands/updateJobScheduler-7.lua
+++ b/src/commands/updateJobScheduler-7.lua
@@ -8,14 +8,14 @@
     KEYS[4] 'delayed'
     KEYS[5] events stream key
     KEYS[6] 'repeat' key
+    KEYS[7] producer key
 
     ARGV[1] next milliseconds
     ARGV[2] jobs scheduler id
     ARGV[3] msgpacked delayed opts
     ARGV[4] timestamp
     ARGV[5] prefix key
-    ARGV[6] producer key
-    ARGV[7] producer id
+    ARGV[6] producer id
 
     Output:
       next delayed job id  - OK
@@ -27,7 +27,7 @@ local timestamp = ARGV[4]
 local nextMillis = ARGV[1]
 local jobSchedulerId = ARGV[2]
 local prefixKey = ARGV[5]
-local producerId = ARGV[7]
+local producerId = ARGV[6]
 
 -- Includes
 --- @include "includes/addDelayedJob"
@@ -58,8 +58,8 @@ if prevMillis ~= false then
     addDelayedJob(nextDelayedJobKey, nextDelayedJobId, delayedKey, eventsKey, schedulerAttributes[1],
       schedulerAttributes[2] or "{}", delayedOpts, timestamp, jobSchedulerId, maxEvents, KEYS[1], nil, nil)
   
-    if ARGV[6] ~= "" then
-      rcall("HSET", ARGV[6], "nrjid", nextDelayedJobId)
+    if KEYS[7] ~= "" then
+      rcall("HSET", KEYS[7], "nrjid", nextDelayedJobId)
     end
 
     return nextDelayedJobId .. "" -- convert to string


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
1. Why is this change necessary? In order to only add delayed jobs while current producer matches with prevMillis

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
1. How did you implement this? Do this validation when updating job scheduler, comparing prevMillis with producerId

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
