### PR TITLE
feat(Worker): Adds two otel span attributes when processJob is called

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -830,6 +830,8 @@ will never work with more accuracy than 1ms. */
           [TelemetryAttributes.WorkerId]: this.id,
           [TelemetryAttributes.WorkerName]: this.opts.name,
           [TelemetryAttributes.JobId]: job.id,
+          [TelemetryAttributes.JobName]: job.name,
+          [TelemetryAttributes.JobAttemptsMade]: job.attemptsMade
         });
 
         const handleCompleted = async (result: ResultType) => {

--- a/src/enums/telemetry-attributes.ts
+++ b/src/enums/telemetry-attributes.ts
@@ -7,6 +7,7 @@ export enum TelemetryAttributes {
   JobId = 'bullmq.job.id',
   JobKey = 'bullmq.job.key',
   JobIds = 'bullmq.job.ids',
+  JobAttemptsMade = 'bullmq.job.attempts.made',
   DeduplicationKey = 'bullmq.job.deduplication.key',
   JobOptions = 'bullmq.job.options',
   JobProgress = 'bullmq.job.progress',


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
This change isn't strictly necessary but adds two span attributes to the open telemetry tracing when a job is being processed.  These additional pieces of metadata could be very helpful when troubleshooting issues.


### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->

I added the two span attributed I'd like so see.

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->

I don't have a good local setup to test this.  The changes seem pretty straightforward, but I will lean on maintainers to validate.