### PR TITLE
fix(worker): wait fetched jobs to be processed when closing

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -453,7 +453,8 @@ export class Worker<
 
       this.mainLoopRunning = this.mainLoop(client, bclient);
 
-      return this.mainLoopRunning;
+      // We must await here or finally will be called too early.
+      await this.mainLoopRunning;
     } finally {
       this.running = false;
     }

--- a/tests/test_bulk.ts
+++ b/tests/test_bulk.ts
@@ -162,7 +162,7 @@ describe('bulk jobs', () => {
     await worker.close();
     await worker2.close();
     await queueEvents.close();
-  });
+  }).timeout(10_000);
 
   it('should process jobs with custom ids', async () => {
     const name = 'test';

--- a/tests/test_events.ts
+++ b/tests/test_events.ts
@@ -29,6 +29,7 @@ describe('events', function () {
 
   beforeEach(async function () {
     queueName = `test-${v4()}`;
+    console.log('queueName', queueName);
     queue = new Queue(queueName, { connection, prefix });
     queueEvents = new QueueEvents(queueName, { connection, prefix });
     await queue.waitUntilReady();

--- a/tests/test_events.ts
+++ b/tests/test_events.ts
@@ -29,7 +29,6 @@ describe('events', function () {
 
   beforeEach(async function () {
     queueName = `test-${v4()}`;
-    console.log('queueName', queueName);
     queue = new Queue(queueName, { connection, prefix });
     queueEvents = new QueueEvents(queueName, { connection, prefix });
     await queue.waitUntilReady();

--- a/tests/test_worker.ts
+++ b/tests/test_worker.ts
@@ -2404,18 +2404,6 @@ describe('workers', function () {
       const worker = new Worker(
         queueName,
         async () => {
-          try {
-            if (++i === 4) {
-              // Pause when all 4 works are processing
-              await worker.pause();
-
-              // Wait for all the active jobs to finalize.
-              expect(nbJobFinish).to.be.equal(3);
-            }
-          } catch (err) {
-            console.error(err);
-          }
-
           // 100 - i*20 is to force to finish job n°4 before lower jobs that will wait longer
           await delay(100 - i * 10);
           nbJobFinish++;
@@ -2433,6 +2421,15 @@ describe('workers', function () {
         },
       );
       await worker.waitUntilReady();
+
+      worker.on('active', async () => {
+        if (++i === 4) {
+          // Pause when all 4 works are processing
+          await worker.pause();
+          // Wait for all the active jobs to finalize.
+          expect(nbJobFinish).to.be.equal(3);
+        }
+      });
 
       const waiting = new Promise((resolve, reject) => {
         const cb = after(8, resolve);


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
This change is necessary to avoid possible stalled jobs when closing a worker, since the close operation just stops processing the jobs that may be already in active status but have not yet started to be processed.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
Making sure that we wait for the jobs to complete before resolving the close promise.

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
