### PR TITLE
perf(delayed): add marker once when promoting delayed jobs

### DIFF
--- a/src/commands/includes/addJobWithPriority.lua
+++ b/src/commands/includes/addJobWithPriority.lua
@@ -4,11 +4,11 @@
 
 -- Includes
 --- @include "addBaseMarkerIfNeeded"
+--- @include "getPriorityScore"
 
 local function addJobWithPriority(markerKey, prioritizedKey, priority, jobId, priorityCounterKey,
   isPausedOrMaxed)
-  local prioCounter = rcall("INCR", priorityCounterKey)
-  local score = priority * 0x100000000 + prioCounter % 0x100000000
+  local score = getPriorityScore(priority, priorityCounterKey)
   rcall("ZADD", prioritizedKey, score, jobId)
   addBaseMarkerIfNeeded(markerKey, isPausedOrMaxed)
 end

--- a/src/commands/includes/getPriorityScore.lua
+++ b/src/commands/includes/getPriorityScore.lua
@@ -1,0 +1,8 @@
+--[[
+  Function to get priority score.
+]]
+
+local function getPriorityScore(priority, priorityCounterKey)
+  local prioCounter = rcall("INCR", priorityCounterKey)
+  return priority * 0x100000000 + prioCounter % 0x100000000
+end

--- a/src/commands/includes/promoteDelayedJobs.lua
+++ b/src/commands/includes/promoteDelayedJobs.lua
@@ -7,8 +7,10 @@
 ]]
 
 -- Includes
+--- @include "addBaseMarkerIfNeeded"
 --- @include "addJobInTargetList"
 --- @include "addJobWithPriority"
+--- @include "getPriorityScore"
 
 -- Try to get as much as 1000 jobs at once
 local function promoteDelayedJobs(delayedKey, markerKey, targetKey, prioritizedKey,
@@ -25,10 +27,10 @@ local function promoteDelayedJobs(delayedKey, markerKey, targetKey, prioritizedK
 
             if priority == 0 then
                 -- LIFO or FIFO
-                addJobInTargetList(targetKey, markerKey, "LPUSH", isPaused, jobId)
+                rcall("LPUSH", targetKey, jobId)
             else
-                addJobWithPriority(markerKey, prioritizedKey, priority,
-                  jobId, priorityCounterKey, isPaused)
+                local score = getPriorityScore(priority, priorityCounterKey)
+                rcall("ZADD", prioritizedKey, score, jobId)
             end
 
             -- Emit waiting event
@@ -36,5 +38,7 @@ local function promoteDelayedJobs(delayedKey, markerKey, targetKey, prioritizedK
                   jobId, "prev", "delayed")
             rcall("HSET", jobKey, "delay", 0)
         end
+
+        addBaseMarkerIfNeeded(markerKey, isPaused)
     end
 end


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? When promoting delayed jobs, instead of adding a marker per each record, we can add only one marker

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Extract add marker logic after moving jobs into wait or prioritized

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
