### PR TITLE
fix(flow): validate pending dependencies before removing lock

### DIFF
--- a/tests/test_job.ts
+++ b/tests/test_job.ts
@@ -673,7 +673,7 @@ describe('Job', function () {
         `${prefix}:${parentQueueName}:${job.id}:lock`,
       );
 
-      expect(lock).to.be.null;
+      expect(lock).to.be.equal(token);
 
       const isCompleted = await job.isCompleted();
 


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? When a parent throws an error because it has pending dependencies, it's removing the lock first. That causes that moveToFailed throws a different error than pending dependencies, it throws error that lock is missing.

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Move pending dependencies validation before releasing lock, that way the error is properly propagated to the parent

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
