### PR TITLE
refactor(pause): stop run execution

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -472,12 +472,10 @@ export class Worker<
          */
         while (
           !this.waiting &&
+          !this.paused &&
           numTotal < this._concurrency &&
           (!this.limitUntil || numTotal == 0)
         ) {
-          if (this.paused) {
-            break;
-          }
           const token = `${this.id}:${tokenPostfix++}`;
 
           const fetchedJob = this.retryIfFailed<void | Job<

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -185,7 +185,6 @@ export class Worker<
   private drained: boolean = false;
   private extendLocksTimer: NodeJS.Timeout | null = null;
   private limitUntil = 0;
-  private resumeWorker: () => void;
 
   private stalledCheckStopper?: () => void;
   private waiting: Promise<number> | null = null;
@@ -193,7 +192,7 @@ export class Worker<
 
   protected _jobScheduler: JobScheduler;
 
-  protected paused: Promise<void>;
+  protected paused: boolean;
   protected processFn: Processor<DataType, ResultType, NameType>;
   protected running = false;
 
@@ -442,7 +441,7 @@ export class Worker<
     try {
       this.running = true;
 
-      if (this.closing) {
+      if (this.closing || this.paused) {
         return;
       }
 
@@ -464,7 +463,7 @@ export class Worker<
        * as efficiently as possible, providing concurrency and minimal unnecessary calls
        * to Redis.
        */
-      while (!this.closing) {
+      while (!(this.closing || this.paused)) {
         let numTotal = asyncFifoQueue.numTotal();
 
         /**
@@ -476,6 +475,9 @@ export class Worker<
           numTotal < this._concurrency &&
           (!this.limitUntil || numTotal == 0)
         ) {
+          if (this.paused) {
+            break;
+          }
           const token = `${this.id}:${tokenPostfix++}`;
 
           const fetchedJob = this.retryIfFailed<void | Job<
@@ -582,11 +584,7 @@ export class Worker<
     { block = true }: GetNextJobOptions = {},
   ): Promise<Job<DataType, ResultType, NameType> | undefined> {
     if (this.paused) {
-      if (block) {
-        await this.paused;
-      } else {
-        return;
-      }
+      return;
     }
 
     if (this.closing) {
@@ -819,7 +817,7 @@ will never work with more accuracy than 1ms. */
     fetchNextCallback = () => true,
     jobsInProgress: Set<{ job: Job; ts: number }>,
   ): Promise<void | Job<DataType, ResultType, NameType>> {
-    if (!job || this.closing || this.paused) {
+    if (!job || this.closing) {
       return;
     }
 
@@ -944,14 +942,9 @@ will never work with more accuracy than 1ms. */
         });
 
         if (!this.paused) {
-          this.paused = new Promise(resolve => {
-            this.resumeWorker = function () {
-              resolve();
-              this.paused = null; // Allow pause to be checked externally for paused state.
-              this.resumeWorker = null;
-            };
-          });
+          this.paused = true;
           await (!doNotWaitActive && this.whenCurrentJobsFinished());
+          this.stalledCheckStopper?.();
           this.emit('paused');
         }
       },
@@ -963,14 +956,16 @@ will never work with more accuracy than 1ms. */
    * Resumes processing of this worker (if paused).
    */
   resume(): void {
-    if (this.resumeWorker) {
+    if (!this.running) {
       this.trace<void>(SpanKind.INTERNAL, 'resume', this.name, span => {
         span?.setAttributes({
           [TelemetryAttributes.WorkerId]: this.id,
           [TelemetryAttributes.WorkerName]: this.opts.name,
         });
 
-        this.resumeWorker();
+        this.paused = false;
+
+        this.run();
         this.emit('resumed');
       });
     }
@@ -1095,7 +1090,7 @@ will never work with more accuracy than 1ms. */
   }
 
   private async stalledChecker() {
-    while (!this.closing) {
+    while (!(this.closing || this.paused)) {
       try {
         await this.checkConnectionError(() => this.moveStalledJobsToWait());
       } catch (err) {

--- a/tests/test_worker.ts
+++ b/tests/test_worker.ts
@@ -2410,7 +2410,8 @@ describe('workers', function () {
 
               // Wait for all the active jobs to finalize.
               expect(nbJobFinish).to.be.equal(3);
-              await worker.resume();
+              await delay(100);
+              worker.resume();
             }
           } catch (err) {
             console.error(err);

--- a/tests/test_worker.ts
+++ b/tests/test_worker.ts
@@ -2399,6 +2399,7 @@ describe('workers', function () {
 
       let i = 0;
       let nbJobFinish = 0;
+      let runExecution: Promise<void>;
 
       const worker = new Worker(
         queueName,
@@ -2410,8 +2411,6 @@ describe('workers', function () {
 
               // Wait for all the active jobs to finalize.
               expect(nbJobFinish).to.be.equal(3);
-              await delay(100);
-              worker.resume();
             }
           } catch (err) {
             console.error(err);
@@ -2427,6 +2426,7 @@ describe('workers', function () {
           }
         },
         {
+          autorun: false,
           connection,
           prefix,
           concurrency: 4,
@@ -2440,7 +2440,21 @@ describe('workers', function () {
         worker.on('failed', cb);
         worker.on('error', reject);
       });
+      const pausing = new Promise<void>(resolve => {
+        worker.on('paused', async () => {
+          // test that loop is stopped and worker is actually paused
+          await runExecution;
+          expect(worker.isRunning()).to.be.false;
+
+          worker.resume();
+          resolve();
+        });
+      });
       await Promise.all(times(8, () => queue.add('test', {})));
+
+      runExecution = worker.run();
+
+      await pausing;
 
       await waiting;
 


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? As part of trying to fix the processing of jobs when closing a worker. When pausing a job we don't need to wait for a promise, instead just set it as paused and stop run execution

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Remove promise from pause method and refactor resume method to re-execute run method

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
Notice that we wait for pending jobs in https://github.com/taskforcesh/bullmq/blob/master/src/classes/worker.ts#L954 when pausing a worker by default, but we can possibly add paused promise into async queue https://github.com/taskforcesh/bullmq/blob/master/src/classes/worker.ts#L586, that means that we can get pause method hanging
