### PR TITLE
test: fix flaky test where worker should start after job additions

### DIFF
--- a/tests/test_worker.ts
+++ b/tests/test_worker.ts
@@ -2865,7 +2865,7 @@ describe('workers', function () {
                 throw new Error('Not yet!');
               }
             },
-            { connection, prefix },
+            { autorun: false, connection, prefix },
           );
 
           await worker.waitUntilReady();
@@ -2891,6 +2891,8 @@ describe('workers', function () {
           }));
 
           await queue.addBulk(jobs);
+
+          worker.run();
 
           await completing;
 


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? Attempt to fix this flaky test that happens in dragonfly

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
