### PR TITLE
Add React .tsx and .jsx to supportedFileTypes in worker.ts

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -259,7 +259,7 @@ export class Worker<
           }
           processor = processor.href;
         } else {
-          const supportedFileTypes = ['.js', '.ts', '.flow', '.cjs'];
+          const supportedFileTypes = ['.js', '.ts', '.flow', '.cjs', '.tsx', '.jsx'];
           const processorFile =
             processor +
             (supportedFileTypes.includes(path.extname(processor)) ? '' : '.js');


### PR DESCRIPTION
### Why
This change is necessary to ensure support for React .tsx and .jsx file types in the worker logic, particularly in scenarios where files like EmailWorker.tsx render React components and manage tasks like sending emails.
### How
Updating the supportedFileTypes array in worker.ts to include .tsx and .jsx. This allows the worker to correctly use React files.
