### PR TITLE
fix: QueueEvent requires a queueName

### DIFF
--- a/docs/gitbook/README (1).md
+++ b/docs/gitbook/README (1).md
@@ -85,7 +85,7 @@ Sometimes you need to listen to all the workers events in a given place, for thi
 ```typescript
 import { QueueEvents } from 'bullmq';
 
-const queueEvents = new QueueEvents();
+const queueEvents = new QueueEvents('foo');
 
 queueEvents.on('waiting', ({ jobId }) => {
   console.log(`A job with ID ${jobId} is waiting`);


### PR DESCRIPTION
### Why
There is an issue in the doc, the Quick Start example is not working for QueueEvents.
It is missing a queueName, a required parameter.

### How
Provide a queueName
