### PR TITLE
fix(telemetry): fix span name for moveToFailed command

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -824,7 +824,7 @@ export class Job<
         return 'delay';
       case 'retryJob':
         return 'retry';
-      case 'moveToFinished':
+      case 'moveToFailed':
         return 'fail';
     }
   }


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->

The span name for failed jobs was `undefined`.

Sreenshot from our monitoring tool.
![CleanShot 2025-02-26 at 14 05 51@2x](https://github.com/user-attachments/assets/1b0767f3-401a-4059-ace9-66facbcc36b5)


### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->

Fixed the switch statement.


### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
