### PR TITLE
feat(queue-getters): add prometheus exporter

### DIFF
--- a/src/classes/queue-getters.ts
+++ b/src/classes/queue-getters.ts
@@ -572,4 +572,32 @@ export class QueueGetters<JobBase extends Job = Job> extends QueueBase {
     });
     return clients;
   }
+
+  /**
+   * Export the metrics for the queue in the Prometheus format.
+   * Automatically exports all the counts returned by getJobCounts().
+   *
+   * @returns - Returns a string with the metrics in the Prometheus format.
+   *
+   * @sa {@link https://prometheus.io/docs/instrumenting/exposition_formats/}
+   *
+   **/
+  async exportPrometheusMetrics(): Promise<string> {
+    const counts = await this.getJobCounts();
+    const metrics: string[] = [];
+
+    // Match the test's expected HELP text
+    metrics.push(
+      '# HELP bullmq_job_count Number of jobs in the queue by state',
+    );
+    metrics.push('# TYPE bullmq_job_count gauge');
+
+    for (const [state, count] of Object.entries(counts)) {
+      metrics.push(
+        `bullmq_job_count{queue="${this.name}", state="${state}"} ${count}`,
+      );
+    }
+
+    return metrics.join('\n');
+  }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
To provide built in support for Prometheus.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
Adding a new method ```exportPrometheusMetrics``` that returns metrics in prometheus open metrics format. 

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
An http server must be used to provide a HTTP endpoint to be consumed by prometheus. The current export only support gauges but we could add counters as well if metrics are enabled in the queue.