### PR TITLE
feat: add a queue registry

### DIFF
--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -21,6 +21,7 @@ import { RedisConnection } from './redis-connection';
 import { SpanKind, TelemetryAttributes } from '../enums';
 import { JobScheduler } from './job-scheduler';
 import { version } from '../version';
+import { BullMQRegistryKey } from '../consts/bullmq-registry-key';
 
 export interface ObliterateOpts {
   /**
@@ -179,13 +180,30 @@ export class Queue<
     this.waitUntilReady()
       .then(client => {
         if (!this.closing && !opts?.skipMetasUpdate) {
-          return client.hmset(this.keys.meta, this.metaValues);
+          const multi = client.multi();
+          multi.hmset(this.keys.meta, this.metaValues);
+          multi.zadd(BullMQRegistryKey, Date.now(), this.qualifiedName);
         }
       })
       .catch(err => {
         // We ignore this error to avoid warnings. The error can still
         // be received by listening to event 'error'
       });
+  }
+
+  /**
+   * Returns the queues that are available in the registry.
+   * @param start - zero based index from where to start returning jobs.
+   * @param end - zero based index where to stop returning jobs.
+   */
+  static getRegistry(
+    client: {
+      zrange: (key: string, start: number, end: number) => Promise<string[]>;
+    },
+    start = 0,
+    end = -1,
+  ): Promise<string[]> {
+    return client.zrange(BullMQRegistryKey, start, end);
   }
 
   emit<U extends keyof QueueListener<JobBase<DataType, ResultType, NameType>>>(

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -43,6 +43,7 @@ import {
 } from '../utils';
 import { ChainableCommander } from 'ioredis';
 import { version as packageVersion } from '../version';
+import { BullMQRegistryKey } from '../consts/bullmq-registry-key';
 export type JobData = [JobJsonRaw | number, string?];
 
 export class Scripts {
@@ -1464,6 +1465,7 @@ export class Scripts {
     const client = await this.queue.client;
 
     const keys: (string | number)[] = [
+      BullMQRegistryKey,
       this.queue.keys.meta,
       this.queue.toKey(''),
     ];

--- a/src/commands/obliterate-3.lua
+++ b/src/commands/obliterate-3.lua
@@ -9,15 +9,16 @@
   however this behaviour can be overrided using the 'force' option.
   
   Input:
-    KEYS[1] meta
-    KEYS[2] base
+    KEYS[1] registry key
+    KEYS[2] meta
+    KEYS[3] base
 
     ARGV[1] count
     ARGV[2] force
 ]]
 
 local maxCount = tonumber(ARGV[1])
-local baseKey = KEYS[2]
+local baseKey = KEYS[3]
 
 local rcall = redis.call
 
@@ -33,7 +34,7 @@ local function removeLockKeys(keys)
 end
 
 -- 1) Check if paused, if not return with error.
-if rcall("HEXISTS", KEYS[1], "paused") ~= 1 then
+if rcall("HEXISTS", KEYS[2], "paused") ~= 1 then
   return -1 -- Error, NotPaused
 end
 
@@ -98,6 +99,9 @@ maxCount = removeZSetJobs(failedKey, true, baseKey, maxCount)
 if(maxCount <= 0) then
   return 1
 end
+
+-- Remove from BullMQ registry
+rcall("ZREM", KEYS[1], KEYS[3])
 
 if(maxCount > 0) then
   rcall("DEL",

--- a/src/consts/bullmq-registry-key.ts
+++ b/src/consts/bullmq-registry-key.ts
@@ -1,0 +1,1 @@
+export const BullMQRegistryKey = 'bullmq:registry';


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
To be able to efficiently get all the bullmq queues that are available in a Redis host. This feature makes
queue discovery a mostly O(1) operation instead of O(n).

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
Added a new key with a fixed name: "bullmq:registry", that holds a ZSET with the fully queue qualified names. This queue names will be kept in the registry until the queue is completely obliterated.

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->

