### PR TITLE
fix(drain): delay queuekey for redis cluster

### DIFF
--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -656,12 +656,12 @@ export class Scripts {
     const keys: (string | number)[] = [
       queueKeys.wait,
       queueKeys.paused,
-      delayed ? queueKeys.delayed : this.queue.toKey(''),
+      queueKeys.delayed,
       queueKeys.prioritized,
       queueKeys.repeat,
     ];
 
-    const args = [queueKeys['']];
+    const args = [queueKeys[''], delayed ? '1' : '0'];
 
     return keys.concat(args);
   }

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -656,7 +656,7 @@ export class Scripts {
     const keys: (string | number)[] = [
       queueKeys.wait,
       queueKeys.paused,
-      delayed ? queueKeys.delayed : '',
+      delayed ? queueKeys.delayed : this.queue.toKey(''),
       queueKeys.prioritized,
       queueKeys.repeat,
     ];

--- a/src/commands/drain-5.lua
+++ b/src/commands/drain-5.lua
@@ -20,7 +20,7 @@ local queueBaseKey = ARGV[1]
 removeListJobs(KEYS[1], true, queueBaseKey, 0) -- wait
 removeListJobs(KEYS[2], true, queueBaseKey, 0) -- paused
 
-if KEYS[3] ~= "" then
+if KEYS[3] ~= queueBaseKey then
 
     -- We must not remove delayed jobs if they are associated to a job scheduler.
     local scheduledJobs = {}

--- a/src/commands/drain-5.lua
+++ b/src/commands/drain-5.lua
@@ -10,6 +10,7 @@
     KEYS[5] 'jobschedulers' (repeat)
 
     ARGV[1]  queue key prefix
+    ARGV[2]  should clean delayed jobs
 ]]
 local rcall = redis.call
 local queueBaseKey = ARGV[1]
@@ -20,7 +21,7 @@ local queueBaseKey = ARGV[1]
 removeListJobs(KEYS[1], true, queueBaseKey, 0) -- wait
 removeListJobs(KEYS[2], true, queueBaseKey, 0) -- paused
 
-if KEYS[3] ~= queueBaseKey then
+if ARGV[2] == "1" then
 
     -- We must not remove delayed jobs if they are associated to a job scheduler.
     local scheduledJobs = {}


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
fix crossslot error when running queue.drain() in redis cluster

### How
replace '' key with queue.toKey('') to include hash tag


