### PR TITLE
Feat/add skip waiting connection option

### DIFF
--- a/src/classes/flow-producer.ts
+++ b/src/classes/flow-producer.ts
@@ -114,12 +114,11 @@ export class FlowProducer extends EventEmitter {
       ...opts,
     };
 
-    this.connection = new Connection(
-      opts.connection,
-      isRedisInstance(opts.connection),
-      false,
-      opts.skipVersionCheck,
-    );
+    this.connection = new Connection(opts.connection, {
+      shared: isRedisInstance(opts.connection),
+      blocking: false,
+      skipVersionCheck: opts.skipVersionCheck,
+    });
 
     this.connection.on('error', (error: Error) => this.emit('error', error));
     this.connection.on('close', () => {

--- a/src/classes/queue-base.ts
+++ b/src/classes/queue-base.ts
@@ -67,6 +67,7 @@ export class QueueBase extends EventEmitter implements MinimalQueue {
       shared: isRedisInstance(opts.connection),
       blocking: hasBlockingConnection,
       skipVersionCheck: opts.skipVersionCheck,
+      skipWaitingForReady: opts.skipWaitingForReady,
     });
 
     this.connection.on('error', (error: Error) => this.emit('error', error));

--- a/src/classes/queue-base.ts
+++ b/src/classes/queue-base.ts
@@ -63,12 +63,11 @@ export class QueueBase extends EventEmitter implements MinimalQueue {
       throw new Error('Queue name cannot contain :');
     }
 
-    this.connection = new Connection(
-      opts.connection,
-      isRedisInstance(opts.connection),
-      hasBlockingConnection,
-      opts.skipVersionCheck,
-    );
+    this.connection = new Connection(opts.connection, {
+      shared: isRedisInstance(opts.connection),
+      blocking: hasBlockingConnection,
+      skipVersionCheck: opts.skipVersionCheck,
+    });
 
     this.connection.on('error', (error: Error) => this.emit('error', error));
     this.connection.on('close', () => {

--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -64,6 +64,7 @@ export class RedisConnection extends EventEmitter {
       shared?: boolean;
       blocking?: boolean;
       skipVersionCheck?: boolean;
+      skipWaitingForReady?: boolean;
     },
   ) {
     super();
@@ -73,6 +74,7 @@ export class RedisConnection extends EventEmitter {
       shared: false,
       blocking: true,
       skipVersionCheck: false,
+      skipWaitingForReady: false,
       ...extraOptions,
     };
 
@@ -241,7 +243,9 @@ export class RedisConnection extends EventEmitter {
 
     this._client.on('ready', this.handleClientReady);
 
-    await RedisConnection.waitUntilReady(this._client);
+    if (!this.extraOptions.skipWaitingForReady) {
+      await RedisConnection.waitUntilReady(this._client);
+    }
 
     this.loadCommands(this.packageVersion);
 

--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -59,12 +59,23 @@ export class RedisConnection extends EventEmitter {
   private handleClientReady: () => void;
 
   constructor(
-    opts?: ConnectionOptions,
-    private readonly shared: boolean = false,
-    private readonly blocking = true,
-    skipVersionCheck = false,
+    opts: ConnectionOptions,
+    private readonly extraOptions?: {
+      shared?: boolean;
+      blocking?: boolean;
+      skipVersionCheck?: boolean;
+    },
   ) {
     super();
+
+    // Set extra options defaults
+    this.extraOptions = {
+      shared: false,
+      blocking: true,
+      skipVersionCheck: false,
+      ...extraOptions,
+    };
+
     if (!isRedisInstance(opts)) {
       this.checkBlockingOptions(overrideMessage, opts);
 
@@ -77,7 +88,7 @@ export class RedisConnection extends EventEmitter {
         ...opts,
       };
 
-      if (this.blocking) {
+      if (this.extraOptions.blocking) {
         this.opts.maxRetriesPerRequest = null;
       }
     } else {
@@ -101,7 +112,9 @@ export class RedisConnection extends EventEmitter {
     }
 
     this.skipVersionCheck =
-      skipVersionCheck || !!(this.opts && this.opts.skipVersionCheck);
+      extraOptions?.skipVersionCheck ||
+      !!(this.opts && this.opts.skipVersionCheck);
+
     this.handleClientError = (err: Error): void => {
       this.emit('error', err);
     };
@@ -123,7 +136,7 @@ export class RedisConnection extends EventEmitter {
     options?: RedisOptions,
     throwError = false,
   ) {
-    if (this.blocking && options && options.maxRetriesPerRequest) {
+    if (this.extraOptions.blocking && options && options.maxRetriesPerRequest) {
       if (throwError) {
         throw new Error(msg);
       } else {
@@ -315,7 +328,7 @@ export class RedisConnection extends EventEmitter {
           // Not sure if we need to wait for this
           await this.initializing;
         }
-        if (!this.shared) {
+        if (!this.extraOptions.shared) {
           if (status == 'initializing' || force) {
             // If we have not still connected to Redis, we need to disconnect.
             this._client.disconnect();

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -315,9 +315,11 @@ export class Worker<
       isRedisInstance(opts.connection)
         ? (<Redis>opts.connection).duplicate({ connectionName })
         : { ...opts.connection, connectionName },
-      false,
-      true,
-      opts.skipVersionCheck,
+      {
+        shared: false,
+        blocking: true,
+        skipVersionCheck: opts.skipVersionCheck,
+      },
     );
     this.blockingConnection.on('error', error => this.emit('error', error));
     this.blockingConnection.on('ready', () =>

--- a/src/interfaces/queue-options.ts
+++ b/src/interfaces/queue-options.ts
@@ -38,6 +38,16 @@ export interface QueueBaseOptions {
    * Telemetry client
    */
   telemetry?: Telemetry;
+
+  /**
+   * Skip waiting for connection ready.
+   *
+   * In some instances if you want the queue to fail fast if the connection is
+   * not ready you can set this to true. This could be useful for testing and when
+   * adding jobs via HTTP endpoints for example.
+   *
+   */
+  skipWaitingForReady?: boolean;
 }
 
 /**
@@ -75,11 +85,6 @@ export interface QueueOptions extends QueueBaseOptions {
    * Advanced options for the repeatable jobs.
    */
   settings?: AdvancedRepeatOptions;
-
-  /**
-   * Telemetry client
-   */
-  telemetry?: Telemetry;
 }
 
 /**

--- a/tests/test_script_loader.ts
+++ b/tests/test_script_loader.ts
@@ -330,7 +330,7 @@ describe('scriptLoader', () => {
     //let loader: ScriptLoader;
 
     beforeEach(async () => {
-      connection = new RedisConnection();
+      connection = new RedisConnection({});
       connection.on('error', () => {});
       client = await connection.client;
       await RedisConnection.waitUntilReady(client);


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
When failing fast if the connection is not available, it is sometimes also needed to fail in the case the initial connection has not yet being stablished with Redis. More background can be found here: https://github.com/taskforcesh/bullmq/issues/995

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
We introduced a new option "skipWaitingForReady" that is by default false, to keep the old behaviour and no introduce breaking changes.

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
