### PR TITLE
fix(worker): process job when closing and it was moved to active

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -819,7 +819,7 @@ will never work with more accuracy than 1ms. */
     fetchNextCallback = () => true,
     jobsInProgress: Set<{ job: Job; ts: number }>,
   ): Promise<void | Job<DataType, ResultType, NameType>> {
-    if (!job || this.closing || this.paused) {
+    if (!job) {
       return;
     }
 

--- a/src/commands/addDelayedJob-6.lua
+++ b/src/commands/addDelayedJob-6.lua
@@ -88,7 +88,7 @@ else
     end
 end
 
-local deduplicationJobId = deduplicateJob(args[1], opts['de'],
+local deduplicationJobId = deduplicateJob(opts['de'],
   jobId, deduplicationKey, eventsKey, maxEvents)
 if deduplicationJobId then
   return deduplicationJobId

--- a/src/commands/addParentJob-4.lua
+++ b/src/commands/addParentJob-4.lua
@@ -81,7 +81,7 @@ else
     end
 end
 
-local deduplicationJobId = deduplicateJob(args[1], opts['de'],
+local deduplicationJobId = deduplicateJob(opts['de'],
   jobId, deduplicationKey, eventsKey, maxEvents)
 if deduplicationJobId then
   return deduplicationJobId

--- a/src/commands/addPrioritizedJob-8.lua
+++ b/src/commands/addPrioritizedJob-8.lua
@@ -90,7 +90,7 @@ else
     end
 end
 
-local deduplicationJobId = deduplicateJob(args[1], opts['de'],
+local deduplicationJobId = deduplicateJob(opts['de'],
   jobId, deduplicationKey, eventsKey, maxEvents)
 if deduplicationJobId then
   return deduplicationJobId

--- a/src/commands/addStandardJob-8.lua
+++ b/src/commands/addStandardJob-8.lua
@@ -94,7 +94,7 @@ else
     end
 end
 
-local deduplicationJobId = deduplicateJob(args[1], opts['de'],
+local deduplicationJobId = deduplicateJob(opts['de'],
   jobId, deduplicationKey, eventsKey, maxEvents)
 if deduplicationJobId then
   return deduplicationJobId


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? When a job is moved to active, even when closing. We need to try to process it. If not, we will create stalled jobs

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Remove closing check when processing a job

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
