### PR TITLE
fix(job-scheduler): validate if next delayed job exists

### DIFF
--- a/src/classes/job-scheduler.ts
+++ b/src/classes/job-scheduler.ts
@@ -165,22 +165,24 @@ export class JobScheduler extends QueueBase {
               producerId,
             );
 
-            const job = new this.Job<T, R, N>(
-              this,
-              jobName,
-              jobData,
-              mergedOpts,
-              jobId,
-            );
+            if (jobId) {
+              const job = new this.Job<T, R, N>(
+                this,
+                jobName,
+                jobData,
+                mergedOpts,
+                jobId,
+              );
 
-            job.id = jobId;
+              job.id = jobId;
 
-            span?.setAttributes({
-              [TelemetryAttributes.JobSchedulerId]: jobSchedulerId,
-              [TelemetryAttributes.JobId]: job.id,
-            });
+              span?.setAttributes({
+                [TelemetryAttributes.JobSchedulerId]: jobSchedulerId,
+                [TelemetryAttributes.JobId]: job.id,
+              });
 
-            return job;
+              return job;
+            }
           } else {
             const jobId = await this.scripts.updateJobSchedulerNextMillis(
               jobSchedulerId,

--- a/src/commands/updateJobScheduler-7.lua
+++ b/src/commands/updateJobScheduler-7.lua
@@ -48,29 +48,31 @@ if prevMillis ~= false then
 
     rcall("ZADD", repeatKey, nextMillis, jobSchedulerId)
 
-    local eventsKey = KEYS[5]
-    local metaKey = KEYS[2]
-    local maxEvents = getOrSetMaxEvents(metaKey)
+    if rcall("EXISTS", nextDelayedJobKey) ~= 1 then
+      local eventsKey = KEYS[5]
+      local metaKey = KEYS[2]
+      local maxEvents = getOrSetMaxEvents(metaKey)
 
-    rcall("INCR", KEYS[3])
+      rcall("INCR", KEYS[3])
 
-    local delayedOpts = cmsgpack.unpack(ARGV[4])
+      local delayedOpts = cmsgpack.unpack(ARGV[4])
 
-    -- TODO: remove this workaround in next breaking change,
-    -- all job-schedulers must save job data
-    local templateData = schedulerAttributes[2] or ARGV[3]
+      -- TODO: remove this workaround in next breaking change,
+      -- all job-schedulers must save job data
+      local templateData = schedulerAttributes[2] or ARGV[3]
 
-    if templateData and templateData ~= '{}' then
-      rcall("HSET", schedulerKey, "data", templateData)
+      if templateData and templateData ~= '{}' then
+        rcall("HSET", schedulerKey, "data", templateData)
+      end
+
+        addDelayedJob(nextDelayedJobKey, nextDelayedJobId, delayedKey, eventsKey, schedulerAttributes[1],
+          templateData or '{}', delayedOpts, timestamp, jobSchedulerId, maxEvents, KEYS[1], nil, nil)
+      
+      if KEYS[7] ~= "" then
+        rcall("HSET", KEYS[7], "nrjid", nextDelayedJobId)
+      end
+
+      return nextDelayedJobId .. "" -- convert to string
     end
-
-    addDelayedJob(nextDelayedJobKey, nextDelayedJobId, delayedKey, eventsKey, schedulerAttributes[1],
-      templateData or '{}', delayedOpts, timestamp, jobSchedulerId, maxEvents, KEYS[1], nil, nil)
-  
-    if KEYS[7] ~= "" then
-      rcall("HSET", KEYS[7], "nrjid", nextDelayedJobId)
-    end
-
-    return nextDelayedJobId .. "" -- convert to string
   end
 end

--- a/tests/test_job_scheduler.ts
+++ b/tests/test_job_scheduler.ts
@@ -53,7 +53,7 @@ describe('Job Scheduler', function () {
     await queue.close();
     await repeat.close();
     await queueEvents.close();
-    await removeAllQueueData(new IORedis(redisHost), queueName);
+    //await removeAllQueueData(new IORedis(redisHost), queueName);
   });
 
   afterAll(async function () {
@@ -241,8 +241,9 @@ describe('Job Scheduler', function () {
       const repeatableJobs = await queue.getJobSchedulers();
       expect(repeatableJobs.length).to.be.eql(1);
       await this.clock.tickAsync(ONE_MINUTE);
-      const delayed = await queue.getDelayed();
-      expect(delayed).to.have.length(1);
+      const counts = await queue.getJobCounts();
+      expect(counts.delayed).to.be.eql(0);
+      expect(counts.completed).to.be.eql(1);
 
       await worker.close();
     });
@@ -1537,6 +1538,8 @@ describe('Job Scheduler', function () {
 
   describe('when repeatable job is promoted', function () {
     it('keeps one repeatable and one delayed after being processed', async function () {
+      this.clock.restore();
+
       const repeatOpts = {
         pattern: '0 * 1 * *',
       };
@@ -1562,15 +1565,64 @@ describe('Job Scheduler', function () {
       const delayedCount2 = await queue.getDelayedCount();
       expect(delayedCount2).to.be.equal(1);
 
-      const configs = await repeat.getRepeatableJobs(0, -1, true);
+      const schedulersCount = await queue.getJobSchedulersCount();
 
       expect(delayedCount).to.be.equal(1);
 
       const count = await queue.count();
 
       expect(count).to.be.equal(1);
-      expect(configs).to.have.length(1);
+      expect(schedulersCount).to.be.equal(1);
       await worker.close();
+    });
+
+    describe('when scheduler is removed and re-added', function () {
+      it('should not add next delayed job if already existed in different state than delayed', async function () {
+        this.clock.restore();
+
+        const repeatOpts = {
+          pattern: '0 * 1 * *',
+        };
+
+        const worker = new Worker(
+          queueName,
+          async () => {
+            await queue.removeJobScheduler('test');
+            await queue.upsertJobScheduler('test', repeatOpts);
+          },
+          {
+            connection,
+            prefix,
+          },
+        );
+
+        const completing = new Promise<void>(resolve => {
+          worker.on('completed', () => {
+            resolve();
+          });
+        });
+
+        const repeatableJob = await queue.upsertJobScheduler(
+          'test',
+          repeatOpts,
+        );
+        const delayedCount = await queue.getDelayedCount();
+        expect(delayedCount).to.be.equal(1);
+
+        await repeatableJob!.promote();
+        await completing;
+
+        const delayedCountAfter = await queue.getDelayedCount();
+        expect(delayedCountAfter).to.be.equal(0);
+
+        const schedulersCount = await queue.getJobSchedulersCount();
+
+        const counts = await queue.getJobCounts();
+
+        expect(counts.completed).to.be.equal(1);
+        expect(schedulersCount).to.be.equal(1);
+        await worker.close();
+      });
     });
   });
 


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
_Enter your explanation here._
2. What problem does it solve or improve? Jobs cannot be in more than 1 state, if we do not validate if a job already exists when a delayed job that is created by a job scheduler is promoted, we can have this job id in more than 1 state, i.e active and delayed or completed and delayed
### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._
 1. How did you implement this? Validate job key existence before trying to add this record
### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
