### PR TITLE
fix(flow-producer): use FlowProducer prefix by default when calling getFlow

### DIFF
--- a/src/classes/flow-producer.ts
+++ b/src/classes/flow-producer.ts
@@ -250,6 +250,7 @@ export class FlowProducer extends EventEmitter {
       {
         depth: 10,
         maxChildren: 20,
+        prefix: this.opts.prefix,
       },
       opts,
     );


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 

  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? Prefix attribute is optional when using getFlow. When this value is not provided it should use the same prefix as being passed in FlowProducer initialization

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Make sure to use default prefix by default if no prefix param is provided

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
