### PR TITLE
fix(worker): cast delay_until to integer [python]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,3 +212,62 @@ jobs:
         run: |
           cd python
           ./run_tests.sh
+
+  python-dragonflydb:
+    runs-on: ubuntu-latest
+
+    name: testing python@${{ matrix.python-version }}, dragonflydb@latest
+
+    strategy:
+      matrix:
+        node-version: [lts/*]
+        redis-version: [7-alpine]
+        python-version: ['3.10']
+
+    services:
+      dragonflydb:
+        image: docker.dragonflydb.io/dragonflydb/dragonfly:v1.24.0
+        env:
+          DFLY_cluster_mode: emulated
+          DFLY_lock_on_hashtags: true
+          HEALTHCHECK_PORT: 6379
+        ports:
+          - 6379:6379
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+      - name: Start Redis
+        uses: supercharge/redis-github-action@f63fe516254d0af5df91755a4488274c2e71e38c # 1.5.0
+        with:
+          redis-version: ${{ matrix.redis-version }}
+      - run: yarn install --ignore-engines --frozen-lockfile --non-interactive
+      - run: yarn build
+      - run: yarn copy:lua:python
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 mypy types-redis
+          pip install -r python/requirements.txt
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 ./python --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 ./python --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test with pytest
+        run: |
+          cd python
+          ./run_tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -265,4 +265,4 @@ jobs:
       - name: Test with pytest
         run: |
           cd python
-          ./run_tests.sh
+          ./run_tests_dragonfly.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,7 +221,6 @@ jobs:
     strategy:
       matrix:
         node-version: [lts/*]
-        redis-version: [7-alpine]
         python-version: ['3.10']
 
     services:
@@ -243,10 +242,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-      - name: Start Redis
-        uses: supercharge/redis-github-action@f63fe516254d0af5df91755a4488274c2e71e38c # 1.5.0
-        with:
-          redis-version: ${{ matrix.redis-version }}
       - run: yarn install --ignore-engines --frozen-lockfile --non-interactive
       - run: yarn build
       - run: yarn copy:lua:python

--- a/docs/gitbook/python/changelog.md
+++ b/docs/gitbook/python/changelog.md
@@ -3,177 +3,166 @@
 <!--next-version-placeholder-->
 
 ## v2.12.0 (2025-02-21)
+
 ### Feature
-* **queue:** Support removeGlobalConcurrency method ([#3076](https://github.com/taskforcesh/bullmq/issues/3076)) ([`ece8532`](https://github.com/taskforcesh/bullmq/commit/ece853203adb420466dfaf3ff8bccc73fb917147))
-* **job:** Add moveToWait method for manual processing ([#2978](https://github.com/taskforcesh/bullmq/issues/2978)) ([`5a97491`](https://github.com/taskforcesh/bullmq/commit/5a97491a0319df320b7858657e03c357284e0108))
-* **job-scheduler:** Revert add delayed job and update in the same script ([`9f0f1ba`](https://github.com/taskforcesh/bullmq/commit/9f0f1ba9b17874a757ac38c1878792c0df3c5a9a))
-* **job-scheduler:** Save limit option ([#3033](https://github.com/taskforcesh/bullmq/issues/3033)) ([`a1571ea`](https://github.com/taskforcesh/bullmq/commit/a1571ea03be6c6c41794fa272c38c29588351bbf))
-* **queue:** Add option to skip wait until connection ready ([`e728299`](https://github.com/taskforcesh/bullmq/commit/e72829922d4234b92290346dce5d33f5b98ee373))
-* **queue-getters:** Add prometheus exporter ([`078ae9d`](https://github.com/taskforcesh/bullmq/commit/078ae9db80f6ca64ff0a8135b57a6dc71d71cb1e))
-* **job-scheduler:** Save iteration count ([#3018](https://github.com/taskforcesh/bullmq/issues/3018)) ([`ad5c07c`](https://github.com/taskforcesh/bullmq/commit/ad5c07cc7672a3f7a7185310b1250763a5fef76b))
-* **sandbox:** Add support for getChildrenValues ([`dcc3b06`](https://github.com/taskforcesh/bullmq/commit/dcc3b0628f992546d7b93f509795e5d4eb3e1b15))
-* **telemetry:** Add option to omit context propagation on jobs ([#2946](https://github.com/taskforcesh/bullmq/issues/2946)) ([`6514c33`](https://github.com/taskforcesh/bullmq/commit/6514c335231cb6e727819cf5e0c56ed3f5132838))
-* Replace multi by lua scripts in moveToFailed ([#2958](https://github.com/taskforcesh/bullmq/issues/2958)) ([`c19c914`](https://github.com/taskforcesh/bullmq/commit/c19c914969169c660a3e108126044c5152faf0cd))
-* **queue:** Enhance getJobSchedulers method to include template information (#2956) ref #2875 ([`5b005cd`](https://github.com/taskforcesh/bullmq/commit/5b005cd94ba0f98677bed4a44f8669c81f073f26))
-* **queue:** Enhance getJobScheduler method to include template information (#2929) ref #2875 ([`cb99080`](https://github.com/taskforcesh/bullmq/commit/cb990808db19dd79b5048ee99308fa7d1eaa2e9f))
-* **queue:** Add getJobSchedulersCount method ([#2945](https://github.com/taskforcesh/bullmq/issues/2945)) ([`38820dc`](https://github.com/taskforcesh/bullmq/commit/38820dc8c267c616ada9931198e9e3e9d2f0d536))
+
+- Replace multi by lua scripts in moveToFailed ([#2958](https://github.com/taskforcesh/bullmq/issues/2958)) ([`c19c914`](https://github.com/taskforcesh/bullmq/commit/c19c914969169c660a3e108126044c5152faf0cd))
 
 ### Fix
-* **worker:** Do not execute run method when no processor is defined when resuming ([#3089](https://github.com/taskforcesh/bullmq/issues/3089)) ([`4a66933`](https://github.com/taskforcesh/bullmq/commit/4a66933496db68a84ec7eb7c153fcedb7bd14c7b))
-* **worker:** Do not resume when closing ([#3080](https://github.com/taskforcesh/bullmq/issues/3080)) ([`024ee0f`](https://github.com/taskforcesh/bullmq/commit/024ee0f3f0e808c256712d3ccb1bcadb025eb931))
-* **job:** Set processedBy when moving job to active in moveToFinished (#3077) fixes #3073 ([`1aa970c`](https://github.com/taskforcesh/bullmq/commit/1aa970ced3c55949aea6726c4ad29531089f5370))
-* **drain:** Pass delayed key for redis cluster ([#3074](https://github.com/taskforcesh/bullmq/issues/3074)) ([`05ea32b`](https://github.com/taskforcesh/bullmq/commit/05ea32b7e4f0cd4099783fd81d2b3214d7a293d5))
-* **job-scheduler:** Restore limit option to be saved ([#3071](https://github.com/taskforcesh/bullmq/issues/3071)) ([`3e649f7`](https://github.com/taskforcesh/bullmq/commit/3e649f7399514b343447ed2073cc07e4661f7390))
-* **job-scheduler:** Return undefined in getJobScheduler when it does not exist (#3065) fixes #3062 ([`548cc1c`](https://github.com/taskforcesh/bullmq/commit/548cc1ce8080042b4b44009ea99108bd24193895))
-* Fix return type of getNextJob ([`b970281`](https://github.com/taskforcesh/bullmq/commit/b9702812e6961f0f5a834f66d43cfb2feabaafd8))
-* **worker:** Wait fetched jobs to be processed when closing ([#3059](https://github.com/taskforcesh/bullmq/issues/3059)) ([`d4de2f5`](https://github.com/taskforcesh/bullmq/commit/d4de2f5e88d57ea00274e62ab23d09f4806196f8))
-* **worker:** Evaluate if a job needs to be fetched when moving to failed ([#3043](https://github.com/taskforcesh/bullmq/issues/3043)) ([`406e21c`](https://github.com/taskforcesh/bullmq/commit/406e21c9aadd7670f353c1c6b102a401fc327653))
-* **retry-job:** Consider updating failures in job ([#3036](https://github.com/taskforcesh/bullmq/issues/3036)) ([`21e8495`](https://github.com/taskforcesh/bullmq/commit/21e8495b5f2bf5418d86f60b59fad25d306a0298))
-* **flow-producer:** Add support for skipWaitingForReady ([`6d829fc`](https://github.com/taskforcesh/bullmq/commit/6d829fceda9f204f193c533ffc780962692b8f16))
-* **worker:** Avoid possible hazard in closing worker ([`0f07467`](https://github.com/taskforcesh/bullmq/commit/0f0746727176d7ff285ae2d1f35048109b4574c5))
-* **job-scheduler:** Use delayed job data when template data is not present (#3010) fixes #3009 ([`95edb40`](https://github.com/taskforcesh/bullmq/commit/95edb4008fcd32f09ec0953d862692d4ac7608c0))
-* **job-scheduler:** Add next delayed job only when prevMillis matches with producerId ([#3001](https://github.com/taskforcesh/bullmq/issues/3001)) ([`4ea35dd`](https://github.com/taskforcesh/bullmq/commit/4ea35dd9e16ff0197f204210696f41c0c5bd0e30))
-* **job-scheduler:** Avoid duplicates when upserting in a quick sequence ([#2991](https://github.com/taskforcesh/bullmq/issues/2991)) ([`e8cdb99`](https://github.com/taskforcesh/bullmq/commit/e8cdb99881bc7cebbc48cb7834da5eafa289712f))
-* **dynamic-rate-limit:** Validate job lock cases ([#2975](https://github.com/taskforcesh/bullmq/issues/2975)) ([`8bb27ea`](https://github.com/taskforcesh/bullmq/commit/8bb27ea4438cbd11e85fa4d0aa516bd1c0e7d51b))
-* **sandbox:** Fix issue where job could stay in active forever ([#2979](https://github.com/taskforcesh/bullmq/issues/2979)) ([`c0a6bcd`](https://github.com/taskforcesh/bullmq/commit/c0a6bcdf9594540ef6c8ec08df28550f4f5e1950))
-* **sandboxed:** Fix detecting special errors by sending default messages (#2967) fixes #2962 ([`52b0e34`](https://github.com/taskforcesh/bullmq/commit/52b0e34f0a38ac71ebd0667a5fa116ecd73ae4d2))
-* **scripts:** Make sure jobs fields are not empty before unpack ([`4360572`](https://github.com/taskforcesh/bullmq/commit/4360572745a929c7c4f6266ec03d4eba77a9715c))
-* **job-scheduler:** Avoid duplicated delayed jobs when repeatable jobs are retried ([`af75315`](https://github.com/taskforcesh/bullmq/commit/af75315f0c7923f5e0a667a9ed4606b28b89b719))
-* Guarantee every repeatable jobs are slotted ([`9917df1`](https://github.com/taskforcesh/bullmq/commit/9917df166aff2e2f143c45297f41ac8520bfc8ae))
-* **job-scheduler:** Omit deduplication and debounce options from template options ([#2960](https://github.com/taskforcesh/bullmq/issues/2960)) ([`b5fa6a3`](https://github.com/taskforcesh/bullmq/commit/b5fa6a3208a8f2a39777dc30c2db2f498addb907))
-* **worker:** Catch connection error when moveToActive is called ([#2952](https://github.com/taskforcesh/bullmq/issues/2952)) ([`544fc7c`](https://github.com/taskforcesh/bullmq/commit/544fc7c9e4755e6b62b82216e25c0cb62734ed59))
-* **scheduler-template:** Remove console.log when getting template information ([#2950](https://github.com/taskforcesh/bullmq/issues/2950)) ([`3402bfe`](https://github.com/taskforcesh/bullmq/commit/3402bfe0d01e5e5205db74d2106cd19d7df53fcb))
-* **flow:** Allow using removeOnFail and failParentOnFailure in parents (#2947) fixes #2229 ([`85f6f6f`](https://github.com/taskforcesh/bullmq/commit/85f6f6f181003fafbf75304a268170f0d271ccc3))
-* **job-scheduler:** Upsert template when same pattern options are provided (#2943) ref #2940 ([`b56c3b4`](https://github.com/taskforcesh/bullmq/commit/b56c3b45a87e52f5faf25406a2b992d1bfed4900))
 
-### Documentation
-* Fix link to use https ([`62075cf`](https://github.com/taskforcesh/bullmq/commit/62075cfbee32e2a8d115b58de2401fa9a64e6671))
-* **readme:** Fix broken link to contributing ([#3047](https://github.com/taskforcesh/bullmq/issues/3047)) ([`63e6245`](https://github.com/taskforcesh/bullmq/commit/63e62450bee6721ffe588a5043a4f8d78df7d21f))
-* **bullmq-pro:** Update changelog to v7.26.3 ([#3031](https://github.com/taskforcesh/bullmq/issues/3031)) ([`a4d5efb`](https://github.com/taskforcesh/bullmq/commit/a4d5efb8903d9ae9bedc40dbce4a6242ba9c3a1a))
-* **connections:** Clarify the usage of prefix option instead of keyPrefix ([#3029](https://github.com/taskforcesh/bullmq/issues/3029)) ([`68b0d33`](https://github.com/taskforcesh/bullmq/commit/68b0d33a569e34df206d02c12098c7b819dbd608))
-* **connections:** Clarify maxRetriesPerRequest usage ([#3028](https://github.com/taskforcesh/bullmq/issues/3028)) ([`3709687`](https://github.com/taskforcesh/bullmq/commit/3709687c5fbf1ae3d3b3a491d79a546cc654b100))
-* Fix several grammar errors in docs ([#3011](https://github.com/taskforcesh/bullmq/issues/3011)) ([`490d902`](https://github.com/taskforcesh/bullmq/commit/490d902c1baf28d8785989ec78f263783ca9cf81))
-* **stop-retrying:** Clarify different between attemptMade and attemptsStarted ([#3003](https://github.com/taskforcesh/bullmq/issues/3003)) ([`14c9fed`](https://github.com/taskforcesh/bullmq/commit/14c9fed50b5e6e4030f61a01a811e85bf5d0007b))
-* Rename pr_template.md to pull_request_template.md ([`e8ca2ec`](https://github.com/taskforcesh/bullmq/commit/e8ca2ecbd884d6991a1b837d1becfb890c923645))
-*  create pr_template.md ([`6c4101a`](https://github.com/taskforcesh/bullmq/commit/6c4101ace86f7f19883091fd879082c6a0cc20e7))
-* Typo in docstring for `moveToDelayed` ([#2961](https://github.com/taskforcesh/bullmq/issues/2961)) ([`3b218ff`](https://github.com/taskforcesh/bullmq/commit/3b218ff3a3af4286068b7aaee8f0d0909fd4f52e))
-* Add missing closing quote ([#2957](https://github.com/taskforcesh/bullmq/issues/2957)) ([`6b5c3de`](https://github.com/taskforcesh/bullmq/commit/6b5c3de4b0c5b4b1eb51f7f6c4cc006dfe18132a))
-* **guide:** Provide connection details in getting started section (#2897) fixes #2838 ([`ba28e37`](https://github.com/taskforcesh/bullmq/commit/ba28e37d77676be8e359d828474cd5e351df47af))
-* Update README.md ([`f1dfbad`](https://github.com/taskforcesh/bullmq/commit/f1dfbad4b9c7cc74313004ea47d51bf910943d18))
-* **job-schedulers:** Add getJobScheduler documentation ([#2953](https://github.com/taskforcesh/bullmq/issues/2953)) ([`fb871dd`](https://github.com/taskforcesh/bullmq/commit/fb871dd87323246438521f997a77ac8ae2d22942))
+- **job:** Set processedBy when moving job to active in moveToFinished (#3077) fixes #3073 ([`1aa970c`](https://github.com/taskforcesh/bullmq/commit/1aa970ced3c55949aea6726c4ad29531089f5370))
+- **drain:** Pass delayed key for redis cluster ([#3074](https://github.com/taskforcesh/bullmq/issues/3074)) ([`05ea32b`](https://github.com/taskforcesh/bullmq/commit/05ea32b7e4f0cd4099783fd81d2b3214d7a293d5))
+- **retry-job:** Consider updating failures in job ([#3036](https://github.com/taskforcesh/bullmq/issues/3036)) ([`21e8495`](https://github.com/taskforcesh/bullmq/commit/21e8495b5f2bf5418d86f60b59fad25d306a0298))
+- **dynamic-rate-limit:** Validate job lock cases ([#2975](https://github.com/taskforcesh/bullmq/issues/2975)) ([`8bb27ea`](https://github.com/taskforcesh/bullmq/commit/8bb27ea4438cbd11e85fa4d0aa516bd1c0e7d51b))
+- **scripts:** Make sure jobs fields are not empty before unpack ([`4360572`](https://github.com/taskforcesh/bullmq/commit/4360572745a929c7c4f6266ec03d4eba77a9715c))
+- **flow:** Allow using removeOnFail and failParentOnFailure in parents (#2947) fixes #2229 ([`85f6f6f`](https://github.com/taskforcesh/bullmq/commit/85f6f6f181003fafbf75304a268170f0d271ccc3))
 
 ### Performance
-* **delayed:** Add marker once when promoting delayed jobs (#3096) (python) ([`38912fb`](https://github.com/taskforcesh/bullmq/commit/38912fba969d614eb44d05517ba2ec8bc418a16e))
-* **add-job:** Add job into wait or prioritized state when delay is provided as 0 ([#3052](https://github.com/taskforcesh/bullmq/issues/3052)) ([`3e990eb`](https://github.com/taskforcesh/bullmq/commit/3e990eb742b3a12065110f33135f282711fdd7b9))
-* **job-scheduler:** Add delayed job and update scheduler in same script ([#2997](https://github.com/taskforcesh/bullmq/issues/2997)) ([`9be28a0`](https://github.com/taskforcesh/bullmq/commit/9be28a0c4a907798a447d02ca50662c12333dd82))
-* **job-scheduler:** Add delayed job and scheduler in same script ([#2993](https://github.com/taskforcesh/bullmq/issues/2993)) ([`95718e8`](https://github.com/taskforcesh/bullmq/commit/95718e888ba64b4071f21bbe0823b55a51ab145c))
+
+- **delayed:** Add marker once when promoting delayed jobs (#3096) (python) ([`38912fb`](https://github.com/taskforcesh/bullmq/commit/38912fba969d614eb44d05517ba2ec8bc418a16e))
+- **add-job:** Add job into wait or prioritized state when delay is provided as 0 ([#3052](https://github.com/taskforcesh/bullmq/issues/3052)) ([`3e990eb`](https://github.com/taskforcesh/bullmq/commit/3e990eb742b3a12065110f33135f282711fdd7b9))
 
 ## v2.11.0 (2024-11-26)
+
 ### Feature
-* **queue:** Add getDelayedCount method [python] ([#2934](https://github.com/taskforcesh/bullmq/issues/2934)) ([`71ce75c`](https://github.com/taskforcesh/bullmq/commit/71ce75c04b096b5593da0986c41a771add1a81ce))
+
+- **queue:** Add getDelayedCount method [python] ([#2934](https://github.com/taskforcesh/bullmq/issues/2934)) ([`71ce75c`](https://github.com/taskforcesh/bullmq/commit/71ce75c04b096b5593da0986c41a771add1a81ce))
 
 ### Performance
-* **marker:** Add base markers while consuming jobs to get workers busy (#2904) fixes #2842 ([`1759c8b`](https://github.com/taskforcesh/bullmq/commit/1759c8bc111cab9e43d5fccb4d8d2dccc9c39fb4))
+
+- **marker:** Add base markers while consuming jobs to get workers busy (#2904) fixes #2842 ([`1759c8b`](https://github.com/taskforcesh/bullmq/commit/1759c8bc111cab9e43d5fccb4d8d2dccc9c39fb4))
 
 ## v2.10.1 (2024-10-26)
+
 ### Fix
-* **commands:** Add missing build statement when releasing [python] (#2869) fixes #2868 ([`ff2a47b`](https://github.com/taskforcesh/bullmq/commit/ff2a47b37c6b36ee1a725f91de2c6e4bcf8b011a))
+
+- **commands:** Add missing build statement when releasing [python] (#2869) fixes #2868 ([`ff2a47b`](https://github.com/taskforcesh/bullmq/commit/ff2a47b37c6b36ee1a725f91de2c6e4bcf8b011a))
 
 ## v2.10.0 (2024-10-24)
+
 ### Feature
-* **job:** Add getChildrenValues method [python] ([#2853](https://github.com/taskforcesh/bullmq/issues/2853)) ([`0f25213`](https://github.com/taskforcesh/bullmq/commit/0f25213b28900a1c35922bd33611701629d83184))
-* **queue:** Add option to skip metas update ([`b7dd925`](https://github.com/taskforcesh/bullmq/commit/b7dd925e7f2a4468c98a05f3a3ca1a476482b6c0))
-* **queue:** Add queue version support ([#2822](https://github.com/taskforcesh/bullmq/issues/2822)) ([`3a4781b`](https://github.com/taskforcesh/bullmq/commit/3a4781bf7cadf04f6a324871654eed8f01cdadae))
-* **job:** Expose priority value ([#2804](https://github.com/taskforcesh/bullmq/issues/2804)) ([`9abec3d`](https://github.com/taskforcesh/bullmq/commit/9abec3dbc4c69f2496c5ff6b5d724f4d1a5ca62f))
-* **job:** Add deduplication logic ([#2796](https://github.com/taskforcesh/bullmq/issues/2796)) ([`0a4982d`](https://github.com/taskforcesh/bullmq/commit/0a4982d05d27c066248290ab9f59349b802d02d5))
-* **queue:** Add getDebounceJobId method ([#2717](https://github.com/taskforcesh/bullmq/issues/2717)) ([`a68ead9`](https://github.com/taskforcesh/bullmq/commit/a68ead95f32a7d9dabba602895d05c22794b2c02))
+
+- **job:** Add getChildrenValues method [python] ([#2853](https://github.com/taskforcesh/bullmq/issues/2853)) ([`0f25213`](https://github.com/taskforcesh/bullmq/commit/0f25213b28900a1c35922bd33611701629d83184))
+- **queue:** Add option to skip metas update ([`b7dd925`](https://github.com/taskforcesh/bullmq/commit/b7dd925e7f2a4468c98a05f3a3ca1a476482b6c0))
+- **queue:** Add queue version support ([#2822](https://github.com/taskforcesh/bullmq/issues/2822)) ([`3a4781b`](https://github.com/taskforcesh/bullmq/commit/3a4781bf7cadf04f6a324871654eed8f01cdadae))
+- **job:** Expose priority value ([#2804](https://github.com/taskforcesh/bullmq/issues/2804)) ([`9abec3d`](https://github.com/taskforcesh/bullmq/commit/9abec3dbc4c69f2496c5ff6b5d724f4d1a5ca62f))
+- **job:** Add deduplication logic ([#2796](https://github.com/taskforcesh/bullmq/issues/2796)) ([`0a4982d`](https://github.com/taskforcesh/bullmq/commit/0a4982d05d27c066248290ab9f59349b802d02d5))
+- **queue:** Add getDebounceJobId method ([#2717](https://github.com/taskforcesh/bullmq/issues/2717)) ([`a68ead9`](https://github.com/taskforcesh/bullmq/commit/a68ead95f32a7d9dabba602895d05c22794b2c02))
 
 ### Fix
-* Proper way to get version ([`b4e25c1`](https://github.com/taskforcesh/bullmq/commit/b4e25c13cafc001748ee6eb590133feb8ee24d7b))
-* **redis:** Use version for naming loaded lua scripts ([`fe73f6d`](https://github.com/taskforcesh/bullmq/commit/fe73f6d4d776dc9f99ad3a094e5c59c5fafc96f1))
-* **repeat:** Also consider startDate when using "every" ([`25bbaa8`](https://github.com/taskforcesh/bullmq/commit/25bbaa81af87f9944a64bc4fb7e0c76ef223ada4))
-* **repeatable:** Avoid delayed job deletion if next job already existed ([#2778](https://github.com/taskforcesh/bullmq/issues/2778)) ([`6a851c1`](https://github.com/taskforcesh/bullmq/commit/6a851c1140b336f0e458b6dfe1022470ac41fceb))
+
+- Proper way to get version ([`b4e25c1`](https://github.com/taskforcesh/bullmq/commit/b4e25c13cafc001748ee6eb590133feb8ee24d7b))
+- **redis:** Use version for naming loaded lua scripts ([`fe73f6d`](https://github.com/taskforcesh/bullmq/commit/fe73f6d4d776dc9f99ad3a094e5c59c5fafc96f1))
+- **repeat:** Also consider startDate when using "every" ([`25bbaa8`](https://github.com/taskforcesh/bullmq/commit/25bbaa81af87f9944a64bc4fb7e0c76ef223ada4))
+- **repeatable:** Avoid delayed job deletion if next job already existed ([#2778](https://github.com/taskforcesh/bullmq/issues/2778)) ([`6a851c1`](https://github.com/taskforcesh/bullmq/commit/6a851c1140b336f0e458b6dfe1022470ac41fceb))
 
 ## v2.9.4 (2024-09-10)
+
 ### Fix
-* **metrics:** Differentiate points in different minutes to be more accurate (#2766) (python) ([`7cb670e`](https://github.com/taskforcesh/bullmq/commit/7cb670e1bf9560a24de3da52427b4f6b6152a59a))
-* **repeat:** Replace delayed job when updating repeat key ([`88029bb`](https://github.com/taskforcesh/bullmq/commit/88029bbeab2a58768f9c438318f540010cd286a7))
+
+- **metrics:** Differentiate points in different minutes to be more accurate (#2766) (python) ([`7cb670e`](https://github.com/taskforcesh/bullmq/commit/7cb670e1bf9560a24de3da52427b4f6b6152a59a))
+- **repeat:** Replace delayed job when updating repeat key ([`88029bb`](https://github.com/taskforcesh/bullmq/commit/88029bbeab2a58768f9c438318f540010cd286a7))
 
 ### Performance
-* **metrics:** Save zeros as much as max data points ([#2758](https://github.com/taskforcesh/bullmq/issues/2758)) ([`3473054`](https://github.com/taskforcesh/bullmq/commit/347305451a9f5d7f2c16733eb139b5de96ea4b9c))
+
+- **metrics:** Save zeros as much as max data points ([#2758](https://github.com/taskforcesh/bullmq/issues/2758)) ([`3473054`](https://github.com/taskforcesh/bullmq/commit/347305451a9f5d7f2c16733eb139b5de96ea4b9c))
 
 ## v2.9.3 (2024-08-31)
+
 ### Fix
-* **flows:** Throw error when queueName contains colon (#2719) fixes #2718 ([`9ef97c3`](https://github.com/taskforcesh/bullmq/commit/9ef97c37663e209f03c501a357b6b1a662b24d99))
-* **flow:** Remove debounce key when parent is moved to fail ([#2720](https://github.com/taskforcesh/bullmq/issues/2720)) ([`d51aabe`](https://github.com/taskforcesh/bullmq/commit/d51aabe999a489c285f871d21e36c3c84e2bef33))
-* **flow:** Recursive ignoreDependencyOnFailure option ([#2712](https://github.com/taskforcesh/bullmq/issues/2712)) ([`53bc9eb`](https://github.com/taskforcesh/bullmq/commit/53bc9eb68b5bb0a470a8fe64ef78ece5cde44632))
-* **job:** Throw error if removeDependencyOnFailure and ignoreDependencyOnFailure are used together ([#2711](https://github.com/taskforcesh/bullmq/issues/2711)) ([`967632c`](https://github.com/taskforcesh/bullmq/commit/967632c9ef8468aab59f0b36d1d828bcde1fbd70))
-* **stalled:** Support removeDependencyOnFailure option when job is stalled ([#2708](https://github.com/taskforcesh/bullmq/issues/2708)) ([`e0d3790`](https://github.com/taskforcesh/bullmq/commit/e0d3790e755c4dfe31006b52f177f08b40348e61))
-* **job:** Change moveToFinished return type to reflect jobData (#2706) ref #2342 ([`de094a3`](https://github.com/taskforcesh/bullmq/commit/de094a361a25886acbee0112bb4341c6b285b1c9))
-* **connection:** Remove unnecessary process.env.CI reference ([#2705](https://github.com/taskforcesh/bullmq/issues/2705)) ([`53de304`](https://github.com/taskforcesh/bullmq/commit/53de3049493ef79e02af40e8e450e2056c134155))
-* **worker:** Fix close sequence to reduce risk for open handlers ([#2656](https://github.com/taskforcesh/bullmq/issues/2656)) ([`8468e44`](https://github.com/taskforcesh/bullmq/commit/8468e44e5e9e39c7b65691945c26688a9e5d2275))
+
+- **flows:** Throw error when queueName contains colon (#2719) fixes #2718 ([`9ef97c3`](https://github.com/taskforcesh/bullmq/commit/9ef97c37663e209f03c501a357b6b1a662b24d99))
+- **flow:** Remove debounce key when parent is moved to fail ([#2720](https://github.com/taskforcesh/bullmq/issues/2720)) ([`d51aabe`](https://github.com/taskforcesh/bullmq/commit/d51aabe999a489c285f871d21e36c3c84e2bef33))
+- **flow:** Recursive ignoreDependencyOnFailure option ([#2712](https://github.com/taskforcesh/bullmq/issues/2712)) ([`53bc9eb`](https://github.com/taskforcesh/bullmq/commit/53bc9eb68b5bb0a470a8fe64ef78ece5cde44632))
+- **job:** Throw error if removeDependencyOnFailure and ignoreDependencyOnFailure are used together ([#2711](https://github.com/taskforcesh/bullmq/issues/2711)) ([`967632c`](https://github.com/taskforcesh/bullmq/commit/967632c9ef8468aab59f0b36d1d828bcde1fbd70))
+- **stalled:** Support removeDependencyOnFailure option when job is stalled ([#2708](https://github.com/taskforcesh/bullmq/issues/2708)) ([`e0d3790`](https://github.com/taskforcesh/bullmq/commit/e0d3790e755c4dfe31006b52f177f08b40348e61))
+- **job:** Change moveToFinished return type to reflect jobData (#2706) ref #2342 ([`de094a3`](https://github.com/taskforcesh/bullmq/commit/de094a361a25886acbee0112bb4341c6b285b1c9))
+- **connection:** Remove unnecessary process.env.CI reference ([#2705](https://github.com/taskforcesh/bullmq/issues/2705)) ([`53de304`](https://github.com/taskforcesh/bullmq/commit/53de3049493ef79e02af40e8e450e2056c134155))
+- **worker:** Fix close sequence to reduce risk for open handlers ([#2656](https://github.com/taskforcesh/bullmq/issues/2656)) ([`8468e44`](https://github.com/taskforcesh/bullmq/commit/8468e44e5e9e39c7b65691945c26688a9e5d2275))
 
 ## v2.9.2 (2024-08-10)
+
 ### Fix
-* **flow:** Validate parentData before ignoreDependencyOnFailure when stalled check happens (#2702) (python) ([`9416501`](https://github.com/taskforcesh/bullmq/commit/9416501551b1ad464e59bdba1045a5a9955e2ea4))
+
+- **flow:** Validate parentData before ignoreDependencyOnFailure when stalled check happens (#2702) (python) ([`9416501`](https://github.com/taskforcesh/bullmq/commit/9416501551b1ad464e59bdba1045a5a9955e2ea4))
 
 ### Performance
-* **worker:** Promote delayed jobs while queue is rate limited (#2697) ref #2582 ([`f3290ac`](https://github.com/taskforcesh/bullmq/commit/f3290ace2f117e26357f9fae611a255af26b950b))
+
+- **worker:** Promote delayed jobs while queue is rate limited (#2697) ref #2582 ([`f3290ac`](https://github.com/taskforcesh/bullmq/commit/f3290ace2f117e26357f9fae611a255af26b950b))
 
 ## v2.9.1 (2024-08-08)
+
 ### Fix
-* **job:** Consider passing stackTraceLimit as 0 (#2692) ref #2487 ([`509a36b`](https://github.com/taskforcesh/bullmq/commit/509a36baf8d8cf37176e406fd28e33f712229d27))
+
+- **job:** Consider passing stackTraceLimit as 0 (#2692) ref #2487 ([`509a36b`](https://github.com/taskforcesh/bullmq/commit/509a36baf8d8cf37176e406fd28e33f712229d27))
 
 ## v2.9.0 (2024-08-02)
+
 ### Feature
-* **queue-events:** Pass debounceId as a param of debounced event ([#2678](https://github.com/taskforcesh/bullmq/issues/2678)) ([`97fb97a`](https://github.com/taskforcesh/bullmq/commit/97fb97a054d6cebbe1d7ff1cb5c46d7da1c018d8))
-* **job:** Allow passing a debounce as option ([#2666](https://github.com/taskforcesh/bullmq/issues/2666)) ([`163ccea`](https://github.com/taskforcesh/bullmq/commit/163ccea19ef48191c4db6da27638ff6fb0080a74))
-* **repeatable:** New repeatables structure (#2617) ref #2612 fixes #2399 #2596 ([`8376a9a`](https://github.com/taskforcesh/bullmq/commit/8376a9a9007f58ac7eab1a3a1c2f9e7ec373bbd6))
-* **queue:** Support global concurrency (#2496) ref #2465 ([`47ba055`](https://github.com/taskforcesh/bullmq/commit/47ba055c1ea36178b684fd11c1e82cde7ec93ac8))
+
+- **queue-events:** Pass debounceId as a param of debounced event ([#2678](https://github.com/taskforcesh/bullmq/issues/2678)) ([`97fb97a`](https://github.com/taskforcesh/bullmq/commit/97fb97a054d6cebbe1d7ff1cb5c46d7da1c018d8))
+- **job:** Allow passing a debounce as option ([#2666](https://github.com/taskforcesh/bullmq/issues/2666)) ([`163ccea`](https://github.com/taskforcesh/bullmq/commit/163ccea19ef48191c4db6da27638ff6fb0080a74))
+- **repeatable:** New repeatables structure (#2617) ref #2612 fixes #2399 #2596 ([`8376a9a`](https://github.com/taskforcesh/bullmq/commit/8376a9a9007f58ac7eab1a3a1c2f9e7ec373bbd6))
+- **queue:** Support global concurrency (#2496) ref #2465 ([`47ba055`](https://github.com/taskforcesh/bullmq/commit/47ba055c1ea36178b684fd11c1e82cde7ec93ac8))
 
 ### Fix
-* **job:** Make sure json.dumps return JSON compliant JSON [python] ([#2683](https://github.com/taskforcesh/bullmq/issues/2683)) ([`4441711`](https://github.com/taskforcesh/bullmq/commit/4441711a986a9f6a326100308d639eb0a2ea8c8d))
-* **repeatable:** Remove repeat hash when removing repeatable job ([#2676](https://github.com/taskforcesh/bullmq/issues/2676)) ([`97a297d`](https://github.com/taskforcesh/bullmq/commit/97a297d90ad8b27bcddb7db6a8a158acfb549389))
-* **repeatable:** Keep legacy repeatables if it exists instead of creating one with new structure ([#2665](https://github.com/taskforcesh/bullmq/issues/2665)) ([`93fad41`](https://github.com/taskforcesh/bullmq/commit/93fad41a9520961d0e6814d82454bc916a039501))
-* **repeatable:** Consider removing legacy repeatable job (#2658) fixes #2661 ([`a6764ae`](https://github.com/taskforcesh/bullmq/commit/a6764aecb557fb918d061f5e5c2e26e4afa3e8ee))
-* **repeatable:** Pass custom key as an args in addRepeatableJob to prevent CROSSSLOT issue (#2662) fixes #2660 ([`9d8f874`](https://github.com/taskforcesh/bullmq/commit/9d8f874b959e09662985f38c4614b95ab4d5e89c))
+
+- **job:** Make sure json.dumps return JSON compliant JSON [python] ([#2683](https://github.com/taskforcesh/bullmq/issues/2683)) ([`4441711`](https://github.com/taskforcesh/bullmq/commit/4441711a986a9f6a326100308d639eb0a2ea8c8d))
+- **repeatable:** Remove repeat hash when removing repeatable job ([#2676](https://github.com/taskforcesh/bullmq/issues/2676)) ([`97a297d`](https://github.com/taskforcesh/bullmq/commit/97a297d90ad8b27bcddb7db6a8a158acfb549389))
+- **repeatable:** Keep legacy repeatables if it exists instead of creating one with new structure ([#2665](https://github.com/taskforcesh/bullmq/issues/2665)) ([`93fad41`](https://github.com/taskforcesh/bullmq/commit/93fad41a9520961d0e6814d82454bc916a039501))
+- **repeatable:** Consider removing legacy repeatable job (#2658) fixes #2661 ([`a6764ae`](https://github.com/taskforcesh/bullmq/commit/a6764aecb557fb918d061f5e5c2e26e4afa3e8ee))
+- **repeatable:** Pass custom key as an args in addRepeatableJob to prevent CROSSSLOT issue (#2662) fixes #2660 ([`9d8f874`](https://github.com/taskforcesh/bullmq/commit/9d8f874b959e09662985f38c4614b95ab4d5e89c))
 
 ### Performance
-* **worker:** Fetch next job on failure ([#2342](https://github.com/taskforcesh/bullmq/issues/2342)) ([`f917b80`](https://github.com/taskforcesh/bullmq/commit/f917b8090f306c0580aac12f6bd4394fd9ef003d))
+
+- **worker:** Fetch next job on failure ([#2342](https://github.com/taskforcesh/bullmq/issues/2342)) ([`f917b80`](https://github.com/taskforcesh/bullmq/commit/f917b8090f306c0580aac12f6bd4394fd9ef003d))
 
 ## v2.8.1 (2024-07-11)
+
 ### Fix
-* **delayed:** Avoid using jobId in order to schedule delayed jobs (#2587) (python) ([`228db2c`](https://github.com/taskforcesh/bullmq/commit/228db2c780a1ca8323900fc568156495a13355a3))
+
+- **delayed:** Avoid using jobId in order to schedule delayed jobs (#2587) (python) ([`228db2c`](https://github.com/taskforcesh/bullmq/commit/228db2c780a1ca8323900fc568156495a13355a3))
 
 ### Performance
-* **delayed:** Keep moving delayed jobs to waiting when queue is paused (#2640) (python) ([`b89e2e0`](https://github.com/taskforcesh/bullmq/commit/b89e2e0913c0886561fc1c2470771232f17f5b3b))
+
+- **delayed:** Keep moving delayed jobs to waiting when queue is paused (#2640) (python) ([`b89e2e0`](https://github.com/taskforcesh/bullmq/commit/b89e2e0913c0886561fc1c2470771232f17f5b3b))
 
 ## v2.8.0 (2024-07-10)
+
 ### Feature
-* **queue:** Add getCountsPerPriority method [python] ([#2607](https://github.com/taskforcesh/bullmq/issues/2607)) ([`02b8338`](https://github.com/taskforcesh/bullmq/commit/02b83380334879cc2434043141566f2a375db958))
+
+- **queue:** Add getCountsPerPriority method [python] ([#2607](https://github.com/taskforcesh/bullmq/issues/2607)) ([`02b8338`](https://github.com/taskforcesh/bullmq/commit/02b83380334879cc2434043141566f2a375db958))
 
 ### Fix
-* **parent:** Consider re-adding child that is in completed state using same jobIds (#2627) (python) fixes #2554 ([`00cd017`](https://github.com/taskforcesh/bullmq/commit/00cd0174539fbe1cc4628b9b6e1a7eb87a5ef705))
-* **priority:** Consider paused state when calling getCountsPerPriority (python) ([#2609](https://github.com/taskforcesh/bullmq/issues/2609)) ([`6e99250`](https://github.com/taskforcesh/bullmq/commit/6e992504b2a7a2fa76f1d04ad53d1512e98add7f))
-* **priority:** Use module instead of bit.band to keep order (python) ([#2597](https://github.com/taskforcesh/bullmq/issues/2597)) ([`9ece15b`](https://github.com/taskforcesh/bullmq/commit/9ece15b17420fe0bee948a5307e870915e3bce87))
+
+- **parent:** Consider re-adding child that is in completed state using same jobIds (#2627) (python) fixes #2554 ([`00cd017`](https://github.com/taskforcesh/bullmq/commit/00cd0174539fbe1cc4628b9b6e1a7eb87a5ef705))
+- **priority:** Consider paused state when calling getCountsPerPriority (python) ([#2609](https://github.com/taskforcesh/bullmq/issues/2609)) ([`6e99250`](https://github.com/taskforcesh/bullmq/commit/6e992504b2a7a2fa76f1d04ad53d1512e98add7f))
+- **priority:** Use module instead of bit.band to keep order (python) ([#2597](https://github.com/taskforcesh/bullmq/issues/2597)) ([`9ece15b`](https://github.com/taskforcesh/bullmq/commit/9ece15b17420fe0bee948a5307e870915e3bce87))
 
 ## v2.7.8 (2024-06-05)
+
 ### Fix
-* Remove print calls [python] ([#2579](https://github.com/taskforcesh/bullmq/issues/2579)) ([`f957186`](https://github.com/taskforcesh/bullmq/commit/f95718689864dbaca8a6b4113a6b37727919d6df))
+
+- Remove print calls [python] ([#2579](https://github.com/taskforcesh/bullmq/issues/2579)) ([`f957186`](https://github.com/taskforcesh/bullmq/commit/f95718689864dbaca8a6b4113a6b37727919d6df))
 
 ## v2.7.7 (2024-06-04)
+
 ### Fix
-* **retry-job:** Throw error when job is not in active state ([#2576](https://github.com/taskforcesh/bullmq/issues/2576)) ([`ca207f5`](https://github.com/taskforcesh/bullmq/commit/ca207f593d0ed455ecc59d9e0ef389a9a50d9634))
-* **job:** Validate job existence when adding a log ([#2562](https://github.com/taskforcesh/bullmq/issues/2562)) ([`f87e3fe`](https://github.com/taskforcesh/bullmq/commit/f87e3fe029e48d8964722da762326e531c2256ee))
+
+- **retry-job:** Throw error when job is not in active state ([#2576](https://github.com/taskforcesh/bullmq/issues/2576)) ([`ca207f5`](https://github.com/taskforcesh/bullmq/commit/ca207f593d0ed455ecc59d9e0ef389a9a50d9634))
+- **job:** Validate job existence when adding a log ([#2562](https://github.com/taskforcesh/bullmq/issues/2562)) ([`f87e3fe`](https://github.com/taskforcesh/bullmq/commit/f87e3fe029e48d8964722da762326e531c2256ee))
 
 ### Performance
-* **job:** Set processedBy using hmset (#2592) (python) ([`238680b`](https://github.com/taskforcesh/bullmq/commit/238680b84593690a73d542dbe1120611c3508b47))
+
+- **job:** Set processedBy using hmset (#2592) (python) ([`238680b`](https://github.com/taskforcesh/bullmq/commit/238680b84593690a73d542dbe1120611c3508b47))
 
 ## v2.7.6 (2024-05-09)
+
 ### Fix
-* **connection:** Use async Retry (#2555) [python] ([`d6dd21d`](https://github.com/taskforcesh/bullmq/commit/d6dd21d3ac28660bbfa7825bba0b586328769709))
-* **worker:** Make sure clearTimeout is always called after bzpopmin ([`782382e`](https://github.com/taskforcesh/bullmq/commit/782382e599218024bb9912ff0572c4aa9b1f22a3))
-* **worker:** Force timeout on bzpopmin command ([#2543](https://github.com/taskforcesh/bullmq/issues/2543)) ([`ae7cb6c`](https://github.com/taskforcesh/bullmq/commit/ae7cb6caefdbfa5ca0d28589cef4b896ffcce2db))
+
+- **connection:** Use async Retry (#2555) [python] ([`d6dd21d`](https://github.com/taskforcesh/bullmq/commit/d6dd21d3ac28660bbfa7825bba0b586328769709))
+- **worker:** Make sure clearTimeout is always called after bzpopmin ([`782382e`](https://github.com/taskforcesh/bullmq/commit/782382e599218024bb9912ff0572c4aa9b1f22a3))
+- **worker:** Force timeout on bzpopmin command ([#2543](https://github.com/taskforcesh/bullmq/issues/2543)) ([`ae7cb6c`](https://github.com/taskforcesh/bullmq/commit/ae7cb6caefdbfa5ca0d28589cef4b896ffcce2db))
 
 ## v2.7.5 (2024-04-28)
 

--- a/python/bullmq/flow_producer.py
+++ b/python/bullmq/flow_producer.py
@@ -29,7 +29,7 @@ class FlowProducer:
     Instantiate a FlowProducer object
     """
 
-    #pass only queueOpts, no need 2 parameters in next breaking change
+    #TODO: pass only queueOpts, no need 2 parameters in next breaking change
     def __init__(self, redisOpts: dict | str = {}, opts: QueueBaseOptions = {}):
         """
         Initialize a connection

--- a/python/bullmq/flow_producer.py
+++ b/python/bullmq/flow_producer.py
@@ -29,6 +29,7 @@ class FlowProducer:
     Instantiate a FlowProducer object
     """
 
+    #pass only queueOpts, no need 2 parameters in next breaking change
     def __init__(self, redisOpts: dict | str = {}, opts: QueueBaseOptions = {}):
         """
         Initialize a connection

--- a/python/bullmq/queue_keys.py
+++ b/python/bullmq/queue_keys.py
@@ -7,7 +7,7 @@ class QueueKeys:
         self.prefix = prefix
 
     def getKeys(self, name: str):
-        names = ["", "active", "wait", "waiting-children", "paused", "completed", "failed", "delayed",
+        names = ["", "active", "wait", "waiting-children", "paused", "completed", "failed", "delayed", "repeat",
                  "stalled", "limiter", "prioritized", "id", "stalled-check", "meta", "pc", "events", "marker"]
         keys = {}
         for name_type in names:

--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -144,8 +144,7 @@ class Worker(EventEmitter):
                 self.blockUntil = 0
 
         if delay_until:
-            print("delay_until", type(delay_until))
-            self.blockUntil = max(delay_until, 0) or 0
+            self.blockUntil = max(int(delay_until), 0) or 0
 
         if job_data:
             self.drained = False

--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -144,6 +144,7 @@ class Worker(EventEmitter):
                 self.blockUntil = 0
 
         if delay_until:
+            print("delay_until", type(delay_until))
             self.blockUntil = max(delay_until, 0) or 0
 
         if job_data:

--- a/python/run_tests_dragonfly.sh
+++ b/python/run_tests_dragonfly.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-BULLMQ_TEST_PREFIX="{b}"
+export BULLMQ_TEST_PREFIX="{b}"
 python3 -m unittest -v tests.bulk_tests
 python3 -m unittest -v tests.delay_tests
 python3 -m unittest -v tests.flow_tests

--- a/python/run_tests_dragonfly.sh
+++ b/python/run_tests_dragonfly.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+BULLMQ_TEST_PREFIX="{b}"
+python3 -m unittest -v tests.bulk_tests
+python3 -m unittest -v tests.delay_tests
+python3 -m unittest -v tests.flow_tests
+python3 -m unittest -v tests.job_tests
+python3 -m unittest -v tests.queue_tests
+python3 -m unittest -v tests.worker_tests

--- a/python/tests/bulk_tests.py
+++ b/python/tests/bulk_tests.py
@@ -5,26 +5,28 @@ https://bbc.github.io/cloudfit-public-docs/asyncio/testing.html
 """
 
 import unittest
+import os
 
 from asyncio import Future
 from bullmq import Queue, Job, Worker
 from uuid import uuid4
 
 queueName = f"__test_queue__{uuid4().hex}"
+prefix = os.environ.get('BULLMQ_TEST_PREFIX') or "bull"
 
 class TestJob(unittest.IsolatedAsyncioTestCase):
 
     async def asyncSetUp(self):
         print("Setting up test queue")
         # Delete test queue
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
         await queue.pause()
         await queue.obliterate()
         await queue.close()
 
     async def test_process_jobs(self):
         name = "test"
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
 
         async def process(job: Job, token: str):
             if job.data.get("idx") == 0:
@@ -34,7 +36,7 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(job.data.get("foo"), "baz")
             return "done"
 
-        worker = Worker(queueName, process)
+        worker = Worker(queueName, process, {"prefix": prefix})
 
         completed_events = Future()
 

--- a/python/tests/delay_tests.py
+++ b/python/tests/delay_tests.py
@@ -6,19 +6,21 @@ https://bbc.github.io/cloudfit-public-docs/asyncio/testing.html
 
 import unittest
 import time
+import os
 
 from asyncio import Future
 from bullmq import Queue, Job, Worker
 from uuid import uuid4
 
 queueName = f"__test_queue__{uuid4().hex}"
+prefix = os.environ.get('BULLMQ_TEST_PREFIX') or "bull"
 
 class TestJob(unittest.IsolatedAsyncioTestCase):
 
     async def asyncSetUp(self):
         print("Setting up test queue")
         # Delete test queue
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
         await queue.pause()
         await queue.obliterate()
         await queue.close()
@@ -27,12 +29,12 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         delay = 1000
         margin = 1.2
         timestamp = round(time.time() * 1000)
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
 
         async def process(job: Job, token: str):
             return "done"
 
-        worker = Worker(queueName, process)
+        worker = Worker(queueName, process, {"prefix": prefix})
 
         completed_events = Future()
 

--- a/python/tests/job_tests.py
+++ b/python/tests/job_tests.py
@@ -5,24 +5,26 @@ https://bbc.github.io/cloudfit-public-docs/asyncio/testing.html
 """
 
 import unittest
+import os
 
 from bullmq import Queue, Job
 from uuid import uuid4
 
 queueName = f"__test_queue__{uuid4().hex}"
+prefix = os.environ.get('BULLMQ_TEST_PREFIX') or "bull"
 
 class TestJob(unittest.IsolatedAsyncioTestCase):
 
     async def asyncSetUp(self):
         print("Setting up test queue")
         # Delete test queue
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
         await queue.pause()
         await queue.obliterate()
         await queue.close()
 
     async def test_set_and_get_progress_as_number(self):
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
         job = await queue.add("test-job", {"foo": "bar"}, {})
         await job.updateProgress(42)
         stored_job = await Job.fromId(queue, job.id)
@@ -31,7 +33,7 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         await queue.close()
 
     async def test_set_and_get_progress_as_object(self):
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
         job = await queue.add("test-job", {"foo": "bar"}, {})
         await job.updateProgress({"total": 120, "completed": 40})
         stored_job = await Job.fromId(queue, job.id)
@@ -40,7 +42,7 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         await queue.close()
 
     async def test_get_job_state(self):
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
         job = await queue.add("test-job", {"foo": "bar"}, {})
         state = await job.getState()
 
@@ -49,7 +51,7 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         await queue.close()
 
     async def test_job_log(self):
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
         firstLog = 'some log text 1'
         secondLog = 'some log text 2'
         job = await queue.add("test-job", {"foo": "bar"}, {})
@@ -63,7 +65,7 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         await queue.close()
 
     async def test_update_job_data(self):
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
         job = await queue.add("test", {"foo": "bar"}, {})
         await job.updateData({"baz": "qux"})
         stored_job = await Job.fromId(queue, job.id)
@@ -73,7 +75,7 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         await queue.close()
 
     async def test_job_data_json_compliant(self):
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
         job = await queue.add("test", {"foo": "bar"}, {})
         with self.assertRaises(ValueError):
             await job.updateData({"baz": float('nan')})
@@ -81,7 +83,7 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         await queue.close()
 
     async def test_update_job_data_when_is_removed(self):
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
         job = await queue.add("test", {"foo": "bar"}, {})
         await job.remove()
         with self.assertRaises(TypeError):
@@ -90,7 +92,7 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         await queue.close()
 
     async def test_promote_delayed_job(self):
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
         job = await queue.add("test", {"foo": "bar"}, {"delay": 1500})
         isDelayed = await job.isDelayed()
         self.assertEqual(isDelayed, True)

--- a/python/tests/queue_tests.py
+++ b/python/tests/queue_tests.py
@@ -124,12 +124,12 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
         await queue.add("test", data={}, opts={})
         await queue.add("test", data={}, opts={})
 
-        events_length = await queue.client.xlen(f"test:{queueName}:events")
+        events_length = await queue.client.xlen(f"{custom_prefix}:{queueName}:events")
         self.assertEqual(events_length, 8)
 
         await queue.trimEvents(0)
 
-        events_length = await queue.client.xlen(f"test:{queue.name}:events")
+        events_length = await queue.client.xlen(f"{custom_prefix}:{queue.name}:events")
 
         self.assertEqual(events_length, 0)
 

--- a/python/tests/worker_tests.py
+++ b/python/tests/worker_tests.py
@@ -179,7 +179,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
             await asyncio.sleep(3)
             return "done"
 
-        worker = Worker(queueName, process, {"lockDuration": 1000 "prefix": prefix})
+        worker = Worker(queueName, process, {"lockDuration": 1000, "prefix": prefix})
 
         processing = Future()
         worker.on("completed", lambda job, result: processing.set_result(None))

--- a/python/tests/worker_tests.py
+++ b/python/tests/worker_tests.py
@@ -13,21 +13,23 @@ from enum import Enum
 import asyncio
 import unittest
 import time
+import os
 
 queueName = f"__test_queue__{uuid4().hex}"
+prefix = os.environ.get('BULLMQ_TEST_PREFIX') or "bull"
 
 class TestWorker(unittest.IsolatedAsyncioTestCase):
 
     async def asyncSetUp(self):
         print("Setting up test queue")
         # Delete test queue
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
         await queue.pause()
         await queue.obliterate()
         await queue.close()
 
     async def test_process_jobs(self):
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
         data = {"foo": "bar"}
         job = await queue.add("test-job", data, {"removeOnComplete": False})
 
@@ -35,7 +37,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
             print("Processing job", job)
             return "done"
 
-        worker = Worker(queueName, process)
+        worker = Worker(queueName, process, {"prefix": prefix})
 
         processing = Future()
         worker.on("completed", lambda job, result: processing.set_result(None))
@@ -54,7 +56,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         await queue.close()
 
     async def test_process_job_with_array_as_return_value(self):
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
         data = {"foo": "bar"}
         job = await queue.add("test-job", data, {"removeOnComplete": False})
 
@@ -62,7 +64,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
             print("Processing job", job)
             return ['foo']
 
-        worker = Worker(queueName, process)
+        worker = Worker(queueName, process, {"prefix": prefix})
 
         processing = Future()
         worker.on("completed", lambda job, result: processing.set_result(None))
@@ -81,7 +83,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         await queue.close()
 
     async def test_process_job_with_boolean_as_return_value(self):
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
         data = {"foo": "bar"}
         job = await queue.add("test-job", data, {"removeOnComplete": False})
 
@@ -89,7 +91,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
             print("Processing job", job)
             return True
 
-        worker = Worker(queueName, process)
+        worker = Worker(queueName, process, {"prefix": prefix})
 
         processing = Future()
         worker.on("completed", lambda job, result: processing.set_result(None))
@@ -108,7 +110,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         await queue.close()
 
     async def test_process_job_fail_with_nan_as_return_value(self):
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
         data = {"foo": "bar"}
         job = await queue.add("test-job", data, {"removeOnComplete": False})
 
@@ -118,7 +120,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
             print("Processing job", job)
             return float('nan')
 
-        worker = Worker(queueName, process)
+        worker = Worker(queueName, process, {"prefix": prefix})
 
         processing = Future()
         worker.on("failed", lambda job, result: processing.set_result(None))
@@ -138,7 +140,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         await queue.close()
 
     async def test_process_jobs_fail(self):
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
         data = {"foo": "bar"}
         job = await queue.add("test-job", data, {"removeOnComplete": False})
 
@@ -148,7 +150,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
             print("Processing job", job)
             raise Exception(failedReason)
 
-        worker = Worker(queueName, process)
+        worker = Worker(queueName, process, {"prefix": prefix})
 
         processing = Future()
         worker.on("failed", lambda job, result: processing.set_result(None))
@@ -169,7 +171,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         await queue.close()
 
     async def test_process_renews_lock(self):
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
         data = {"foo": "bar"}
         job = await queue.add("test-job", data, {"removeOnComplete": False})
 
@@ -177,7 +179,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
             await asyncio.sleep(3)
             return "done"
 
-        worker = Worker(queueName, process, {"lockDuration": 1000})
+        worker = Worker(queueName, process, {"lockDuration": 1000 "prefix": prefix})
 
         processing = Future()
         worker.on("completed", lambda job, result: processing.set_result(None))
@@ -196,7 +198,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         await queue.close()
 
     async def test_process_stalled_jobs(self):
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
         data = {"foo": "bar"}
         job = await queue.add("test-job", data, {"removeOnComplete": False})
 
@@ -208,7 +210,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
             await asyncio.sleep(2)
             return "done1"
 
-        worker = Worker(queueName, process1, {"lockDuration": 1000})
+        worker = Worker(queueName, process1, {"lockDuration": 1000, "prefix": prefix})
 
         await startProcessing
         await worker.close(force=True)
@@ -217,7 +219,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
             return "done2"
 
         worker2 = Worker(queueName, process2, {
-            "lockDuration": 1000, "stalledInterval": 1000})
+            "lockDuration": 1000, "stalledInterval": 1000, "prefix": prefix})
 
         processing = Future()
         worker2.on("completed", lambda job,
@@ -241,14 +243,14 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         await queue.close()
 
     async def test_retry_job_after_delay_with_fixed_backoff(self):
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
 
         async def process1(job: Job, token: str):
             if job.attemptsMade < 2:
                 raise Exception("Not yet!")
             return None
 
-        worker = Worker(queueName, process1)
+        worker = Worker(queueName, process1, {"prefix": prefix})
 
         start = round(time.time() * 1000)
         await queue.add("test", { "foo": "bar" },
@@ -269,7 +271,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         await worker.close()
 
     async def test_retry_job_after_delay_with_custom_backoff(self):
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
 
         async def process1(job: Job, token: str):
             if job.attemptsMade < 2:
@@ -281,7 +283,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
 
         worker = Worker(queueName, process1, {"settings": {
             "backoffStrategy": backoff_strategy
-        }})
+        }, "prefix": prefix})
 
         start = round(time.time() * 1000)
         await queue.add("test", { "foo": "bar" },
@@ -303,8 +305,8 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
 
     async def test_create_children_at_runtime(self):
         parent_queue_name = f"__parent_queue__{uuid4().hex}"
-        parent_queue = Queue(parent_queue_name)
-        queue = Queue(queueName)
+        parent_queue = Queue(parent_queue_name, {"prefix": prefix})
+        queue = Queue(queueName, {"prefix": prefix})
 
         class Step(int, Enum):
             Initial = 1
@@ -358,8 +360,8 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
             await asyncio.sleep(0.2)
             return None
 
-        worker = Worker(parent_queue_name, parent_process, {})
-        children_worker = Worker(queueName, children_process, {})
+        worker = Worker(parent_queue_name, parent_process, {"prefix": prefix})
+        children_worker = Worker(queueName, children_process, {"prefix": prefix})
 
         await parent_queue.add( "test", {"step": Step.Initial},
             {
@@ -390,7 +392,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         pending_message_to_process = 8
         wait = 0.01
         job_count = 0
-        queue = Queue(queueName)
+        queue = Queue(queueName, {"prefix": prefix})
 
         async def process(job: Job, token: str):
             nonlocal num_jobs_processing
@@ -409,7 +411,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         for _ in range(8):
             await queue.add("test", data={})
 
-        worker = Worker(queueName, process, {"concurrency": 4 })
+        worker = Worker(queueName, process, {"concurrency": 4, "prefix": prefix})
 
         completed_events = Future()
 
@@ -428,7 +430,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
 
     async def test_reusable_redis(self):
         conn = redis.Redis(decode_responses=True, host="localhost", port="6379", db=0)
-        queue = Queue(queueName, {"connection": conn})
+        queue = Queue(queueName, {"connection": conn, "prefix": prefix})
         data = {"foo": "bar"}
         job = await queue.add("test-job", data, {"removeOnComplete": False})
 
@@ -436,7 +438,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
             print("Processing job", job)
             return "done"
 
-        worker = Worker(queueName, process, {"connection": conn})
+        worker = Worker(queueName, process, {"connection": conn, "prefix": prefix})
 
         processing = Future()
         worker.on("completed", lambda job, result: processing.set_result(None))


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? When delay_until is retrieved from dragonfly, it's returned as string, we need to cast it to integer in order to prevent errors when using max method

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Cast delay_until as integer

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
ref https://github.com/taskforcesh/bullmq/pull/3092
