### PR TITLE
feat(job): implement moveToWaitingChildren for sandboxed jobs

### DIFF
--- a/src/classes/child-processor.ts
+++ b/src/classes/child-processor.ts
@@ -156,6 +156,15 @@ export class ChildProcessor {
         });
       },
       /*
+       * Proxy `moveToWaitingChildren` function.
+       */
+      moveToWaitingChildren: async (token?: string) => {
+        await send({
+          cmd: ParentCommand.MoveToWaitingChildren,
+          value: { token },
+        });
+      },
+      /*
        * Proxy `updateData` function.
        */
       updateData: async (data: any) => {

--- a/src/classes/sandbox.ts
+++ b/src/classes/sandbox.ts
@@ -52,6 +52,9 @@ const sandbox = <T, R, N extends string>(
                       msg.value?.token,
                     );
                     break;
+                  case ParentCommand.MoveToWaitingChildren:
+                    await job.moveToWaitingChildren(msg.value?.token);
+                    break;
                   case ParentCommand.Update:
                     await job.updateData(msg.value);
                     break;

--- a/src/enums/parent-command.ts
+++ b/src/enums/parent-command.ts
@@ -9,4 +9,5 @@ export enum ParentCommand {
   Progress,
   Update,
   GetChildrenValues,
+  MoveToWaitingChildren,
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
`moveToWaitingChildren` is not implemented on sandboxed jobs. The docs don't explain this and from what I could see there was no reason for it not to be other than that it just wasn't implemented there.

### How
I followed the same approach that the `moveToDelayed` function uses in a sandboxed job to send commands back to the parent process to actually execute the functionality.

### Additional Notes (Optional)
I did not see any tests for `moveToDelayed` that tested from within a sandboxed process so I wasn't sure if there was somewhere to add tests for this functionality.

I've done a `yarn pack` and then untarred it in a local bullmq project and confirmed that it was working though.

Fixes #3230 
