### PR TITLE
fix(worker): evaluate if a job needs to be fetched when moving to failed

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -878,7 +878,11 @@ will never work with more accuracy than 1ms. */
                 return;
               }
 
-              const result = await job.moveToFailed(err, token, true);
+              const result = await job.moveToFailed(
+                err,
+                token,
+                fetchNextCallback() && !(this.closing || this.paused),
+              );
               this.emit('failed', job, err, 'active');
 
               span?.addEvent('job failed', {


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
1. Why is this change necessary? No need to fetch need job always when moving a job to failed, need to use similar logic as we do with move to completed

### How
<!--

  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Use same logic as in move to completed

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
