### PR TITLE
fix(queue-getters): filter undefined jobs from getJobs

### DIFF
--- a/src/classes/queue-getters.ts
+++ b/src/classes/queue-getters.ts
@@ -391,9 +391,13 @@ export class QueueGetters<JobBase extends Job = Job> extends QueueBase {
 
     const jobIds = await this.getRanges(currentTypes, start, end, asc);
 
-    return Promise.all(
-      jobIds.map(jobId => this.Job.fromId(this, jobId) as Promise<JobBase>),
+    const jobs: (JobBase | undefined)[] = await Promise.all(
+      jobIds.map(
+        jobId => this.Job.fromId(this, jobId) as Promise<JobBase | undefined>,
+      ),
     );
+
+    return jobs.filter(job => Boolean(job));
   }
 
   /**


### PR DESCRIPTION
Ensure getJobs does not return undefined if a job is deleted between ID retrieval and fetching.

# Why

* getJobs could return undefined if a job was deleted between ID retrieval with a return type `Promise<JobBase[]>`
* This caused unexpected behavior when processing job lists.
* Fixing this ensures getJobs only returns valid job objects.

# How

* Updated getJobs to filter out undefined results.
* Ensured that the function always returns a valid JobBase[] array.