### PR TITLE
test: fix flaky test when lock is lost

### DIFF
--- a/tests/test_worker.ts
+++ b/tests/test_worker.ts
@@ -1976,12 +1976,10 @@ describe('workers', function () {
   });
 
   it('emits error if lock is lost', async function () {
-    this.timeout(10000);
-
     const worker = new Worker(
       queueName,
       async () => {
-        return delay(2000);
+        return delay(1250);
       },
       {
         connection,


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? test is flaky because renewal of token happens after lockRenewTime/2, in this case 1500 and delay of processing is 2000.

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Decrease processing delay to be less than 1500 and greater than lock time (1000)

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
