### PR TITLE
fix(flow): consider prioritized state when moving a parent to failed

### DIFF
--- a/src/commands/includes/moveParentFromWaitingChildrenToFailed.lua
+++ b/src/commands/includes/moveParentFromWaitingChildrenToFailed.lua
@@ -10,15 +10,29 @@
 local function moveParentFromWaitingChildrenToFailed(parentQueueKey, parentKey, parentId, jobIdKey, timestamp)
   local parentWaitingChildrenKey = parentQueueKey .. ":waiting-children"
   local parentDelayedKey = parentQueueKey .. ":delayed"
-  if rcall("ZSCORE", parentWaitingChildrenKey, parentId) ~= false then
-    rcall("ZREM", parentWaitingChildrenKey, parentId)
+  local parentPrioritizedKey = parentQueueKey .. ":prioritized"
+  local parentWaitingChildrenOrDelayedOrPrioritizedKey
+  local prevState
+  if rcall("ZSCORE", parentWaitingChildrenKey, parentId) then
+    parentWaitingChildrenOrDelayedOrPrioritizedKey = parentWaitingChildrenKey
+    prevState = "waiting-children"
+  elseif rcall("ZSCORE", parentDelayedKey, parentId) then
+    parentWaitingChildrenOrDelayedOrPrioritizedKey = parentDelayedKey
+    prevState = "delayed"
+  elseif rcall("ZSCORE", parentPrioritizedKey, parentId) then
+    parentWaitingChildrenOrDelayedOrPrioritizedKey = parentPrioritizedKey
+    prevState = "prioritized"
+  end
+
+  if parentWaitingChildrenOrDelayedOrPrioritizedKey then
+    rcall("ZREM", parentWaitingChildrenOrDelayedOrPrioritizedKey, parentId)
     local parentQueuePrefix = parentQueueKey .. ":"
     local parentFailedKey = parentQueueKey .. ":failed"
     rcall("ZADD", parentFailedKey, timestamp, parentId)
     local failedReason = "child " .. jobIdKey .. " failed"
     rcall("HSET", parentKey, "failedReason", failedReason, "finishedOn", timestamp)
     rcall("XADD", parentQueueKey .. ":events", "*", "event", "failed", "jobId", parentId, "failedReason",
-      failedReason, "prev", "waiting-children")
+      failedReason, "prev", prevState)
 
     local jobAttributes = rcall("HMGET", parentKey, "parent", "deid", "opts")
 
@@ -29,48 +43,6 @@ local function moveParentFromWaitingChildrenToFailed(parentQueueKey, parentKey, 
       local grandParentKey = parentData['queueKey'] .. ':' .. parentData['id']
       local grandParentUnsuccesssful = grandParentKey .. ":unsuccessful"
       rcall("ZADD", grandParentUnsuccesssful, timestamp, parentKey)
-      if parentData['fpof'] then
-        moveParentFromWaitingChildrenToFailed(
-          parentData['queueKey'],
-          parentData['queueKey'] .. ':' .. parentData['id'],
-          parentData['id'],
-          parentKey,
-          timestamp
-        )
-      elseif parentData['idof'] or parentData['rdof'] then
-        local grandParentKey = parentData['queueKey'] .. ':' .. parentData['id']
-        local grandParentDependenciesSet = grandParentKey .. ":dependencies"
-        if rcall("SREM", grandParentDependenciesSet, parentKey) == 1 then
-          moveParentToWaitIfNeeded(parentData['queueKey'], grandParentDependenciesSet,
-            grandParentKey, parentData['id'], timestamp)
-          if parentData['idof'] then
-            local grandParentFailedSet = grandParentKey .. ":failed"
-            rcall("HSET", grandParentFailedSet, parentKey, failedReason)
-          end
-        end
-      end
-    end
-
-    local parentRawOpts = jobAttributes[3]
-    local parentOpts = cjson.decode(parentRawOpts)
-    
-    removeJobsOnFail(parentQueuePrefix, parentFailedKey, parentId, parentOpts, timestamp)
-  elseif rcall("ZSCORE", parentDelayedKey, parentId) ~= false then
-    rcall("ZREM", parentDelayedKey, parentId)
-    local parentQueuePrefix = parentQueueKey .. ":"
-    local parentFailedKey = parentQueueKey .. ":failed"
-    rcall("ZADD", parentFailedKey, timestamp, parentId)
-    local failedReason = "child " .. jobIdKey .. " failed"
-    rcall("HMSET", parentKey, "failedReason", failedReason, "finishedOn", timestamp)
-    rcall("XADD", parentQueueKey .. ":events", "*", "event", "failed", "jobId", parentId, "failedReason",
-      failedReason, "prev", "delayed")
-
-    local jobAttributes = rcall("HMGET", parentKey, "parent", "deid", "opts")
-
-    removeDeduplicationKeyIfNeeded(parentQueueKey .. ":", jobAttributes[2])
-
-    if jobAttributes[1] then
-      local parentData = cjson.decode(jobAttributes[1])
       if parentData['fpof'] then
         moveParentFromWaitingChildrenToFailed(
           parentData['queueKey'],

--- a/tests/test_flow.ts
+++ b/tests/test_flow.ts
@@ -11,6 +11,7 @@ import {
   JobNode,
   WaitingChildrenError,
   DelayedError,
+  RateLimitError,
 } from '../src/classes';
 import { removeAllQueueData, delay } from '../src/utils';
 
@@ -2494,6 +2495,138 @@ describe('flows', () => {
           {
             attempts: 3,
             backoff: 1000,
+          },
+        );
+
+        await failed;
+        await flow.close();
+        await worker.close();
+        await grandchildrenWorker.close();
+        await removeAllQueueData(new IORedis(redisHost), childrenQueueName);
+        await removeAllQueueData(
+          new IORedis(redisHost),
+          grandchildrenQueueName,
+        );
+      });
+    });
+
+    describe('when parent is in prioritized state', async () => {
+      it('should move parent to failed when child is moved to failed', async () => {
+        const childrenQueueName = `children-queue-${v4()}`;
+        const grandchildrenQueueName = `grandchildren-queue-${v4()}`;
+
+        enum Step {
+          Initial,
+          Second,
+          Third,
+          Finish,
+        }
+
+        const flow = new FlowProducer({ connection, prefix });
+
+        const grandchildrenWorker = new Worker(
+          grandchildrenQueueName,
+          async () => {
+            await delay(500);
+            throw new Error('failed');
+          },
+          { connection, prefix },
+        );
+
+        const queueEvents = new QueueEvents(queueName, {
+          connection,
+          prefix,
+        });
+        await queueEvents.waitUntilReady();
+
+        let childId;
+        const worker = new Worker(
+          queueName,
+          async (job: Job, token?: string) => {
+            let step = job.data.step;
+            while (step !== Step.Finish) {
+              switch (step) {
+                case Step.Initial: {
+                  const { job: child } = await flow.add({
+                    name: 'child-job',
+                    queueName: childrenQueueName,
+                    data: {},
+                    children: [
+                      {
+                        name: 'grandchild-job',
+                        data: { idx: 0, foo: 'bar' },
+                        queueName: grandchildrenQueueName,
+                        opts: {
+                          failParentOnFailure: true,
+                        },
+                      },
+                    ],
+                    opts: {
+                      failParentOnFailure: true,
+                      parent: {
+                        id: job.id!,
+                        queue: job.queueQualifiedName,
+                      },
+                    },
+                  });
+                  childId = child.id;
+                  await job.updateData({
+                    step: Step.Second,
+                  });
+                  step = Step.Second;
+                  break;
+                }
+                case Step.Second: {
+                  await queue.rateLimit(2000);
+                  await job.updateData({
+                    step: Step.Third,
+                  });
+                  step = Step.Third;
+                  throw new RateLimitError();
+                }
+                case Step.Third: {
+                  const shouldWait = await job.moveToWaitingChildren(token!);
+                  if (!shouldWait) {
+                    await job.updateData({
+                      step: Step.Finish,
+                    });
+                    step = Step.Finish;
+                    return Step.Finish;
+                  } else {
+                    throw new WaitingChildrenError();
+                  }
+                }
+                default: {
+                  throw new Error('invalid step');
+                }
+              }
+            }
+          },
+          { connection, prefix },
+        );
+        await grandchildrenWorker.waitUntilReady();
+        await worker.waitUntilReady();
+
+        const failed = new Promise<void>((resolve, reject) => {
+          queueEvents.on('failed', async ({ jobId, failedReason, prev }) => {
+            try {
+              expect(jobId).to.be.equal(job.id);
+              expect(prev).to.be.equal('prioritized');
+              expect(failedReason).to.be.equal(
+                `child ${prefix}:${childrenQueueName}:${childId} failed`,
+              );
+              resolve();
+            } catch (error) {
+              reject(error);
+            }
+          });
+        });
+
+        const job = await queue.add(
+          'test',
+          { step: Step.Initial },
+          {
+            priority: 10,
           },
         );
 


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? When dynamically add children jobs, a parent can be in prioritized state when failParentOnFailure is activated

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Consider prioritized state when moving a parent to failed

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._