### PR TITLE
fix(scheduler): validate repeatKey is present when cleaning failed jobs

### DIFF
--- a/src/commands/includes/cleanSet.lua
+++ b/src/commands/includes/cleanSet.lua
@@ -31,7 +31,7 @@ local function cleanSet(
         local jobKey = jobKeyPrefix .. job
         -- Extract a Job Scheduler Id from jobId ("repeat:job-scheduler-id:millis") 
         -- and check if it is in the scheduled jobs
-        if not isJobSchedulerJob(job, jobKey, jobSchedulersKey) then
+        if not (jobSchedulersKey and isJobSchedulerJob(job, jobKey, jobSchedulersKey)) then
             if isFinished then
                 removeJob(job, true, jobKeyPrefix, true --[[remove debounce key]] )
                 deletedCount = deletedCount + 1

--- a/tests/test_clean.ts
+++ b/tests/test_clean.ts
@@ -178,6 +178,48 @@ describe('Cleaner', () => {
     await worker.close();
   });
 
+  describe('when job scheduler is present', async () => {
+    it('should clean all failed jobs', async () => {
+      const worker = new Worker(
+        queueName,
+        async () => {
+          await delay(100);
+          throw new Error('It failed');
+        },
+        { connection, prefix, autorun: false },
+      );
+      await worker.waitUntilReady();
+
+      await queue.addBulk([
+        {
+          name: 'test',
+          data: { some: 'data' },
+        },
+        {
+          name: 'test',
+          data: { some: 'data' },
+        },
+      ]);
+      await queue.upsertJobScheduler('test-scheduler1', { every: 5000 });
+
+      const failing = new Promise(resolve => {
+        queueEvents.on('failed', after(3, resolve));
+      });
+
+      worker.run();
+
+      await failing;
+      await delay(50);
+
+      const jobs = await queue.clean(0, 0, 'failed');
+      expect(jobs.length).to.be.eql(3);
+      const count = await queue.count();
+      expect(count).to.be.eql(1);
+
+      await worker.close();
+    });
+  });
+
   it('should clean all waiting jobs', async () => {
     await queue.add('test', { some: 'data' });
     await queue.add('test', { some: 'data' });


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? When removing failed jobs, no need to validate generated jobs being generated by job schedulers

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Check that repeat key is present when removing zset records

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
Fixes https://github.com/taskforcesh/bullmq/issues/3114
_Any extra info here._
