### PR TITLE
test: fix flaky test when get all workers

### DIFF
--- a/tests/test_getters.ts
+++ b/tests/test_getters.ts
@@ -101,11 +101,7 @@ describe('Jobs getters', function () {
         prefix,
         name: 'worker1',
       });
-      await new Promise<void>(resolve => {
-        worker.on('ready', () => {
-          resolve();
-        });
-      });
+      await worker.waitUntilReady();
 
       const workers = await queue.getWorkers();
       expect(workers).to.have.length(1);
@@ -119,11 +115,7 @@ describe('Jobs getters', function () {
         prefix,
         name: 'worker2',
       });
-      await new Promise<void>(resolve => {
-        worker2.on('ready', () => {
-          resolve();
-        });
-      });
+      await worker2.waitUntilReady();
 
       const nextWorkers = await queue.getWorkers();
       expect(nextWorkers).to.have.length(2);


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? To fix a flaky test when get all workers

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Instead of waiting for ready event, use waitUntilReady method

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
