### PR TITLE
refactor(deduplicate-job): remove unused prefixKey variable

### DIFF
--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -158,7 +158,7 @@ export class Queue<
 
   protected libName = 'bullmq';
 
-  private _repeat?: Repeat; // To be deprecated in v6 in favor of JobScheduler
+  protected _repeat?: Repeat; // To be deprecated in v6 in favor of JobScheduler
   protected _jobScheduler?: JobScheduler;
 
   constructor(

--- a/src/commands/addDelayedJob-6.lua
+++ b/src/commands/addDelayedJob-6.lua
@@ -88,8 +88,8 @@ else
     end
 end
 
-local deduplicationJobId = deduplicateJob(args[1], opts['de'],
-  jobId, deduplicationKey, eventsKey, maxEvents)
+local deduplicationJobId = deduplicateJob(opts['de'], jobId, deduplicationKey,
+  eventsKey, maxEvents)
 if deduplicationJobId then
   return deduplicationJobId
 end

--- a/src/commands/addParentJob-4.lua
+++ b/src/commands/addParentJob-4.lua
@@ -81,8 +81,8 @@ else
     end
 end
 
-local deduplicationJobId = deduplicateJob(args[1], opts['de'],
-  jobId, deduplicationKey, eventsKey, maxEvents)
+local deduplicationJobId = deduplicateJob(opts['de'], jobId,
+  deduplicationKey, eventsKey, maxEvents)
 if deduplicationJobId then
   return deduplicationJobId
 end

--- a/src/commands/addPrioritizedJob-8.lua
+++ b/src/commands/addPrioritizedJob-8.lua
@@ -90,8 +90,8 @@ else
     end
 end
 
-local deduplicationJobId = deduplicateJob(args[1], opts['de'],
-  jobId, deduplicationKey, eventsKey, maxEvents)
+local deduplicationJobId = deduplicateJob(opts['de'], jobId,
+  deduplicationKey, eventsKey, maxEvents)
 if deduplicationJobId then
   return deduplicationJobId
 end

--- a/src/commands/addStandardJob-8.lua
+++ b/src/commands/addStandardJob-8.lua
@@ -94,8 +94,8 @@ else
     end
 end
 
-local deduplicationJobId = deduplicateJob(args[1], opts['de'],
-  jobId, deduplicationKey, eventsKey, maxEvents)
+local deduplicationJobId = deduplicateJob(opts['de'], jobId,
+  deduplicationKey, eventsKey, maxEvents)
 if deduplicationJobId then
   return deduplicationJobId
 end

--- a/src/commands/includes/deduplicateJob.lua
+++ b/src/commands/includes/deduplicateJob.lua
@@ -2,7 +2,7 @@
   Function to debounce a job.
 ]]
 
-local function deduplicateJob(prefixKey, deduplicationOpts, jobId, deduplicationKey, eventsKey, maxEvents)
+local function deduplicateJob(deduplicationOpts, jobId, deduplicationKey, eventsKey, maxEvents)
   local deduplicationId = deduplicationOpts and deduplicationOpts['id']
   if deduplicationId then
     local ttl = deduplicationOpts['ttl']

--- a/src/commands/includes/getNextDelayedTimestamp.lua
+++ b/src/commands/includes/getNextDelayedTimestamp.lua
@@ -5,7 +5,7 @@ local function getNextDelayedTimestamp(delayedKey)
   local result = rcall("ZRANGE", delayedKey, 0, 0, "WITHSCORES")
   if #result then
     local nextTimestamp = tonumber(result[2])
-    if nextTimestamp ~= nil then 
+    if nextTimestamp ~= nil then
       return nextTimestamp / 0x1000
     end
   end


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? Remove unused prefixKey variable

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Remove it from deduplicateJob include and all references when this method is called

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
