### PR TITLE
fix(job-scheduler): remove next delayed job if present even if scheduler does not exist

### DIFF
--- a/src/commands/addJobScheduler-11.lua
+++ b/src/commands/addJobScheduler-11.lua
@@ -59,81 +59,50 @@ local schedulerKey = repeatKey .. ":" .. jobSchedulerId
 local nextDelayedJobKey = schedulerKey .. ":" .. nextMillis
 local nextDelayedJobId = "repeat:" .. jobSchedulerId .. ":" .. nextMillis
 
-if rcall("EXISTS", nextDelayedJobKey) == 1 then
-    if rcall("ZSCORE", delayedKey, nextDelayedJobId) then
+local maxEvents = getOrSetMaxEvents(metaKey)
+
+local function removeJobFromScheduler(prefixKey, delayedKey, prioritizedKey, waitKey, pausedKey, jobId, metaKey, eventsKey)
+    if rcall("ZSCORE", delayedKey, jobId) then
         removeJob(nextDelayedJobId, true, prefixKey, true --[[remove debounce key]] )
-        rcall("ZREM", delayedKey, nextDelayedJobId)
-    elseif rcall("ZSCORE", prioritizedKey, nextDelayedJobId) then
-        removeJob(nextDelayedJobId, true, prefixKey, true --[[remove debounce key]] )
-        rcall("ZREM", prioritizedKey, nextDelayedJobId)
+        rcall("ZREM", delayedKey, jobId)
+        return true
+    elseif rcall("ZSCORE", prioritizedKey, jobId) then
+        removeJob(jobId, true, prefixKey, true --[[remove debounce key]] )
+        rcall("ZREM", prioritizedKey, jobId)
+        return true
     else
         local pausedOrWaitKey = waitKey
         if isQueuePaused(metaKey) then
             pausedOrWaitKey = pausedKey
         end
 
-        if rcall("LREM", pausedOrWaitKey, 1, nextDelayedJobId) > 0 then
-            removeJob(nextDelayedJobId, true, prefixKey, true --[[remove debounce key]] )
-        else
-            local maxEvents = getOrSetMaxEvents(metaKey)
-
-            rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event",
-                "duplicated", "jobId", nextDelayedJobId)
-
-            return nextDelayedJobId .. "" -- convert to string
+        if rcall("LREM", pausedOrWaitKey, 1, jobId) > 0 then
+            removeJob(jobId, true, prefixKey, true --[[remove debounce key]] )
+            return true
         end
+    end
+    return false
+end
+    
+if rcall("EXISTS", nextDelayedJobKey) == 1 then
+    if not removeJobFromScheduler(prefixKey, delayedKey, prioritizedKey, waitKey, pausedKey,
+        nextDelayedJobId, metaKey, eventsKey) then
+        rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event",
+            "duplicated", "jobId", nextDelayedJobId)
+
+        return nextDelayedJobId .. "" -- convert to string
     end
 end
 
 local prevMillis = rcall("ZSCORE", repeatKey, jobSchedulerId)
 
-if prevMillis ~= false then
+if prevMillis then
     local currentJobId = "repeat:" .. jobSchedulerId .. ":" .. prevMillis
     local currentDelayedJobKey = schedulerKey .. ":" .. prevMillis
-
-    if rcall("EXISTS", nextDelayedJobKey) == 1 then
-        if rcall("ZSCORE", delayedKey, nextDelayedJobId) then
-            removeJob(nextDelayedJobId, true, prefixKey, true --[[remove debounce key]] )
-            rcall("ZREM", delayedKey, nextDelayedJobId)
-        elseif rcall("ZSCORE", prioritizedKey, nextDelayedJobId) then
-            removeJob(nextDelayedJobId, true, prefixKey, true --[[remove debounce key]] )
-            rcall("ZREM", prioritizedKey, nextDelayedJobId)
-        else
-            local pausedOrWaitKey = waitKey
-            if isQueuePaused(metaKey) then
-                pausedOrWaitKey = pausedKey
-            end
-    
-            if rcall("LREM", pausedOrWaitKey, 1, nextDelayedJobId) > 0 then
-                removeJob(nextDelayedJobId, true, prefixKey, true --[[remove debounce key]] )
-            else
-                local maxEvents = getOrSetMaxEvents(metaKey)
-    
-                rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event",
-                    "duplicated", "jobId", nextDelayedJobId)
-    
-                return nextDelayedJobId .. "" -- convert to string
-            end
-        end
-    end
     
     if currentJobId ~= nextDelayedJobId and rcall("EXISTS", currentDelayedJobKey) == 1 then
-        if rcall("ZSCORE", delayedKey, currentJobId) ~= false then
-            removeJob(currentJobId, true, prefixKey, true --[[remove debounce key]] )
-            rcall("ZREM", delayedKey, currentJobId)
-        elseif rcall("ZSCORE", prioritizedKey, currentJobId) ~= false then
-            removeJob(currentJobId, true, prefixKey, true --[[remove debounce key]] )
-            rcall("ZREM", prioritizedKey, currentJobId)
-        else
-            local pausedOrWaitKey = waitKey
-            if isQueuePaused(metaKey) then
-                pausedOrWaitKey = pausedKey
-            end
-
-            if rcall("LREM", pausedOrWaitKey, 1, currentJobId) > 0 then
-                removeJob(currentJobId, true, prefixKey, true --[[remove debounce key]] )
-            end
-        end
+        removeJobFromScheduler(prefixKey, delayedKey, prioritizedKey, waitKey, pausedKey,
+            currentJobId, metaKey, eventsKey)
     end
 end
 
@@ -141,8 +110,6 @@ local schedulerOpts = cmsgpack.unpack(ARGV[2])
 storeJobScheduler(jobSchedulerId, schedulerKey, repeatKey, nextMillis, schedulerOpts, ARGV[4], templateOpts)
 
 rcall("INCR", KEYS[8])
-
-local maxEvents = getOrSetMaxEvents(metaKey)
 
 addJobFromScheduler(nextDelayedJobKey, nextDelayedJobId, ARGV[6], waitKey, pausedKey,
     KEYS[11], metaKey, prioritizedKey, KEYS[10], delayedKey, KEYS[7], eventsKey,

--- a/src/commands/addJobScheduler-11.lua
+++ b/src/commands/addJobScheduler-11.lua
@@ -61,7 +61,8 @@ local nextDelayedJobId = "repeat:" .. jobSchedulerId .. ":" .. nextMillis
 
 local maxEvents = getOrSetMaxEvents(metaKey)
 
-local function removeJobFromScheduler(prefixKey, delayedKey, prioritizedKey, waitKey, pausedKey, jobId, metaKey, eventsKey)
+local function removeJobFromScheduler(prefixKey, delayedKey, prioritizedKey, waitKey, pausedKey, jobId,
+    metaKey, eventsKey)
     if rcall("ZSCORE", delayedKey, jobId) then
         removeJob(nextDelayedJobId, true, prefixKey, true --[[remove debounce key]] )
         rcall("ZREM", delayedKey, jobId)
@@ -83,7 +84,7 @@ local function removeJobFromScheduler(prefixKey, delayedKey, prioritizedKey, wai
     end
     return false
 end
-    
+
 if rcall("EXISTS", nextDelayedJobKey) == 1 then
     if not removeJobFromScheduler(prefixKey, delayedKey, prioritizedKey, waitKey, pausedKey,
         nextDelayedJobId, metaKey, eventsKey) then
@@ -96,7 +97,7 @@ end
 
 local prevMillis = rcall("ZSCORE", repeatKey, jobSchedulerId)
 
-if prevMillis then
+if prevMillis then    
     local currentJobId = "repeat:" .. jobSchedulerId .. ":" .. prevMillis
     local currentDelayedJobKey = schedulerKey .. ":" .. prevMillis
     

--- a/src/commands/includes/storeJob.lua
+++ b/src/commands/includes/storeJob.lua
@@ -10,7 +10,6 @@ local function storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp,
     
     local optionalValues = {}
     if parentKey ~= nil then
-        rcall("SET", "DEBUG-pk", type(repeatJobKey))
         table.insert(optionalValues, "parentKey")
         table.insert(optionalValues, parentKey)
         table.insert(optionalValues, "parent")
@@ -18,7 +17,6 @@ local function storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp,
     end
 
     if repeatJobKey then
-        rcall("SET", "DEBUG-rjk", type(repeatJobKey))
         table.insert(optionalValues, "rjk")
         table.insert(optionalValues, repeatJobKey)
     end
@@ -27,13 +25,7 @@ local function storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp,
         table.insert(optionalValues, "deid")
         table.insert(optionalValues, debounceId)
     end
-    rcall("SET", "DEBUG-key", type(jobIdKey))
-    rcall("SET", "DEBUG-name", type(name))
-    rcall("SET", "DEBUG-data", type(data))
-    rcall("SET", "DEBUG-opts", type(jsonOpts))
-    rcall("SET", "DEBUG-times", type(timestamp))
-    rcall("SET", "DEBUG-delay", type(delay))
-    rcall("SET", "DEBUG-priority", type(priority))
+
     rcall("HMSET", jobIdKey, "name", name, "data", data, "opts", jsonOpts,
           "timestamp", timestamp, "delay", delay, "priority", priority,
           unpack(optionalValues))

--- a/src/commands/includes/storeJob.lua
+++ b/src/commands/includes/storeJob.lua
@@ -10,13 +10,15 @@ local function storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp,
     
     local optionalValues = {}
     if parentKey ~= nil then
+        rcall("SET", "DEBUG-pk", type(repeatJobKey))
         table.insert(optionalValues, "parentKey")
         table.insert(optionalValues, parentKey)
         table.insert(optionalValues, "parent")
         table.insert(optionalValues, parentData)
     end
 
-    if repeatJobKey ~= nil then
+    if repeatJobKey then
+        rcall("SET", "DEBUG-rjk", type(repeatJobKey))
         table.insert(optionalValues, "rjk")
         table.insert(optionalValues, repeatJobKey)
     end
@@ -25,7 +27,13 @@ local function storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp,
         table.insert(optionalValues, "deid")
         table.insert(optionalValues, debounceId)
     end
-
+    rcall("SET", "DEBUG-key", type(jobIdKey))
+    rcall("SET", "DEBUG-name", type(name))
+    rcall("SET", "DEBUG-data", type(data))
+    rcall("SET", "DEBUG-opts", type(jsonOpts))
+    rcall("SET", "DEBUG-times", type(timestamp))
+    rcall("SET", "DEBUG-delay", type(delay))
+    rcall("SET", "DEBUG-priority", type(priority))
     rcall("HMSET", jobIdKey, "name", name, "data", data, "opts", jsonOpts,
           "timestamp", timestamp, "delay", delay, "priority", priority,
           unpack(optionalValues))

--- a/src/commands/moveToFinished-14.lua
+++ b/src/commands/moveToFinished-14.lua
@@ -274,5 +274,6 @@ if rcall("EXISTS", jobIdKey) == 1 then -- Make sure job exists
 
     return 0
 else
+    rcall("SET", "DEBUG", "DEBUG")
     return -1
 end

--- a/src/commands/moveToFinished-14.lua
+++ b/src/commands/moveToFinished-14.lua
@@ -274,6 +274,5 @@ if rcall("EXISTS", jobIdKey) == 1 then -- Make sure job exists
 
     return 0
 else
-    rcall("SET", "DEBUG", "DEBUG")
     return -1
 end

--- a/src/commands/updateJobScheduler-12.lua
+++ b/src/commands/updateJobScheduler-12.lua
@@ -49,7 +49,7 @@ local nextDelayedJobKey = schedulerKey .. ":" .. nextMillis
 
 -- Validate that scheduler exists.
 local prevMillis = rcall("ZSCORE", repeatKey, jobSchedulerId)
-if prevMillis ~= false then
+if prevMillis then
     local currentDelayedJobId = "repeat:" .. jobSchedulerId .. ":" .. prevMillis
 
     if producerId == currentDelayedJobId then

--- a/tests/test_job_scheduler.ts
+++ b/tests/test_job_scheduler.ts
@@ -2467,6 +2467,53 @@ describe('Job Scheduler', function () {
     expect(waiting.length).to.be.eql(1);
   });
 
+  it.only(
+    'should not throw error when deleting and upserting a job scheduler while processing jobs',
+    async function () {
+      this.clock.restore();
+
+      const worker = new Worker(
+        queueName,
+        async () => {
+          await queue.removeJobScheduler('foo');
+          await queue.upsertJobScheduler(
+            'foo',
+            { every: 1000 },
+            {
+              name: 'bruh',
+              data: { something: 'else' },
+            },
+          );
+        },
+        { autorun: false, connection, prefix },
+      );
+      await worker.waitUntilReady();
+
+      await queue.upsertJobScheduler(
+        'foo',
+        { every: 1000 },
+        {
+          name: 'bruh',
+          data: { hello: 'world' },
+        },
+      );
+
+      const completing = new Promise<void>((resolve, reject) => {
+        queueEvents.once('completed', () => {
+          resolve();
+        });
+        worker.on('error', () => {
+          reject();
+        });
+      });
+      worker.run();
+
+      await completing;
+
+      await worker.close();
+    },
+  ).timeout(4000);
+
   it('should not repeat more than 5 times', async function () {
     const date = new Date('2017-02-07T09:24:00.000+05:30');
     this.clock.setSystemTime(date);


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? When a job scheduler is removed, we skip the validation of next delayed job existence. That means that we are not trying to remove it, we add this record back. That means that this job could exist in 2 different states (active, waiting/delayed). Another worker can take this record again while first instance is still running. That would cause a mismatch on locks

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Remove existing next delayed job even when job scheduler does not exists

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
ref https://github.com/taskforcesh/bullmq/issues/3197