### PR TITLE
feat(updateProgress): allow more types to be used as progress

### DIFF
--- a/src/classes/child-processor.ts
+++ b/src/classes/child-processor.ts
@@ -127,7 +127,7 @@ export class ChildProcessor {
       /*
        * Proxy `updateProgress` function, should works as `progress` function.
        */
-      async updateProgress(progress: number | object) {
+      async updateProgress(progress: number | object | string | boolean) {
         // Locally store reference to new progress value
         // so that we can return it from this process synchronously.
         this.progress = progress;

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -81,7 +81,7 @@ export class Job<
    * The progress a job has performed so far.
    * @defaultValue 0
    */
-  progress: number | object = 0;
+  progress: number | object | string | boolean = 0;
 
   /**
    * The value returned by the processor when processing this job.
@@ -570,7 +570,9 @@ export class Job<
    *
    * @param progress - number or object to be saved as progress.
    */
-  async updateProgress(progress: number | object): Promise<void> {
+  async updateProgress(
+    progress: number | object | string | boolean,
+  ): Promise<void> {
     this.progress = progress;
     await this.scripts.updateProgress(this.id, progress);
     this.queue.emit('progress', this, progress);

--- a/src/classes/queue-events.ts
+++ b/src/classes/queue-events.ts
@@ -177,7 +177,7 @@ export interface QueueEventsListener extends IoredisListener {
    * @param id - The identifier of the event.
    */
   progress: (
-    args: { jobId: string; data: number | object },
+    args: { jobId: string; data: number | object | string | boolean },
     id: string,
   ) => void;
 

--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -810,7 +810,7 @@ export class Queue<
    */
   async updateJobProgress(
     jobId: string,
-    progress: number | object,
+    progress: number | object | string | boolean,
   ): Promise<void> {
     await this.trace<void>(
       SpanKind.INTERNAL,

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -555,7 +555,7 @@ export class Scripts {
 
   async updateProgress(
     jobId: string,
-    progress: number | object,
+    progress: number | object | string | boolean,
   ): Promise<void> {
     const client = await this.queue.client;
 

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -131,7 +131,7 @@ export interface WorkerListener<
    */
   progress: (
     job: Job<DataType, ResultType, NameType>,
-    progress: number | object,
+    progress: number | object | string | boolean,
   ) => void;
 
   /**

--- a/src/interfaces/job-json.ts
+++ b/src/interfaces/job-json.ts
@@ -6,7 +6,7 @@ export interface JobJson {
   name: string;
   data: string;
   opts: RedisJobOptions;
-  progress: number | object;
+  progress: number | object | string | boolean;
   attemptsMade: number;
   attemptsStarted: number;
   finishedOn?: number;

--- a/src/interfaces/minimal-job.ts
+++ b/src/interfaces/minimal-job.ts
@@ -56,7 +56,7 @@ export interface MinimalJob<
    * The progress a job has performed so far.
    * @defaultValue 0
    */
-  progress: number | object;
+  progress: number | object | string | boolean;
   /**
    * The value returned by the processor when processing this job.
    * @defaultValue null
@@ -126,7 +126,7 @@ export interface MinimalJob<
    *
    * @param progress - number or object to be saved as progress.
    */
-  updateProgress(progress: number | object): Promise<void>;
+  updateProgress(progress: number | object | string | boolean): Promise<void>;
   /**
    * Logs one row of log data.
    *

--- a/src/interfaces/sandboxed-job.ts
+++ b/src/interfaces/sandboxed-job.ts
@@ -10,6 +10,6 @@ export interface SandboxedJob<T = any, R = any>
   moveToDelayed: (timestamp: number, token?: string) => Promise<void>;
   log: (row: any) => void;
   updateData: (data: any) => Promise<void>;
-  updateProgress: (value: object | number) => Promise<void>;
+  updateProgress: (value: object | number | string | boolean) => Promise<void>;
   returnValue: R;
 }

--- a/tests/test_job.ts
+++ b/tests/test_job.ts
@@ -391,6 +391,23 @@ describe('Job', function () {
       expect(storedJob!.progress).to.eql({ total: 120, completed: 40 });
     });
 
+    it('can set and get progress as string', async function () {
+      const job = await Job.create(queue, 'test', { foo: 'bar' });
+      await job.updateProgress('hello, world!');
+      const storedJob = await Job.fromId(queue, job.id!);
+      expect(storedJob!.progress).to.eql('hello, world!');
+    });
+
+    it('can set and get progress as boolean', async function () {
+      const job = await Job.create(queue, 'test', { foo: 'bar' });
+      await job.updateProgress(false);
+      let storedJob = await Job.fromId(queue, job.id!);
+      expect(storedJob!.progress).to.eql(false);
+      await job.updateProgress(true);
+      storedJob = await Job.fromId(queue, job.id!);
+      expect(storedJob!.progress).to.eql(true);
+    });
+
     it('cat set progress as number using the Queue instance', async () => {
       const job = await Job.create(queue, 'test', { foo: 'bar' });
 


### PR DESCRIPTION
### Why

Currently `Job.updateProgress()` requires his argument to be a `number | object` union, this does not let us use other primitives types like `string` and `boolean`.

Since the progress is serialized using `JSON.stringify()` we can have a more permissive type for the progress.

### How

All references to the `updateProgress()` method and the `progress` property are now a `number | object | string | boolean` union.

The implementation of the serialization process has not changed, since `JSON.stringify()` already handles both `string` and `boolean`.
