### PR TITLE
fix(worker): do not execute run method when no processor is defined when resuming

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -963,7 +963,9 @@ will never work with more accuracy than 1ms. */
 
         this.paused = false;
 
-        this.run();
+        if (this.processFn) {
+          this.run();
+        }
         this.emit('resumed');
       });
     }


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
 1. Why is this change necessary? When resuming a worker without a processor, instead of throwing an error. We can ignore to execute run method

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Check processor before executing run method when resuming

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
