### PR TITLE
fix(flow): only validate pending dependencies when moving to completed

### DIFF
--- a/src/commands/moveToFinished-14.lua
+++ b/src/commands/moveToFinished-14.lua
@@ -95,7 +95,8 @@ if rcall("EXISTS", jobIdKey) == 1 then -- // Make sure job exists
     local maxCount = opts['keepJobs']['count']
     local maxAge = opts['keepJobs']['age']
 
-    if ARGV[5] == "completed" and rcall("SCARD", jobIdKey .. ":dependencies") ~= 0 then -- // Make sure it does not have pending dependencies
+    -- Make sure it does not have pending dependencies
+    if ARGV[5] == "completed" and rcall("SCARD", jobIdKey .. ":dependencies") ~= 0 then
         return -4
     end
 
@@ -194,7 +195,7 @@ if rcall("EXISTS", jobIdKey) == 1 then -- // Make sure job exists
     end
 
     rcall("XADD", eventStreamKey, "*", "event", ARGV[5], "jobId", jobId, ARGV[3],
-          ARGV[4])
+          ARGV[4], "prev", "active")
 
     if ARGV[5] == "failed" then
         if tonumber(attemptsMade) >= tonumber(attempts) then

--- a/src/commands/moveToFinished-14.lua
+++ b/src/commands/moveToFinished-14.lua
@@ -95,7 +95,7 @@ if rcall("EXISTS", jobIdKey) == 1 then -- // Make sure job exists
     local maxCount = opts['keepJobs']['count']
     local maxAge = opts['keepJobs']['age']
 
-    if rcall("SCARD", jobIdKey .. ":dependencies") ~= 0 then -- // Make sure it does not have pending dependencies
+    if ARGV[5] == "completed" and rcall("SCARD", jobIdKey .. ":dependencies") ~= 0 then -- // Make sure it does not have pending dependencies
         return -4
     end
 

--- a/tests/test_flow.ts
+++ b/tests/test_flow.ts
@@ -1206,6 +1206,119 @@ describe('flows', () => {
         await grandchildrenWorker.close();
       });
     });
+
+    describe('when parent failed before moving to waiting-children', () => {
+      it('should fail parent with last error', async function () {
+        const childrenQueueName = `children-queue-${v4()}`;
+        const grandchildrenQueueName = `grandchildren-queue-${v4()}`;
+
+        enum Step {
+          Initial,
+          Second,
+          Third,
+          Finish,
+        }
+
+        const flow = new FlowProducer({ connection, prefix });
+
+        const grandchildrenWorker = new Worker(
+          grandchildrenQueueName,
+          async () => {
+            throw new Error('fail');
+          },
+          { connection, prefix },
+        );
+
+        const worker = new Worker(
+          queueName,
+          async (job: Job, token?: string) => {
+            let step = job.data.step;
+            while (step !== Step.Finish) {
+              switch (step) {
+                case Step.Initial: {
+                  await flow.add({
+                    name: 'child-job',
+                    queueName: childrenQueueName,
+                    data: {},
+                    children: [
+                      {
+                        name: 'grandchild-job',
+                        data: { idx: 0, foo: 'bar' },
+                        queueName: grandchildrenQueueName,
+                        opts: {
+                          failParentOnFailure: true,
+                        },
+                      },
+                    ],
+                    opts: {
+                      parent: {
+                        id: job.id!,
+                        queue: job.queueQualifiedName,
+                      },
+                      failParentOnFailure: true,
+                    },
+                  });
+                  await job.updateData({
+                    step: Step.Second,
+                  });
+                  step = Step.Second;
+                  break;
+                }
+                case Step.Second: {
+                  await job.updateData({
+                    step: Step.Third,
+                  });
+                  step = Step.Third;
+
+                  throw new Error('fail');
+                }
+                case Step.Third: {
+                  const shouldWait = await job.moveToWaitingChildren(token!);
+                  if (!shouldWait) {
+                    await job.updateData({
+                      step: Step.Finish,
+                    });
+                    step = Step.Finish;
+                    return Step.Finish;
+                  } else {
+                    throw new WaitingChildrenError();
+                  }
+                }
+                default: {
+                  throw new Error('invalid step');
+                }
+              }
+            }
+          },
+          { connection, prefix },
+        );
+        const queueEvents = new QueueEvents(queueName, {
+          connection,
+          prefix,
+        });
+        await queueEvents.waitUntilReady();
+        await grandchildrenWorker.waitUntilReady();
+        await worker.waitUntilReady();
+
+        const job = await queue.add('test', { step: Step.Initial });
+
+        const failed = new Promise<void>(resolve => {
+          queueEvents.on('failed', async ({ jobId, failedReason, prev }) => {
+            if (jobId === job.id) {
+              expect(prev).to.be.equal('active');
+              expect(failedReason).to.be.equal('fail');
+              resolve();
+            }
+          });
+        });
+
+        await failed;
+
+        await flow.close();
+        await worker.close();
+        await grandchildrenWorker.close();
+      });
+    });
   });
 
   describe('when moving jobs from wait to active continuing', async () => {


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? When parent is moved to failed, error should be saved saved, even if there are pending dependencies. As it will be moved to failed anyway, better to preserve the real error. Pending dependencies must be validated only when trying to move a parent to completed

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Before validating the quantity of pending dependencies, check that we are trying to move parent to completed

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
