### PR TITLE
build and publish wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         if: ${{ contains(env.commitmsg, 'python') }}
         run: |
           cd python
-          pip install packaging
+          pip install build
           git config --global user.email "manast@taskforce.sh"
           git config --global user.name "manast"
           export VERSION=$(semantic-release print-version)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "setuptools==68.0.0",
     "pre-commit==3.3.3",
     "build==0.8.0",
     "python-semantic-release==7.28.1",
@@ -48,7 +47,7 @@ bullmq = ["commands/*.lua", "types/*"]
 branch = "master"
 version_variable = "bullmq/__init__.py:__version__"
 version_toml = "pyproject.toml:project.version"
-build_command = "python3 setup.py sdist"
+build_command = "python3 -m build"
 tag_format = "vpy{version}"
 version_source = "commit"
 changelog_file = "../docs/gitbook/python/changelog.md"

--- a/python/release.sh
+++ b/python/release.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# https://betterscientificsoftware.github.io/python-for-hpc/tutorials/python-pypi-packaging/
 rm -Rf dist
 rm -Rf bullmq.egg-info
 yarn build bullmq # latest version
-python setup.py sdist
+python -m build
 twine upload dist/*


### PR DESCRIPTION
direct invocation of setup.py is [deprecated](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/).  Build and publish wheels.