### PR TITLE
fix(job-scheduler): return undefined in getJobScheduler when it does not exist

### DIFF
--- a/src/classes/job-scheduler.ts
+++ b/src/classes/job-scheduler.ts
@@ -283,7 +283,9 @@ export class JobScheduler extends QueueBase {
       };
     }
 
-    return this.keyToData(key, next);
+    if (key.includes(':')) {
+      return this.keyToData(key, next);
+    }
   }
 
   private keyToData(key: string, next?: number): JobSchedulerJson {
@@ -301,7 +303,9 @@ export class JobScheduler extends QueueBase {
     };
   }
 
-  async getScheduler<D = any>(id: string): Promise<JobSchedulerJson<D>> {
+  async getScheduler<D = any>(
+    id: string,
+  ): Promise<JobSchedulerJson<D> | undefined> {
     const [rawJobData, next] = await this.scripts.getJobScheduler(id);
 
     return this.transformSchedulerData<D>(

--- a/src/classes/job-scheduler.ts
+++ b/src/classes/job-scheduler.ts
@@ -283,6 +283,7 @@ export class JobScheduler extends QueueBase {
       };
     }
 
+    // TODO: remove this check and keyToData as it is here only to support legacy code
     if (key.includes(':')) {
       return this.keyToData(key, next);
     }

--- a/tests/test_job_scheduler.ts
+++ b/tests/test_job_scheduler.ts
@@ -340,6 +340,14 @@ describe('Job Scheduler', function () {
     });
   });
 
+  describe('when job scheduler does not exist', function () {
+    it('should return undefined', async function () {
+      const scheduler = await queue.getJobScheduler('test');
+
+      expect(scheduler).to.be.undefined;
+    });
+  });
+
   it('should create job schedulers with different cron patterns', async function () {
     const date = new Date('2017-02-07T15:24:00.000Z');
     this.clock.setSystemTime(date);


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? If job scheduler does not exist, getJobScheduler method tries to split the id because of the old format of repeatable jobs. But as old format requires to have this id separated by :, we can also validate that the id does not contains :. Take in count that transformation of this data is being used for getJobSchedulers too.

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Change retuned type to undefined and when validating old format, make sure id/ key contains : before trying to transform it to old repeatable format

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
fixes https://github.com/taskforcesh/bullmq/issues/3062