### PR TITLE
perf(flow): change parent failure in a lazy way

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -139,6 +139,11 @@ export class Job<
   failedReason: string;
 
   /**
+   * Reason for failing in a lazy way.
+   */
+  lazyFailedReason: string;
+
+  /**
    * Timestamp for when the job finished (completed or failed).
    */
   finishedOn?: number;
@@ -384,6 +389,10 @@ export class Job<
     job.attemptsMade = parseInt(json.attemptsMade || json.atm || '0');
 
     job.stalledCounter = parseInt(json.stc || '0');
+
+    if (json.lfr) {
+      job.lazyFailedReason = json.lfr;
+    }
 
     job.stacktrace = getTraces(json.stacktrace);
 

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -139,7 +139,8 @@ export class Job<
   failedReason: string;
 
   /**
-   * Deferred failure to move a job to failed.
+   * Deferred failure. Stores a failed message and marks this job to be failed directly
+   * as soon as the job is picked up by a worker, and using this string as the failed reason.
    */
   deferredFailure: string;
 

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -139,9 +139,9 @@ export class Job<
   failedReason: string;
 
   /**
-   * Reason for failing in a lazy way.
+   * Deferred failure to move a job to failed.
    */
-  lazyFailedReason: string;
+  deferredFailure: string;
 
   /**
    * Timestamp for when the job finished (completed or failed).
@@ -390,8 +390,8 @@ export class Job<
 
     job.stalledCounter = parseInt(json.stc || '0');
 
-    if (json.lfr) {
-      job.lazyFailedReason = json.lfr;
+    if (json.defa) {
+      job.deferredFailure = json.defa;
     }
 
     job.stacktrace = getTraces(json.stacktrace);

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -35,6 +35,7 @@ import {
   RateLimitError,
   RATE_LIMIT_ERROR,
   WaitingChildrenError,
+  UnrecoverableError,
 } from './errors';
 import { SpanKind, TelemetryAttributes } from '../enums';
 import { JobScheduler } from './job-scheduler';
@@ -906,6 +907,12 @@ will never work with more accuracy than 1ms. */
 
         try {
           jobsInProgress.add(inProgressItem);
+          if (job.lazyFailedReason) {
+            const failed = await handleFailed(
+              new UnrecoverableError(job.lazyFailedReason),
+            );
+            return failed;
+          }
           const result = await this.callProcessJob(job, token);
           return await handleCompleted(result);
         } catch (err) {

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -906,13 +906,14 @@ will never work with more accuracy than 1ms. */
         const inProgressItem = { job, ts: processedOn };
 
         try {
-          jobsInProgress.add(inProgressItem);
           if (job.deferredFailure) {
             const failed = await handleFailed(
               new UnrecoverableError(job.deferredFailure),
             );
             return failed;
           }
+          jobsInProgress.add(inProgressItem);
+
           const result = await this.callProcessJob(job, token);
           return await handleCompleted(result);
         } catch (err) {

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -907,9 +907,9 @@ will never work with more accuracy than 1ms. */
 
         try {
           jobsInProgress.add(inProgressItem);
-          if (job.lazyFailedReason) {
+          if (job.deferredFailure) {
             const failed = await handleFailed(
-              new UnrecoverableError(job.lazyFailedReason),
+              new UnrecoverableError(job.deferredFailure),
             );
             return failed;
           }

--- a/src/commands/includes/moveChildFromDependenciesIfNeeded.lua
+++ b/src/commands/includes/moveChildFromDependenciesIfNeeded.lua
@@ -31,13 +31,13 @@ moveParentToFailedIfNeeded = function (parentQueueKey, parentKey, parentId, jobI
       rcall("ZREM", parentWaitingChildrenOrDelayedKey, parentId)
       local parentQueuePrefix = parentQueueKey .. ":"
       local parentFailedKey = parentQueueKey .. ":failed"
-      local lazyFailedReason = "child " .. jobIdKey .. " failed"
-      rcall("HSET", parentKey, "lfr", lazyFailedReason)
+      local deferredFailure = "child " .. jobIdKey .. " failed"
+      rcall("HSET", parentKey, "defa", deferredFailure)
       moveParentToWait(parentQueueKey, parentKey, parentId, timestamp)
     else
       if not rcall("ZSCORE", parentQueueKey .. ":failed", parentId) then
-        local lazyFailedReason = "child " .. jobIdKey .. " failed"
-        rcall("HSET", parentKey, "lfr", lazyFailedReason)
+        local deferredFailure = "child " .. jobIdKey .. " failed"
+        rcall("HSET", parentKey, "defa", deferredFailure)
       end
     end
   end

--- a/src/commands/includes/moveChildFromDependenciesIfNeeded.lua
+++ b/src/commands/includes/moveChildFromDependenciesIfNeeded.lua
@@ -3,6 +3,7 @@
 ]]
 
 -- Includes
+--- @include "moveParentToWaitIfNoPendingDependencies"
 --- @include "moveParentToWaitIfNeeded"
 --- @include "moveParentToWait"
 --- @include "removeDeduplicationKeyIfNeeded"
@@ -15,45 +16,28 @@ moveParentToFailedIfNeeded = function (parentQueueKey, parentKey, parentId, jobI
     local parentWaitingChildrenKey = parentQueueKey .. ":waiting-children"
     local parentDelayedKey = parentQueueKey .. ":delayed"
     local parentPrioritizedKey = parentQueueKey .. ":prioritized"
-    local parentWaitingChildrenOrDelayedOrPrioritizedKey
+    local parentWaitingChildrenOrDelayedKey
     local prevState
     if rcall("ZSCORE", parentWaitingChildrenKey, parentId) then
-      parentWaitingChildrenOrDelayedOrPrioritizedKey = parentWaitingChildrenKey
+      parentWaitingChildrenOrDelayedKey = parentWaitingChildrenKey
       prevState = "waiting-children"
     elseif rcall("ZSCORE", parentDelayedKey, parentId) then
-      parentWaitingChildrenOrDelayedOrPrioritizedKey = parentDelayedKey
+      parentWaitingChildrenOrDelayedKey = parentDelayedKey
       prevState = "delayed"
-    elseif rcall("ZSCORE", parentPrioritizedKey, parentId) then
-      parentWaitingChildrenOrDelayedOrPrioritizedKey = parentPrioritizedKey
-      prevState = "prioritized"
+      rcall("HSET", parentKey, "delay", 0)
     end
 
-    if parentWaitingChildrenOrDelayedOrPrioritizedKey then
-      rcall("ZREM", parentWaitingChildrenOrDelayedOrPrioritizedKey, parentId)
+    if parentWaitingChildrenOrDelayedKey then
+      rcall("ZREM", parentWaitingChildrenOrDelayedKey, parentId)
       local parentQueuePrefix = parentQueueKey .. ":"
       local parentFailedKey = parentQueueKey .. ":failed"
-      rcall("ZADD", parentFailedKey, timestamp, parentId)
-      local failedReason = "child " .. jobIdKey .. " failed"
-      rcall("HSET", parentKey, "failedReason", failedReason, "finishedOn", timestamp)
-      rcall("XADD", parentQueueKey .. ":events", "*", "event", "failed", "jobId", parentId, "failedReason",
-        failedReason, "prev", prevState)
-
-      local jobAttributes = rcall("HMGET", parentKey, "parent", "deid", "opts")
-
-      removeDeduplicationKeyIfNeeded(parentQueueKey .. ":", jobAttributes[2])
-
-      moveChildFromDependenciesIfNeeded(jobAttributes[1], parentKey, failedReason, timestamp)
-
-      local parentRawOpts = jobAttributes[3]
-      local parentOpts = cjson.decode(parentRawOpts)
-      
-      removeJobsOnFail(parentQueuePrefix, parentFailedKey, parentId, parentOpts, timestamp)
+      local lazyFailedReason = "child " .. jobIdKey .. " failed"
+      rcall("HSET", parentKey, "lfr", lazyFailedReason)
+      moveParentToWait(parentQueueKey, parentKey, parentId, timestamp)
     else
-      local grandParentKey = rcall("HGET", parentKey, "parentKey")
-
-      if grandParentKey then
-        local grandParentUnsuccesssfulSet = grandParentKey .. ":unsuccessful"
-        rcall("ZADD", grandParentUnsuccesssfulSet, timestamp, parentKey)
+      if not rcall("ZSCORE", parentQueueKey .. ":failed", parentId) then
+        local lazyFailedReason = "child " .. jobIdKey .. " failed"
+        rcall("HSET", parentKey, "lfr", lazyFailedReason)
       end
     end
   end
@@ -80,11 +64,11 @@ moveChildFromDependenciesIfNeeded = function (rawParentData, childKey, failedRea
       if rcall("SREM", parentDependenciesChildrenKey, childKey) == 1 then
         local parentFailedChildrenKey = parentKey .. ":failed"
         rcall("HSET", parentFailedChildrenKey, childKey, failedReason)
-        moveParentToWait(parentData['queueKey'], parentKey, parentData['id'], timestamp)
+        moveParentToWaitIfNeeded(parentData['queueKey'], parentKey, parentData['id'], timestamp)
       end
     elseif parentData['idof'] or parentData['rdof'] then
       if rcall("SREM", parentDependenciesChildrenKey, childKey) == 1 then
-        moveParentToWaitIfNeeded(parentData['queueKey'], parentDependenciesChildrenKey,
+        moveParentToWaitIfNoPendingDependencies(parentData['queueKey'], parentDependenciesChildrenKey,
           parentKey, parentData['id'], timestamp)
         if parentData['idof'] then
           local parentFailedChildrenKey = parentKey .. ":failed"

--- a/src/commands/includes/moveParentToWait.lua
+++ b/src/commands/includes/moveParentToWait.lua
@@ -1,49 +1,48 @@
 --[[
   Validate and move parent to a wait status (wait, prioritized or delayed)
 ]]
+
+-- Includes
 --- @include "addDelayMarkerIfNeeded"
 --- @include "addJobInTargetList"
 --- @include "addJobWithPriority"
 --- @include "isQueuePausedOrMaxed"
 --- @include "getTargetQueueList"
 local function moveParentToWait(parentQueueKey, parentKey, parentId, timestamp)
-    local isParentWaitingChildren = rcall("ZREM", parentQueueKey .. ":waiting-children", parentId)
-    if isParentWaitingChildren > 0 then
-        local parentWaitKey = parentQueueKey .. ":wait"
-        local parentPausedKey = parentQueueKey .. ":paused"
-        local parentActiveKey = parentQueueKey .. ":active"
-        local parentMetaKey = parentQueueKey .. ":meta"
+    local parentWaitKey = parentQueueKey .. ":wait"
+    local parentPausedKey = parentQueueKey .. ":paused"
+    local parentActiveKey = parentQueueKey .. ":active"
+    local parentMetaKey = parentQueueKey .. ":meta"
 
-        local parentMarkerKey = parentQueueKey .. ":marker"
-        local jobAttributes = rcall("HMGET", parentKey, "priority", "delay")
-        local priority = tonumber(jobAttributes[1]) or 0
-        local delay = tonumber(jobAttributes[2]) or 0
+    local parentMarkerKey = parentQueueKey .. ":marker"
+    local jobAttributes = rcall("HMGET", parentKey, "priority", "delay")
+    local priority = tonumber(jobAttributes[1]) or 0
+    local delay = tonumber(jobAttributes[2]) or 0
 
-        -- ignore dependencies if any left
-        rcall("HSET", parentKey, "igdp", 1)
+    -- ignore dependencies if any left
+    rcall("HSET", parentKey, "igdp", 1)
 
-        if delay > 0 then
-            local delayedTimestamp = tonumber(timestamp) + delay
-            local score = delayedTimestamp * 0x1000
-            local parentDelayedKey = parentQueueKey .. ":delayed"
-            rcall("ZADD", parentDelayedKey, score, parentId)
-            rcall("XADD", parentQueueKey .. ":events", "*", "event", "delayed", "jobId", parentId, "delay",
-                delayedTimestamp)
+    if delay > 0 then
+        local delayedTimestamp = tonumber(timestamp) + delay
+        local score = delayedTimestamp * 0x1000
+        local parentDelayedKey = parentQueueKey .. ":delayed"
+        rcall("ZADD", parentDelayedKey, score, parentId)
+        rcall("XADD", parentQueueKey .. ":events", "*", "event", "delayed", "jobId", parentId, "delay",
+            delayedTimestamp)
 
-            addDelayMarkerIfNeeded(parentMarkerKey, parentDelayedKey)
+        addDelayMarkerIfNeeded(parentMarkerKey, parentDelayedKey)
+    else
+        if priority == 0 then
+            local parentTarget, isParentPausedOrMaxed = getTargetQueueList(parentMetaKey, parentActiveKey,
+                parentWaitKey, parentPausedKey)
+            addJobInTargetList(parentTarget, parentMarkerKey, "RPUSH", isParentPausedOrMaxed, parentId)
         else
-            if priority == 0 then
-                local parentTarget, isParentPausedOrMaxed = getTargetQueueList(parentMetaKey, parentActiveKey,
-                    parentWaitKey, parentPausedKey)
-                addJobInTargetList(parentTarget, parentMarkerKey, "RPUSH", isParentPausedOrMaxed, parentId)
-            else
-                local isPausedOrMaxed = isQueuePausedOrMaxed(parentMetaKey, parentActiveKey)
-                addJobWithPriority(parentMarkerKey, parentQueueKey .. ":prioritized", priority, parentId,
-                    parentQueueKey .. ":pc", isPausedOrMaxed)
-            end
-
-            rcall("XADD", parentQueueKey .. ":events", "*", "event", "waiting", "jobId", parentId, "prev",
-                "waiting-children")
+            local isPausedOrMaxed = isQueuePausedOrMaxed(parentMetaKey, parentActiveKey)
+            addJobWithPriority(parentMarkerKey, parentQueueKey .. ":prioritized", priority, parentId,
+                parentQueueKey .. ":pc", isPausedOrMaxed)
         end
+
+        rcall("XADD", parentQueueKey .. ":events", "*", "event", "waiting", "jobId", parentId, "prev",
+            "waiting-children")
     end
 end

--- a/src/commands/includes/moveParentToWait.lua
+++ b/src/commands/includes/moveParentToWait.lua
@@ -1,5 +1,5 @@
 --[[
-  Validate and move parent to a wait status (wait, prioritized or delayed)
+  Move parent to a wait status (wait, prioritized or delayed)
 ]]
 
 -- Includes

--- a/src/commands/includes/moveParentToWaitIfNeeded.lua
+++ b/src/commands/includes/moveParentToWaitIfNeeded.lua
@@ -1,10 +1,14 @@
 --[[
   Validate and move parent to a wait status (waiting, delayed or prioritized) if needed.
 ]]
+-- Includes
 --- @include "moveParentToWait"
-local function moveParentToWaitIfNeeded(parentQueueKey, parentDependenciesKey, parentKey, parentId, timestamp)
-    local doNotHavePendingDependencies = rcall("SCARD", parentDependenciesKey) == 0
-    if doNotHavePendingDependencies then
-        moveParentToWait(parentQueueKey, parentKey, parentId, timestamp)
+local function moveParentToWaitIfNeeded(parentQueueKey, parentKey, parentId, timestamp)
+  if rcall("EXISTS", parentKey) == 1 then
+    local parentWaitingChildrenKey = parentQueueKey .. ":waiting-children"
+    if rcall("ZSCORE", parentWaitingChildrenKey, parentId) then    
+      rcall("ZREM", parentWaitingChildrenKey, parentId)
+      moveParentToWait(parentQueueKey, parentKey, parentId, timestamp)
     end
+  end
 end

--- a/src/commands/includes/moveParentToWaitIfNoPendingDependencies.lua
+++ b/src/commands/includes/moveParentToWaitIfNoPendingDependencies.lua
@@ -1,0 +1,17 @@
+--[[
+  Validate and move parent to a wait status (waiting, delayed or prioritized) if needed.
+]]
+-- Includes
+--- @include "moveParentToWait"
+local function moveParentToWaitIfNoPendingDependencies(parentQueueKey, parentDependenciesKey, parentKey, parentId, timestamp)
+  local doNotHavePendingDependencies = rcall("SCARD", parentDependenciesKey) == 0
+  if doNotHavePendingDependencies then
+    if rcall("EXISTS", parentKey) == 1 then
+      local parentWaitingChildrenKey = parentQueueKey .. ":waiting-children"
+      if rcall("ZSCORE", parentWaitingChildrenKey, parentId) then    
+        rcall("ZREM", parentWaitingChildrenKey, parentId)
+        moveParentToWait(parentQueueKey, parentKey, parentId, timestamp)
+      end
+    end
+  end
+end

--- a/src/commands/includes/moveParentToWaitIfNoPendingDependencies.lua
+++ b/src/commands/includes/moveParentToWaitIfNoPendingDependencies.lua
@@ -1,17 +1,13 @@
 --[[
-  Validate and move parent to a wait status (waiting, delayed or prioritized) if needed.
+  Validate and move parent to a wait status (waiting, delayed or prioritized)
+  if no pending dependencies.
 ]]
 -- Includes
---- @include "moveParentToWait"
-local function moveParentToWaitIfNoPendingDependencies(parentQueueKey, parentDependenciesKey, parentKey, parentId, timestamp)
+--- @include "moveParentToWaitIfNeeded"
+local function moveParentToWaitIfNoPendingDependencies(parentQueueKey, parentDependenciesKey, parentKey,
+  parentId, timestamp)
   local doNotHavePendingDependencies = rcall("SCARD", parentDependenciesKey) == 0
   if doNotHavePendingDependencies then
-    if rcall("EXISTS", parentKey) == 1 then
-      local parentWaitingChildrenKey = parentQueueKey .. ":waiting-children"
-      if rcall("ZSCORE", parentWaitingChildrenKey, parentId) then    
-        rcall("ZREM", parentWaitingChildrenKey, parentId)
-        moveParentToWait(parentQueueKey, parentKey, parentId, timestamp)
-      end
-    end
+    moveParentToWaitIfNeeded(parentQueueKey, parentKey, parentId, timestamp)
   end
 end

--- a/src/commands/includes/updateParentDepsIfNeeded.lua
+++ b/src/commands/includes/updateParentDepsIfNeeded.lua
@@ -3,11 +3,11 @@
 ]]
 
 -- Includes
---- @include "moveParentToWaitIfNeeded"
+--- @include "moveParentToWaitIfNoPendingDependencies"
 
 local function updateParentDepsIfNeeded(parentKey, parentQueueKey, parentDependenciesKey,
   parentId, jobIdKey, returnvalue, timestamp )
   local processedSet = parentKey .. ":processed"
   rcall("HSET", processedSet, jobIdKey, returnvalue)
-  moveParentToWaitIfNeeded(parentQueueKey, parentDependenciesKey, parentKey, parentId, timestamp)
+  moveParentToWaitIfNoPendingDependencies(parentQueueKey, parentDependenciesKey, parentKey, parentId, timestamp)
 end

--- a/src/commands/moveStalledJobsToWait-9.lua
+++ b/src/commands/moveStalledJobsToWait-9.lua
@@ -27,8 +27,6 @@ local rcall = redis.call
 --- @include "includes/batches"
 --- @include "includes/getTargetQueueList"
 --- @include "includes/moveChildFromDependenciesIfNeeded"
---- @include "includes/moveParentToWaitIfNeeded"
---- @include "includes/moveParentToWait"
 --- @include "includes/removeDeduplicationKeyIfNeeded"
 --- @include "includes/removeJobsOnFail"
 --- @include "includes/trimEvents"

--- a/src/commands/moveToFinished-14.lua
+++ b/src/commands/moveToFinished-14.lua
@@ -165,7 +165,7 @@ if rcall("EXISTS", jobIdKey) == 1 then -- Make sure job exists
         -- "returnvalue" / "failedReason" and "finishedOn"
 
         if ARGV[5] == "failed" then
-            rcall("HDEL", jobIdKey, "lfr")
+            rcall("HDEL", jobIdKey, "defa")
         end
 
         -- Remove old jobs?

--- a/src/commands/moveToFinished-14.lua
+++ b/src/commands/moveToFinished-14.lua
@@ -161,8 +161,12 @@ if rcall("EXISTS", jobIdKey) == 1 then -- Make sure job exists
         local targetSet = KEYS[11]
         -- Add to complete/failed set
         rcall("ZADD", targetSet, timestamp, jobId)
-        rcall("HMSET", jobIdKey, ARGV[3], ARGV[4], "finishedOn", timestamp)
+        rcall("HSET", jobIdKey, ARGV[3], ARGV[4], "finishedOn", timestamp)
         -- "returnvalue" / "failedReason" and "finishedOn"
+
+        if ARGV[5] == "failed" then
+            rcall("HDEL", jobIdKey, "lfr")
+        end
 
         -- Remove old jobs?
         if maxAge ~= nil then

--- a/src/commands/moveToFinished-14.lua
+++ b/src/commands/moveToFinished-14.lua
@@ -65,8 +65,6 @@ local rcall = redis.call
 --- @include "includes/getTargetQueueList"
 --- @include "includes/moveJobFromPriorityToActive"
 --- @include "includes/moveChildFromDependenciesIfNeeded"
---- @include "includes/moveParentToWait"
---- @include "includes/moveParentToWaitIfNeeded"
 --- @include "includes/prepareJobForProcessing"
 --- @include "includes/promoteDelayedJobs"
 --- @include "includes/removeDeduplicationKeyIfNeeded"

--- a/src/commands/moveToWaitingChildren-8.lua
+++ b/src/commands/moveToWaitingChildren-8.lua
@@ -37,8 +37,6 @@ local jobId = ARGV[4]
 
 --- Includes
 --- @include "includes/moveChildFromDependenciesIfNeeded"
---- @include "includes/moveParentToWait"
---- @include "includes/moveParentToWaitIfNeeded"
 --- @include "includes/removeDeduplicationKeyIfNeeded"
 --- @include "includes/removeJobsOnFail"
 --- @include "includes/removeLock"

--- a/src/interfaces/job-json.ts
+++ b/src/interfaces/job-json.ts
@@ -46,7 +46,7 @@ export interface JobJsonRaw {
   rjk?: string;
   nrjid?: string;
   atm?: string;
-  lfr?: string;
+  defa?: string;
   stc?: string;
   ats?: string;
   pb?: string; // Worker name

--- a/src/interfaces/job-json.ts
+++ b/src/interfaces/job-json.ts
@@ -46,6 +46,7 @@ export interface JobJsonRaw {
   rjk?: string;
   nrjid?: string;
   atm?: string;
+  lfr?: string;
   stc?: string;
   ats?: string;
   pb?: string; // Worker name

--- a/tests/test_clean.ts
+++ b/tests/test_clean.ts
@@ -543,6 +543,7 @@ describe('Cleaner', () => {
           expect(countAfterEmpty).to.be.eql(1);
 
           await flow.close();
+          await childrenQueue.close();
         });
       });
 

--- a/tests/test_concurrency.ts
+++ b/tests/test_concurrency.ts
@@ -210,6 +210,7 @@ describe('Concurrency', () => {
 
     await worker.close();
     await queue.close();
+    await queueEvents.close();
   }).timeout(6000);
 
   describe('when global dynamic limit is used', () => {

--- a/tests/test_connection.ts
+++ b/tests/test_connection.ts
@@ -117,21 +117,23 @@ describe('RedisConnection', () => {
   });
 
   describe('Worker', () => {
-    it('initializes blockingConnection with blocking: true', () => {
+    it('initializes blockingConnection with blocking: true', async () => {
       const worker = new Worker('test', async () => {}, { connection: {} });
       expect((<any>worker).blockingConnection.extraOptions.blocking).to.be.true;
+      await worker.close();
     });
 
-    it('sets shared: false for blockingConnection', () => {
+    it('sets shared: false for blockingConnection', async () => {
       const connection = new IORedis({ maxRetriesPerRequest: null });
 
       const worker = new Worker('test', async () => {}, { connection });
       expect((<any>worker).blockingConnection.extraOptions.shared).to.be.false;
 
+      await worker.close();
       connection.disconnect();
     });
 
-    it('uses blocking connection by default', () => {
+    it('uses blocking connection by default', async () => {
       const connection = new IORedis({ maxRetriesPerRequest: null });
 
       const worker = new Worker('test', async () => {}, { connection });
@@ -139,14 +141,16 @@ describe('RedisConnection', () => {
       expect((<any>worker).connection.extraOptions.blocking).to.be.false;
       expect((<any>worker).blockingConnection.extraOptions.blocking).to.be.true;
 
+      await worker.close();
       connection.disconnect();
     });
   });
 
   describe('FlowProducer', () => {
-    it('uses non-blocking connection', () => {
+    it('uses non-blocking connection', async () => {
       const flowProducer = new FlowProducer();
       expect((<any>flowProducer).connection.extraOptions.blocking).to.be.false;
+      await flowProducer.close();
     });
 
     it('shares connection if provided Redis instance', () => {

--- a/tests/test_events.ts
+++ b/tests/test_events.ts
@@ -650,6 +650,7 @@ describe('events', function () {
       );
 
       await waitingEvent;
+      await worker.close();
     });
 
     describe('when ttl is provided', function () {

--- a/tests/test_flow.ts
+++ b/tests/test_flow.ts
@@ -1165,6 +1165,7 @@ describe('flows', () => {
 
         await flow.close();
         await worker.close();
+        await queueEvents.close();
         await removeAllQueueData(new IORedis(redisHost), childrenQueueName);
       });
     });
@@ -1300,6 +1301,7 @@ describe('flows', () => {
         await worker.close();
         await grandchildrenWorker.close();
         await childrenWorker.close();
+        await queueEvents.close();
       });
     });
 
@@ -1413,6 +1415,7 @@ describe('flows', () => {
         await flow.close();
         await worker.close();
         await grandchildrenWorker.close();
+        await queueEvents.close();
       });
     });
   });
@@ -2729,6 +2732,7 @@ describe('flows', () => {
         await worker.close();
         await childrenWorker.close();
         await grandchildrenWorker.close();
+        await queueEvents.close();
         await removeAllQueueData(new IORedis(redisHost), childrenQueueName);
         await removeAllQueueData(
           new IORedis(redisHost),
@@ -2867,6 +2871,7 @@ describe('flows', () => {
         await worker.close();
         await childrenWorker.close();
         await grandchildrenWorker.close();
+        await queueEvents.close();
         await removeAllQueueData(new IORedis(redisHost), childrenQueueName);
         await removeAllQueueData(
           new IORedis(redisHost),
@@ -3636,7 +3641,7 @@ describe('flows', () => {
 
       const childrenWorker = new Worker(
         queueName,
-        async job => {
+        async () => {
           throw new Error('failed');
         },
         {
@@ -3666,6 +3671,7 @@ describe('flows', () => {
 
       await parentWorker.close();
       await childrenWorker.close();
+      await parentQueue.close();
       await flow.close();
       await removeAllQueueData(new IORedis(redisHost), parentQueueName);
     });
@@ -3756,6 +3762,7 @@ describe('flows', () => {
 
       await parentWorker.close();
       await childrenWorker.close();
+      await parentQueue.close();
       await flow.close();
       await removeAllQueueData(new IORedis(redisHost), parentQueueName);
     });
@@ -5110,6 +5117,7 @@ describe('flows', () => {
         await processing;
       } finally {
         await worker.close();
+        await flow.close();
         await removeAllQueueData(new IORedis(redisHost), parentQueueName);
       }
     });
@@ -5620,6 +5628,7 @@ describe('flows', () => {
         expect(await tree.job.getState()).to.be.equal('unknown');
 
         await flow.close();
+        await parentQueueEvents.close();
         await childrenWorker.close();
         await parentWorker.close();
         await parentQueue.close();

--- a/tests/test_job.ts
+++ b/tests/test_job.ts
@@ -1433,6 +1433,7 @@ describe('Job', function () {
         expect(isDelayedAfterPromote).to.be.equal(false);
         const isCompleted = await job.isCompleted();
         expect(isCompleted).to.be.equal(true);
+        await worker.close();
       });
 
       describe('when re-adding same repeatable job after previous delayed one is promoted', () => {
@@ -1493,6 +1494,7 @@ describe('Job', function () {
           const delayedCountAfterReAddition = await queue.getDelayedCount();
           expect(completedCountAfterReAddition).to.be.equal(1);
           expect(delayedCountAfterReAddition).to.be.equal(1);
+          await worker.close();
         });
       });
     });

--- a/tests/test_job_scheduler_stress.ts
+++ b/tests/test_job_scheduler_stress.ts
@@ -100,7 +100,6 @@ describe('Job Scheduler Stress', function () {
     });
 
     expect(completedJobs).to.be.eql(1);
-    await queue.close();
   });
 
   it('should start processing a job as soon as it is upserted when using every', async () => {

--- a/tests/test_queue.ts
+++ b/tests/test_queue.ts
@@ -245,6 +245,7 @@ describe('queues', function () {
             expect(countAfterEmpty).to.be.eql(1);
 
             await flow.close();
+            await childrenQueue.close();
           });
         });
       });

--- a/tests/test_rate_limiter.ts
+++ b/tests/test_rate_limiter.ts
@@ -302,6 +302,7 @@ describe('Rate Limiter', function () {
       await worker.close();
       await parentWorker.close();
       await parentQueueEvents.close();
+      await flow.close();
     });
   });
 

--- a/tests/test_stalled_jobs.ts
+++ b/tests/test_stalled_jobs.ts
@@ -413,14 +413,19 @@ describe('stalled jobs', function () {
             concurrency,
           },
         );
+        const parentWorker = new Worker(parentQueueName, async () => {}, {
+          connection,
+          prefix,
+        });
 
         const allActive = new Promise(resolve => {
           worker.on('active', after(concurrency, resolve));
         });
 
         await worker.waitUntilReady();
+        await parentWorker.waitUntilReady();
 
-        const { job: parent } = await flow.add({
+        const { children } = await flow.add({
           name: 'parent-job',
           queueName: parentQueueName,
           data: {},
@@ -456,9 +461,6 @@ describe('stalled jobs', function () {
           worker2.on(
             'failed',
             after(concurrency, async (job, failedReason, prev) => {
-              const parentState = await parent.getState();
-
-              expect(parentState).to.be.equal('failed');
               expect(prev).to.be.equal('active');
               expect(failedReason.message).to.be.equal(errorMessage);
               resolve();
@@ -466,9 +468,20 @@ describe('stalled jobs', function () {
           );
         });
 
+        const parentFailure = new Promise<void>(resolve => {
+          parentWorker.once('failed', async (job, failedReason, prev) => {
+            expect(prev).to.be.equal('active');
+            expect(failedReason.message).to.be.equal(
+              `child ${prefix}:${queueName}:${children[0].job.id!} failed`,
+            );
+            resolve();
+          });
+        });
         await allFailed;
+        await parentFailure;
 
         await worker2.close();
+        await parentWorker.close();
         await parentQueue.close();
         await flow.close();
         await removeAllQueueData(new IORedis(redisHost), parentQueueName);

--- a/tests/test_worker.ts
+++ b/tests/test_worker.ts
@@ -210,6 +210,7 @@ describe('workers', function () {
     expect(eventsLength).to.be.gte(maxEvents);
 
     await worker.close();
+    await trimmedEventsQueue.close();
   });
 
   it('process a job that updates progress as object', async () => {
@@ -1114,6 +1115,7 @@ describe('workers', function () {
 
       await worker.close();
       await queue1.close();
+      await connection.quit();
       await removeAllQueueData(new IORedis(redisHost), queueName2);
     });
   });

--- a/tests/test_worker.ts
+++ b/tests/test_worker.ts
@@ -2117,6 +2117,7 @@ describe('workers', function () {
     await workerError;
 
     await worker.close();
+    await connection.quit();
   });
 
   it('continues processing after a worker has stalled', async function () {


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? Instead of trying to move parent jobs recursively to failed status, a lazy failed process will be triggered. Failed parent jobs should instead be moved to be processed by the parent workers. In this way workers can also handle failed events from these jobs. This is not only more elegant and is a better design, but it is also a more scalable approach than our current implementation.
We introduce a new job internal attribute, which is called deferredFailure used to identify that a job must be moved to failed when it's eventually picked by a worker.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
1. How did you implement this? 
Move parent to wait when a child with failParentOnFailure true is triggered and set deferredFailure attribute with a special error message. When the worker picks this job, it will call detect the new attribute and call moveToFailed script with this deferredFailure as an UnrecoverableError. Something to take into account is that if the job is already in wait, prioritized, active or failed state, the job will not  be affected by this new logic. The job is moved only if it's in waiting-children or a delayed state (setting delay to 0 in this case to process this job as soon as possible)

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
ref https://github.com/taskforcesh/bullmq/issues/3215
