### PR TITLE
test(clean): fix flaky test when checking keys quantity

### DIFF
--- a/tests/test_clean.ts
+++ b/tests/test_clean.ts
@@ -486,6 +486,8 @@ describe('Cleaner', () => {
           await queue.clean(0, 0, 'failed');
 
           const client = await queue.client;
+          // only checks if there are keys under job key prefix
+          // this way we make sure that all of them were removed
           const keys = await client.keys(
             `${prefix}:${queue.name}:${tree.job.id}*`,
           );

--- a/tests/test_clean.ts
+++ b/tests/test_clean.ts
@@ -486,10 +486,11 @@ describe('Cleaner', () => {
           await queue.clean(0, 0, 'failed');
 
           const client = await queue.client;
-          const keys = await client.keys(`${prefix}:${queue.name}:*`);
+          const keys = await client.keys(
+            `${prefix}:${queue.name}:${tree.job.id}*`,
+          );
 
-          // Expected keys: meta, id, stalled-check, events, failed and 2 jobs
-          expect(keys.length).to.be.eql(7);
+          expect(keys.length).to.be.eql(0);
 
           const jobs = await queue.getJobCountByTypes('completed');
           expect(jobs).to.be.equal(2);


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? This is a flaky test, where keys could be greater than 7. Instead we can check those keys that we are interested - those related to the parent job that it's being removed

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Filter keys to only include the ones related to the parent job

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
