### PR TITLE
docs(readme): typo fixed for text Job.fromId

### DIFF
--- a/docs/gitbook/README (1).md
+++ b/docs/gitbook/README (1).md
@@ -117,5 +117,5 @@ queueEvents.on('progress', ({ jobId, data }, timestamp) => {
 ```
 
 {% hint style="danger" %}
-For performance reasons, the events emitted by a `QueueEvents` instance do not contain the `Job` instance, only the `jobId`. Use the `Job#fromId` method if you need the `Job` instance.
+For performance reasons, the events emitted by a `QueueEvents` instance do not contain the `Job` instance, only the `jobId`. Use the `Job.fromId(queue, jobId)` method if you need the `Job` instance.
 {% endhint %}

--- a/docs/gitbook/README (1).md
+++ b/docs/gitbook/README (1).md
@@ -117,5 +117,5 @@ queueEvents.on('progress', ({ jobId, data }, timestamp) => {
 ```
 
 {% hint style="danger" %}
-For performance reasons, the events emitted by a `QueueEvents` instance do not contain the `Job` instance, only the `jobId`. Use the `Job.fromId(queue, jobId)` method if you need the `Job` instance.
+For performance reasons, the events emitted by a `QueueEvents` instance do not contain the `Job` instance, only the `jobId`. Use the [`Job.fromId`](https://api.docs.bullmq.io/classes/v5.Job.html#fromId) method if you need the `Job` instance.
 {% endhint %}


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
1. typo fixed, text updated from `Job#fromId` to `Job.fromId(queue, jobId)`

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
