### PR TITLE
test(scheduler): fix flaky tests when validating job counts

### DIFF
--- a/tests/test_job_scheduler.ts
+++ b/tests/test_job_scheduler.ts
@@ -242,8 +242,8 @@ describe('Job Scheduler', function () {
       const repeatableJobs = await queue.getJobSchedulers();
       expect(repeatableJobs.length).to.be.eql(1);
       await this.clock.tickAsync(ONE_MINUTE);
-      const delayed = await queue.getDelayed();
-      expect(delayed).to.have.length(1);
+      const count = await queue.getJobCountByTypes('delayed', 'waiting');
+      expect(count).to.be.equal(1);
 
       await worker.close();
     });
@@ -292,8 +292,8 @@ describe('Job Scheduler', function () {
       expect(repeatableJobs[0]).to.be.have.property('every', '240000');
 
       await this.clock.tickAsync(ONE_MINUTE);
-      const delayed = await queue.getDelayed();
-      expect(delayed).to.have.length(1);
+      const count = await queue.getJobCountByTypes('delayed', 'waiting');
+      expect(count).to.be.equal(1);
 
       await worker.close();
     });


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? Jobs that are generated by a job scheduler when using every, they are added to waiting state, and next iteration will be added into delayed. It can be only in one of this possible states

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Validate in test cases that delayed + waiting counts is 1

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
