### PR TITLE
fix(job-scheduler): fix endDate presence validation

### DIFF
--- a/src/classes/async-fifo-queue.ts
+++ b/src/classes/async-fifo-queue.ts
@@ -8,7 +8,7 @@ class Node<T> {
 }
 
 class LinkedList<T> {
-  length: number = 0;
+  length = 0;
   private head: Node<T> | null;
   private tail: Node<T> | null;
 

--- a/src/classes/child.ts
+++ b/src/classes/child.ts
@@ -36,7 +36,7 @@ export class Child extends EventEmitter {
 
   private _exitCode: number = null;
   private _signalCode: number = null;
-  private _killed: boolean = false;
+  private _killed = false;
 
   constructor(
     private mainFile: string,

--- a/src/classes/job-scheduler.ts
+++ b/src/classes/job-scheduler.ts
@@ -77,7 +77,7 @@ export class JobScheduler extends QueueBase {
     // Check if we reached the end date of the repeatable job
     let now = Date.now();
     const { endDate } = repeatOpts;
-    if (!(typeof endDate === undefined) && now > new Date(endDate!).getTime()) {
+    if (endDate && now > new Date(endDate!).getTime()) {
       return;
     }
 

--- a/src/classes/queue-base.ts
+++ b/src/classes/queue-base.ts
@@ -28,8 +28,8 @@ export class QueueBase extends EventEmitter implements MinimalQueue {
   keys: KeysMap;
   closing: Promise<void> | undefined;
 
-  protected closed: boolean = false;
-  protected hasBlockingConnection: boolean = false;
+  protected closed = false;
+  protected hasBlockingConnection = false;
   protected scripts: Scripts;
   protected connection: RedisConnection;
   public readonly qualifiedName: string;

--- a/src/classes/queue-keys.ts
+++ b/src/classes/queue-keys.ts
@@ -1,7 +1,7 @@
 export type KeysMap = { [index in string]: string };
 
 export class QueueKeys {
-  constructor(public readonly prefix: string = 'bull') {}
+  constructor(public readonly prefix = 'bull') {}
 
   getKeys(name: string): KeysMap {
     const keys: { [index: string]: string } = {};

--- a/src/classes/repeat.ts
+++ b/src/classes/repeat.ts
@@ -52,7 +52,7 @@ export class Repeat extends QueueBase {
     // Check if we reached the end date of the repeatable job
     let now = Date.now();
     const { endDate } = repeatOpts;
-    if (!(typeof endDate === undefined) && now > new Date(endDate!).getTime()) {
+    if (endDate && now > new Date(endDate!).getTime()) {
       return;
     }
 

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -177,7 +177,7 @@ export class Worker<
   private blockUntil = 0;
   private _concurrency: number;
   private childPool: ChildPool;
-  private drained: boolean = false;
+  private drained = false;
   private extendLocksTimer: NodeJS.Timeout | null = null;
   private limitUntil = 0;
 


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
1. Why is this change necessary? Because typeof returns a string, it won't return undefined. This pr fixes endDate presence validation

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Instead of checking that is not undefined, just check it's presence

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
