### PR TITLE
fix(job-scheduler): use delayed job data when template data is not present

### DIFF
--- a/src/classes/job-scheduler.ts
+++ b/src/classes/job-scheduler.ts
@@ -185,6 +185,7 @@ export class JobScheduler extends QueueBase {
             const jobId = await this.scripts.updateJobSchedulerNextMillis(
               jobSchedulerId,
               nextMillis,
+              JSON.stringify(typeof jobData === 'undefined' ? {} : jobData),
               Job.optsAsJSON(mergedOpts),
               producerId,
             );

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -354,6 +354,7 @@ export class Scripts {
   async updateJobSchedulerNextMillis(
     jobSchedulerId: string,
     nextMillis: number,
+    templateData: string,
     delayedJobOpts: JobsOptions,
     // The job id of the job that produced this next iteration
     producerId?: string,
@@ -375,6 +376,7 @@ export class Scripts {
     const args = [
       nextMillis,
       jobSchedulerId,
+      templateData,
       pack(delayedJobOpts),
       Date.now(),
       queueKeys[''],

--- a/src/commands/updateJobScheduler-7.lua
+++ b/src/commands/updateJobScheduler-7.lua
@@ -56,8 +56,16 @@ if prevMillis ~= false then
 
     local delayedOpts = cmsgpack.unpack(ARGV[4])
 
+    -- TODO: remove this workaround in next breaking change,
+    -- all job-schedulers must save job data
+    local templateData = schedulerAttributes[2] or ARGV[3]
+
+    if templateData and templateData ~= '{}' then
+      rcall("HSET", schedulerKey, "data", templateData)
+    end
+
     addDelayedJob(nextDelayedJobKey, nextDelayedJobId, delayedKey, eventsKey, schedulerAttributes[1],
-      schedulerAttributes[2] or ARGV[3], delayedOpts, timestamp, jobSchedulerId, maxEvents, KEYS[1], nil, nil)
+      templateData or '{}', delayedOpts, timestamp, jobSchedulerId, maxEvents, KEYS[1], nil, nil)
   
     if KEYS[7] ~= "" then
       rcall("HSET", KEYS[7], "nrjid", nextDelayedJobId)

--- a/src/commands/updateJobScheduler-7.lua
+++ b/src/commands/updateJobScheduler-7.lua
@@ -12,10 +12,11 @@
 
     ARGV[1] next milliseconds
     ARGV[2] jobs scheduler id
-    ARGV[3] msgpacked delayed opts
-    ARGV[4] timestamp
-    ARGV[5] prefix key
-    ARGV[6] producer id
+    ARGV[3] Json stringified delayed data
+    ARGV[4] msgpacked delayed opts
+    ARGV[5] timestamp
+    ARGV[6] prefix key
+    ARGV[7] producer id
 
     Output:
       next delayed job id  - OK
@@ -23,11 +24,11 @@
 local rcall = redis.call
 local repeatKey = KEYS[6]
 local delayedKey = KEYS[4]
-local timestamp = ARGV[4]
 local nextMillis = ARGV[1]
 local jobSchedulerId = ARGV[2]
-local prefixKey = ARGV[5]
-local producerId = ARGV[6]
+local timestamp = ARGV[5]
+local prefixKey = ARGV[6]
+local producerId = ARGV[7]
 
 -- Includes
 --- @include "includes/addDelayedJob"
@@ -53,10 +54,10 @@ if prevMillis ~= false then
 
     rcall("INCR", KEYS[3])
 
-    local delayedOpts = cmsgpack.unpack(ARGV[3])
+    local delayedOpts = cmsgpack.unpack(ARGV[4])
 
     addDelayedJob(nextDelayedJobKey, nextDelayedJobId, delayedKey, eventsKey, schedulerAttributes[1],
-      schedulerAttributes[2] or "{}", delayedOpts, timestamp, jobSchedulerId, maxEvents, KEYS[1], nil, nil)
+      schedulerAttributes[2] or ARGV[3], delayedOpts, timestamp, jobSchedulerId, maxEvents, KEYS[1], nil, nil)
   
     if KEYS[7] ~= "" then
       rcall("HSET", KEYS[7], "nrjid", nextDelayedJobId)


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
_Enter your explanation here._
  1. Why is this change necessary? Since version v[5.31.0](https://github.com/taskforcesh/bullmq/commit/9ae31bac5bb5c1f35d59db94d2af3d6eaaec1ad3) template data is saved in job scheduler record, and since v[5.34.8](https://github.com/taskforcesh/bullmq/commit/0418cd7676e730e9ddcad00ace01adbe899e124d) this same data is used for saving the next delayed job that is produced by a job scheduler. If someone migrates to v5.34.8 or a greater version, without recreating their job scheduler, next delayed jobs won't get data information.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
 1. How did you implement this? Pass delayed job data when updating a job scheduler, if no data is saved as template, reuse data from previous delayed job

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
fixes https://github.com/taskforcesh/bullmq/issues/3009
