### PR TITLE
feat(job): support ignored and failed counts in getDependenciesCount

### DIFF
--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -834,6 +834,31 @@ export class Scripts {
     return await this.execCommand(client, 'getCountsPerPriority', args);
   }
 
+  protected getDependencyCountsArgs(
+    jobId: string,
+    types: string[],
+  ): (string | number)[] {
+    const keys: string[] = [
+      `${jobId}:processed`,
+      `${jobId}:dependencies`,
+      `${jobId}:failed`,
+      `${jobId}:unsuccessful`,
+    ].map(name => {
+      return this.queue.toKey(name);
+    });
+
+    const args = types;
+
+    return keys.concat(args);
+  }
+
+  async getDependencyCounts(jobId: string, types: string[]): Promise<number[]> {
+    const client = await this.queue.client;
+    const args = this.getDependencyCountsArgs(jobId, types);
+
+    return await this.execCommand(client, 'getDependencyCounts', args);
+  }
+
   moveToCompletedArgs<T = any, R = any, N extends string = string>(
     job: MinimalJob<T, R, N>,
     returnvalue: R,

--- a/src/commands/getDependencyCounts-4.lua
+++ b/src/commands/getDependencyCounts-4.lua
@@ -1,5 +1,5 @@
 --[[
-  Get counts per provided states
+  Get counts per child states
 
     Input:
       KEYS[1]    processed key

--- a/src/commands/getDependencyCounts-4.lua
+++ b/src/commands/getDependencyCounts-4.lua
@@ -1,0 +1,31 @@
+--[[
+  Get counts per provided states
+
+    Input:
+      KEYS[1]    processed key
+      KEYS[2]    unprocessed key
+      KEYS[3]    ignored key
+      KEYS[4]    failed key
+
+      ARGV[1...] types
+]]
+local rcall = redis.call;
+local processedKey = KEYS[1]
+local unprocessedKey = KEYS[2]
+local ignoredKey = KEYS[3]
+local failedKey = KEYS[4]
+local results = {}
+
+for i = 1, #ARGV do
+  if ARGV[i] == "processed" then
+    results[#results+1] = rcall("HLEN", processedKey)
+  elseif ARGV[i] == "unprocessed" then
+    results[#results+1] = rcall("SCARD", unprocessedKey)
+  elseif ARGV[i] == "ignored" then
+    results[#results+1] = rcall("HLEN", ignoredKey)
+  else
+    results[#results+1] = rcall("ZCARD", failedKey)
+  end
+end
+
+return results


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
1. Why is this change necessary? getDependenciesCount is not returning number for ignored or failed child states

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Create a new script to handle these numbers that are missing

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
ref https://github.com/taskforcesh/bullmq/issues/3136