### PR TITLE
fix(job): deserialize priority in fromjson

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -349,6 +349,8 @@ export class Job<
 
     job.delay = parseInt(json.delay);
 
+    job.priority = parseInt(json.priority);
+
     job.timestamp = parseInt(json.timestamp);
 
     if (json.finishedOn) {

--- a/src/interfaces/job-json.ts
+++ b/src/interfaces/job-json.ts
@@ -34,6 +34,7 @@ export interface JobJsonRaw {
   attemptsMade?: string;
   finishedOn?: string;
   processedOn?: string;
+  priority: string;
   timestamp: string;
   failedReason: string;
   stacktrace: string[];

--- a/tests/test_job.ts
+++ b/tests/test_job.ts
@@ -1164,7 +1164,12 @@ describe('Job', function () {
 
         const worker = new Worker(
           queueName,
-          async () => {
+          async (job: Job) => {
+            if (job.name === 'test1') {
+              expect(job.priority).to.be.eql(8);
+            } else {
+              expect(job.priority).to.be.eql(1);
+            }
             await delay(20);
           },
           { connection, prefix },


### PR DESCRIPTION
### Why
When serializing jobs from json, the Job object is serialized with the value in opts.priority, rather than priority. These values get desynced when changing a job's priority after it has been added. Therefore, the real priority value will not be visible in the Job object. See example code below.

### How
Deserialized priority from json. I did not add priority to the JobJson class since priority changes seemed to be propagating to redis fine, I only added it to the JobJsonRaw class.

### Additional Notes
Code to reproduce:
```ts
import { Job, Queue } from 'bullmq';

const myQueue = new Queue('myQueue');

await myQueue.add('myJob', {}, { jobId: "myJobId", priority: 10 });

let job: Job = await myQueue.getJob("myJobId");
console.log(job.priority); // returns 10
await job.changePriority({
  priority: 9
})
console.log(job.priority); // returns 9
job = await myQueue.getJob("myJobId");
console.log(job.priority); // returns 10, it should return 9 <-------------

