### PR TITLE
docs: fix several grammer errors in docs

### DIFF
--- a/docs/gitbook/guide/jobs/deduplication.md
+++ b/docs/gitbook/guide/jobs/deduplication.md
@@ -4,7 +4,7 @@ Deduplication in BullMQ is a process where job execution is delayed and deduplic
 
 ## Simple Mode
 
-The Simple Mode takes a different approach by extending the deduplication duration until the job's completion or failure. This means as long as the job remains in an incomplete state (neither succeeded nor failed), any subsequent job with the same deduplication ID will be ignored.
+The Simple Mode extends the deduplication duration until the job's completion or failure. This means that as long as the job remains in an incomplete state (neither succeeded nor failed), any subsequent job with the same deduplication ID will be ignored.
 
 ```typescript
 // Add a job that will be deduplicated as this record is not finished (completed or failed).
@@ -46,7 +46,7 @@ Any manual deletion will disable the deduplication. For example, when calling _j
 
 ## Get Deduplication Job Id
 
-If you need to know which is the job id that started the deduplicated state. You can call **getDeduplicationJobId** method.
+If you need to know the id of the job that started the deduplicated state, you can call the **getDeduplicationJobId** method.
 
 ```typescript
 const jobId = await myQueue.getDeduplicationJobId('customValue');
@@ -54,7 +54,7 @@ const jobId = await myQueue.getDeduplicationJobId('customValue');
 
 ## Remove Deduplication Key
 
-If you need to stop deduplication before ttl finishes or before finishing a job. You can call **removeDeduplicationKey** method.
+If you need to stop deduplication before ttl finishes or before finishing a job, you can call the **removeDeduplicationKey** method.
 
 ```typescript
 await myQueue.removeDeduplicationKey('customValue');

--- a/docs/gitbook/guide/jobs/job-ids.md
+++ b/docs/gitbook/guide/jobs/job-ids.md
@@ -27,7 +27,7 @@ await myQueue.add(
 ```
 
 {% hint style="danger" %}
-Custom job ids must not contains **:** separator as it will be translated in 2 different values, we are also following Redis naming convention. So if you need to add a separator, use a different value, for example **-**, **\_**.
+Custom job ids must not contain the **:** separator as it will be translated in 2 different values, since we are also following Redis naming convention. So if you need to add a separator, use a different value, for example **-**, **\_**.
 {% endhint %}
 
 ## Read more:

--- a/docs/gitbook/guide/queues/README.md
+++ b/docs/gitbook/guide/queues/README.md
@@ -36,8 +36,8 @@ Prior to BullMQ 2.0, in order for delay jobs to work you need to have at least o
 From BullMQ 2.0 and onwards, the `QueueScheduler` is not needed anymore.
 {% endhint %}
 
-There are many other options available such as priorities, backoff settings, lifo behaviour, remove-on-complete policies, etc. Please check the remaining of this guide for more information regarding these options.
+There are many other options available such as priorities, backoff settings, lifo behaviour, remove-on-complete policies, etc. Please check the remainder of this guide for more information regarding these options.
 
 ## Read more:
 
-* 💡 [Queue API Reference](https://api.docs.bullmq.io/classes/v5.Queue.html)
+- 💡 [Queue API Reference](https://api.docs.bullmq.io/classes/v5.Queue.html)

--- a/docs/gitbook/guide/queuescheduler.md
+++ b/docs/gitbook/guide/queuescheduler.md
@@ -18,7 +18,7 @@ await queueScheduler.close();
 This class automatically moves delayed jobs back to the waiting queue when it is the right time to process them. It also automatically checks for stalled jobs (i.e. detects jobs that are active but where the worker has either crashed or stopped working properly). [Stalled jobs](jobs/stalled.md) are moved back or failed depending on the settings selected when instantiating the class.
 
 {% hint style="info" %}
-You need at least one `QueueScheduler` running somewhere for a given queue if you require functionality such as delayed jobs, retries with backoff and rate limiting.
+You need at least one `QueueScheduler` running somewhere for a given queue if you require functionality such as delayed jobs, retries with backoff, and rate limiting.
 {% endhint %}
 
 The reason for having this functionality in a separate class instead of in the workers (as in Bull 3.x) is because whereas you may want to have a large number of workers for parallel processing, for the scheduler you probably only want a couple of instances for each queue that requires delayed or stalled checks. One will be enough but you can have more just for redundancy.
@@ -29,4 +29,4 @@ It is ok to have as many `QueueScheduler` instances as you want, just keep in mi
 
 ## Read more:
 
-* 💡 [Queue Scheduler API Reference](https://api.docs.bullmq.io/classes/v1.QueueScheduler.html)
+- 💡 [Queue Scheduler API Reference](https://api.docs.bullmq.io/classes/v1.QueueScheduler.html)


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
My company is considering implementing BullMQ and I've been fixing obvious grammer errors as I read the docs. I noticed these errors when I had to reread the sentence a couple times in order to understand it.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
I used vim and `git grep`. :muscle: 
