### PR TITLE
fix(job): set processedBy when moving job to active in moveToFinished

### DIFF
--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -597,6 +597,7 @@ export class Scripts {
       queueKeys[''],
       pack({
         token,
+        name: opts.name,
         keepJobs,
         limiter: opts.limiter,
         lockDuration: opts.lockDuration,

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -173,11 +173,6 @@ export class Worker<
   readonly id: string;
 
   private abortDelayController: AbortController | null = null;
-  private asyncFifoQueue: AsyncFifoQueue<void | Job<
-    DataType,
-    ResultType,
-    NameType
-  >>;
   private blockingConnection: RedisConnection;
   private blockUntil = 0;
   private _concurrency: number;
@@ -466,11 +461,11 @@ export class Worker<
    * to Redis.
    */
   private async mainLoop(client: RedisClient, bclient: RedisClient) {
-    const asyncFifoQueue = (this.asyncFifoQueue = new AsyncFifoQueue<void | Job<
+    const asyncFifoQueue = new AsyncFifoQueue<void | Job<
       DataType,
       ResultType,
       NameType
-    >>());
+    >>();
     const jobsInProgress = new Set<{ job: Job; ts: number }>();
     this.startLockExtenderTimer(jobsInProgress);
 

--- a/src/commands/moveToActive-11.lua
+++ b/src/commands/moveToActive-11.lua
@@ -33,6 +33,7 @@
     opts - token - lock token
     opts - lockDuration
     opts - limiter
+    opts - name - worker name
 ]]
 local rcall = redis.call
 local waitKey = KEYS[1]

--- a/src/commands/moveToFinished-14.lua
+++ b/src/commands/moveToFinished-14.lua
@@ -42,6 +42,7 @@
       opts - fpof - fail parent on fail
       opts - idof - ignore dependency on fail
       opts - rdof - remove dependency on fail
+      opts - name - worker name
 
     Output:
       0 OK

--- a/tests/test_worker.ts
+++ b/tests/test_worker.ts
@@ -714,23 +714,25 @@ describe('workers', function () {
       worker = new Worker(
         queueName,
         async job => {
-          const fetchedJob = await queue.getJob(job.id!);
-
           try {
-            expect(fetchedJob).to.be.ok;
-            expect(fetchedJob!.processedBy).to.be.equal(worker.opts.name);
+            await delay(100);
+            expect(job).to.be.ok;
+            expect(job!.processedBy).to.be.equal(worker.opts.name);
           } catch (err) {
             reject(err);
           }
 
-          resolve();
+          if (job.data.foo === 'baz') {
+            resolve();
+          }
         },
         { connection, prefix, name: 'foobar' },
       );
       await worker.waitUntilReady();
     });
 
-    await queue.add('test', { foo: 'bar' });
+    await queue.add('test1', { foo: 'bar' });
+    await queue.add('test2', { foo: 'baz' });
 
     await processing;
 


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? processedBy attribute is not being set when moveToFinished script is called


### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Pass worker name as part of options, this arg is already passed

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
fixes https://github.com/taskforcesh/bullmq/issues/3073