### PR TITLE
fix(FlowProducer): fix the queueName otel attribute when using addNode

### DIFF
--- a/src/classes/flow-producer.ts
+++ b/src/classes/flow-producer.ts
@@ -329,7 +329,7 @@ export class FlowProducer extends EventEmitter {
     return trace<Promise<JobNode>>(
       this.telemetry,
       SpanKind.PRODUCER,
-      node.name,
+      node.queueName,
       'addNode',
       node.queueName,
       async (span, srcPropagationMedatada) => {


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->

1. This fixes a bug where the job name was getting set as the queue name in span attributes.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->

1. I implemented this by switching it to use the correct value.

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->

![flow-producer_ts__Working_Tree___flow-producer_ts__—_bullmq](https://github.com/user-attachments/assets/4d4f0f27-b91e-4b40-a155-073036d367e8)

Example in Grafana UI where the attribute is incorrectly set to the job name:
![Screenshot 2025-04-04 at 12 37 19 PM](https://github.com/user-attachments/assets/52ec2aea-86c9-4339-8d3a-f3ce7c2fb3a4)
