### PR TITLE
fix(job-scheduler): decouple scheduler from delayed job

### DIFF
--- a/src/classes/job-scheduler.ts
+++ b/src/classes/job-scheduler.ts
@@ -1,5 +1,6 @@
 import { parseExpression } from 'cron-parser';
 import {
+  JobRepeatOptsRaw,
   JobSchedulerJson,
   JobSchedulerTemplateJson,
   RedisClient,
@@ -33,6 +34,7 @@ export class JobScheduler extends QueueBase {
 
   async upsertJobScheduler<T = any, R = any, N extends string = string>(
     jobSchedulerId: string,
+    rawRepeatOpts: JobRepeatOptsRaw,
     repeatOpts: Omit<RepeatOptions, 'key' | 'prevMillis'>,
     jobName: N,
     jobData: T,
@@ -268,11 +270,11 @@ export class JobScheduler extends QueueBase {
     return this.transformSchedulerData<D>(key, jobData, next);
   }
 
-  private async transformSchedulerData<D>(
+  private transformSchedulerData<D>(
     key: string,
     jobData: any,
     next?: number,
-  ): Promise<JobSchedulerJson<D>> {
+  ): JobSchedulerJson<D> {
     if (jobData) {
       const jobSchedulerData: JobSchedulerJson<D> = {
         key,
@@ -314,6 +316,7 @@ export class JobScheduler extends QueueBase {
       return jobSchedulerData;
     }
 
+    // TODO: remove next line in next breaking change
     return this.keyToData(key, next);
   }
 

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -5,6 +5,7 @@ import {
   DependenciesOpts,
   JobJson,
   JobJsonRaw,
+  JobRepeatOptsRaw,
   MinimalJob,
   MoveToWaitingChildrenOpts,
   ParentKeys,

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -1616,9 +1616,12 @@ export class Scripts {
 
 export function raw2NextJobData(raw: any[]) {
   if (raw) {
-    const result = [null, raw[1], raw[2], raw[3]];
+    const result = [null, raw[1], null, raw[2], raw[3]];
     if (raw[0]) {
       result[0] = array2obj(raw[0]);
+    }
+    if (raw[2]) {
+      result[2] = array2obj(raw[2]);
     }
     return result;
   }

--- a/src/interfaces/job-json.ts
+++ b/src/interfaces/job-json.ts
@@ -47,3 +47,17 @@ export interface JobJsonRaw {
   ats?: string;
   pb?: string; // Worker name
 }
+// TODO: Evaluate tm value
+
+export interface JobRepeatOptsRaw {
+  tz?: string;
+  limit?: string;
+  pattern?: string;
+  endDate?: string;
+  every?: string;
+  opts?: string;
+  data?: string;
+  name: string;
+  ic: string;
+  prevM: number;
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? There is a hard dependency between a delayed job generated by scheduler template and the next iteration. Job scheduler data must be the source of truth once it gets updated

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Return scheduler data along side with delayed job once it gets passed to active

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
