### PR TITLE
feat: add deduplicated job id to the deduplicated event

### DIFF
--- a/src/commands/includes/deduplicateJob.lua
+++ b/src/commands/includes/deduplicateJob.lua
@@ -1,24 +1,23 @@
 --[[
   Function to debounce a job.
-]]
-
+]] 
 local function deduplicateJob(deduplicationOpts, jobId, deduplicationKey, eventsKey, maxEvents)
   local deduplicationId = deduplicationOpts and deduplicationOpts['id']
   if deduplicationId then
-    local ttl = deduplicationOpts['ttl']
-    local deduplicationKeyExists
-    if ttl then
-      deduplicationKeyExists = not rcall('SET', deduplicationKey, jobId, 'PX', ttl, 'NX')
-    else
-      deduplicationKeyExists = not rcall('SET', deduplicationKey, jobId, 'NX')
-    end
-    if deduplicationKeyExists then
-      local currentDebounceJobId = rcall('GET', deduplicationKey)
-      rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event",
-        "debounced", "jobId", currentDebounceJobId, "debounceId", deduplicationId)
-      rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event",
-        "deduplicated", "jobId", currentDebounceJobId, "deduplicationId", deduplicationId)
-      return currentDebounceJobId
-    end
+      local ttl = deduplicationOpts['ttl']
+      local deduplicationKeyExists
+      if ttl then
+          deduplicationKeyExists = not rcall('SET', deduplicationKey, jobId, 'PX', ttl, 'NX')
+      else
+          deduplicationKeyExists = not rcall('SET', deduplicationKey, jobId, 'NX')
+      end
+      if deduplicationKeyExists then
+          local currentDebounceJobId = rcall('GET', deduplicationKey)
+          rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event", "debounced", "jobId", currentDebounceJobId,
+              "debounceId", deduplicationId)
+          rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event", "deduplicated", "jobId",
+              currentDebounceJobId, "deduplicationId", deduplicationId, "deduplicatedJobId", jobId)
+          return currentDebounceJobId
+      end
   end
 end


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
So that it is possible to get a notification of the job id that was actually discarded due to deduplication.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
passing the job id to the deduplication event.

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
