### PR TITLE
fix(retry-job): consider updating failures in job

### DIFF
--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -24,6 +24,7 @@ import {
   KeepJobs,
   MoveToDelayedOpts,
   RepeatableOptions,
+  RetryJobOpts,
 } from '../interfaces';
 import {
   JobState,
@@ -1165,7 +1166,7 @@ export class Scripts {
     jobId: string,
     lifo: boolean,
     token: string,
-    fieldsToUpdate?: Record<string, any>,
+    opts: MoveToDelayedOpts = {},
   ): (string | number | Buffer)[] {
     const keys: (string | number | Buffer)[] = [
       this.queue.keys.active,
@@ -1189,19 +1190,21 @@ export class Scripts {
       pushCmd,
       jobId,
       token,
-      fieldsToUpdate ? pack(objectToFlatArray(fieldsToUpdate)) : void 0,
+      opts.fieldsToUpdate
+        ? pack(objectToFlatArray(opts.fieldsToUpdate))
+        : void 0,
     ]);
   }
 
   async retryJob(
     jobId: string,
     lifo: boolean,
-    token: string,
-    fieldsToUpdate?: Record<string, any>,
+    token = '0',
+    opts: MoveToDelayedOpts = {},
   ): Promise<void> {
     const client = await this.queue.client;
 
-    const args = this.retryJobArgs(jobId, lifo, token, fieldsToUpdate);
+    const args = this.retryJobArgs(jobId, lifo, token, opts);
     const result = await this.execCommand(client, 'retryJob', args);
     if (result < 0) {
       throw this.finishedErrors({

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -1200,7 +1200,7 @@ export class Scripts {
     jobId: string,
     lifo: boolean,
     token = '0',
-    opts: MoveToDelayedOpts = {},
+    opts: RetryJobOpts = {},
   ): Promise<void> {
     const client = await this.queue.client;
 

--- a/src/commands/includes/updateJobFields.lua
+++ b/src/commands/includes/updateJobFields.lua
@@ -2,10 +2,10 @@
   Function to update a bunch of fields in a job.
 ]]
 local function updateJobFields(jobKey, msgpackedFields)
-    if msgpackedFields and #msgpackedFields > 0 then
-        local fieldsToUpdate = cmsgpack.unpack(msgpackedFields)
-        if fieldsToUpdate then
-            redis.call("HMSET", jobKey, unpack(fieldsToUpdate))
-        end
+  if msgpackedFields and #msgpackedFields > 0 then
+    local fieldsToUpdate = cmsgpack.unpack(msgpackedFields)
+    if fieldsToUpdate then
+      rcall("HMSET", jobKey, unpack(fieldsToUpdate))
     end
+  end
 end

--- a/src/interfaces/minimal-job.ts
+++ b/src/interfaces/minimal-job.ts
@@ -9,6 +9,10 @@ export interface MoveToDelayedOpts {
   fieldsToUpdate?: Record<string, any>;
 }
 
+export interface RetryJobOpts {
+  fieldsToUpdate?: Record<string, any>;
+}
+
 export interface MoveToWaitingChildrenOpts {
   child?: {
     id: string;


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? Errors are not updated when retrying a job

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Pass right object into retryJob script and reuse updateJobFields include 

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
