### PR TITLE
fix(worker): avoid possible hazard in closing worker

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -1007,18 +1007,17 @@ will never work with more accuracy than 1ms. */
       return this.closing;
     }
 
-    await this.trace<void>(
-      SpanKind.INTERNAL,
-      'close',
-      this.name,
-      async span => {
-        span?.setAttributes({
-          [TelemetryAttributes.WorkerId]: this.id,
-          [TelemetryAttributes.WorkerName]: this.opts.name,
-          [TelemetryAttributes.WorkerForceClose]: force,
-        });
-
-        this.closing = (async () => {
+    this.closing = (async () => {
+      await this.trace<void>(
+        SpanKind.INTERNAL,
+        'close',
+        this.name,
+        async span => {
+          span?.setAttributes({
+            [TelemetryAttributes.WorkerId]: this.id,
+            [TelemetryAttributes.WorkerName]: this.opts.name,
+            [TelemetryAttributes.WorkerForceClose]: force,
+          });
           this.emit('closing', 'closing queue');
           this.abortDelayController?.abort();
 
@@ -1048,11 +1047,11 @@ will never work with more accuracy than 1ms. */
 
           this.closed = true;
           this.emit('closed');
-        })();
+        },
+      );
+    })();
 
-        return await this.closing;
-      },
-    );
+    return await this.closing;
   }
 
   /**


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
It seems like in some edge cases BZPOPMIN is issued after the closing procedure starts which in some backend like DragonFly can cause a longer time to actually close the worker which leads to some tests timing out.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
Make sure BZPOPMIN is only called if the closing process has not started yet.

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
We are not 100% sure this is the cause for the timing out of some tests but still this change is needed to rule out this possibility.
