### PR TITLE
perf(worker): call moveToActive after special errors

### DIFF
--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -1274,7 +1274,9 @@ export class Scripts {
     }
   }
 
-  async moveToActive(client: RedisClient, token: string, name?: string) {
+  async moveToActive(token: string, name?: string) {
+    const client = await this.queue.client;
+
     const opts = this.queue.opts as WorkerOptions;
 
     const queueKeys = this.queue.keys;

--- a/src/commands/moveToFinished-14.lua
+++ b/src/commands/moveToFinished-14.lua
@@ -228,25 +228,16 @@ if rcall("EXISTS", jobIdKey) == 1 then -- // Make sure job exists
 
         jobId = rcall("RPOPLPUSH", KEYS[1], KEYS[2])
 
-        if jobId then
-            -- Markers in waitlist DEPRECATED in v5: Remove in v6.
-            if string.sub(jobId, 1, 2) == "0:" then
-                rcall("LREM", KEYS[2], 1, jobId)
+        -- Markers in waitlist DEPRECATED in v5: Will be completely removed in v6.
+        if jobId and string.sub(jobId, 1, 2) == "0:" then
+            rcall("LREM", KEYS[2], 1, jobId)
+            jobId = rcall("RPOPLPUSH", KEYS[1], KEYS[2])
+        end
 
-                -- If jobId is special ID 0:delay (delay greater than 0), then there is no job to process
-                -- but if ID is 0:0, then there is at least 1 prioritized job to process
-                if jobId == "0:0" then
-                    jobId = moveJobFromPriorityToActive(KEYS[3], KEYS[2],
-                                                        KEYS[10])
-                    return prepareJobForProcessing(prefix, KEYS[6], eventStreamKey, jobId,
-                                                   timestamp, maxJobs, markerKey,
-                                                   opts)
-                end
-            else
-                return prepareJobForProcessing(prefix, KEYS[6], eventStreamKey, jobId,
-                                               timestamp, maxJobs, markerKey,
-                                               opts)
-            end
+        if jobId then
+            return prepareJobForProcessing(prefix, KEYS[6], eventStreamKey, jobId,
+                                            timestamp, maxJobs, markerKey,
+                                            opts)
         else
             jobId = moveJobFromPriorityToActive(KEYS[3], KEYS[2], KEYS[10])
             if jobId then


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? When manually moving a job to delayed or waiting-children, we can continue moving jobs to active without waiting for delayed marker if there are prioritized or waiting jobs

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Call moveToActive after evaluating special errors

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
