### PR TITLE
fix(job-scheduler): emit duplicated event when next delayed job exists

### DIFF
--- a/tests/test_job_scheduler.ts
+++ b/tests/test_job_scheduler.ts
@@ -342,6 +342,80 @@ describe('Job Scheduler', function () {
 
         await worker.close();
       });
+
+      describe('when job scheduler is being updated', function () {
+        it('emits duplicated event and does not update scheduler', async function () {
+          const date = new Date('2017-02-07T09:24:00.000+05:30');
+          this.clock.setSystemTime(date);
+          const worker = new Worker(
+            queueName,
+            async job => {
+              if (job.data.foo === 'bar') {
+                await queue.upsertJobScheduler(
+                  jobSchedulerId,
+                  {
+                    pattern: '*/2 * * * * *',
+                  },
+                  {
+                    data: {
+                      foo: 'baz',
+                    },
+                  },
+                );
+              }
+              this.clock.tick(2000);
+            },
+            { autorun: false, connection, prefix },
+          );
+
+          await worker.waitUntilReady();
+
+          const jobSchedulerId = 'test';
+          const delayedJob = await queue.upsertJobScheduler(
+            jobSchedulerId,
+            {
+              pattern: '*/10 * * * * *',
+            },
+            {
+              data: {
+                foo: 'bar',
+              },
+            },
+          );
+
+          await delayedJob!.promote();
+          worker.run();
+
+          const duplicating = new Promise<void>(resolve => {
+            queueEvents.once('duplicated', () => {
+              resolve();
+            });
+          });
+
+          await duplicating;
+
+          const repeatableJobs = await queue.getJobSchedulers();
+          expect(repeatableJobs.length).to.be.eql(1);
+
+          expect(repeatableJobs[0]).to.deep.equal({
+            key: 'test',
+            name: 'test',
+            next: 1486439648000,
+            iterationCount: 4,
+            pattern: '*/2 * * * * *',
+            template: {
+              data: {
+                foo: 'baz',
+              },
+            },
+          });
+
+          const count = await queue.getJobCountByTypes('delayed');
+          expect(count).to.be.equal(0);
+
+          await worker.close();
+        });
+      });
     });
 
     describe('when generated job is in waiting state', function () {


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? When a job already exists and job scheduler is updated. We are missing to emit duplicated event

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Emit duplicated event only when trying to add next job scheduler and id already exists

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
