### PR TITLE
fix(deduplication): remove deduplication key only when jobId matches with the last one being saved

### DIFF
--- a/src/commands/includes/moveChildFromDependenciesIfNeeded.lua
+++ b/src/commands/includes/moveChildFromDependenciesIfNeeded.lua
@@ -6,7 +6,6 @@
 --- @include "moveParentToWaitIfNoPendingDependencies"
 --- @include "moveParentToWaitIfNeeded"
 --- @include "moveParentToWait"
---- @include "removeDeduplicationKeyIfNeeded"
 --- @include "removeJobsOnFail"
 
 local moveParentToFailedIfNeeded

--- a/src/commands/includes/removeDeduplicationKey.lua
+++ b/src/commands/includes/removeDeduplicationKey.lua
@@ -2,10 +2,13 @@
   Function to remove deduplication key.
 ]]
 
-local function removeDeduplicationKey(prefixKey, jobKey)
+local function removeDeduplicationKey(prefixKey, jobKey, jobId)
   local deduplicationId = rcall("HGET", jobKey, "deid")
   if deduplicationId then
     local deduplicationKey = prefixKey .. "de:" .. deduplicationId
-    rcall("DEL", deduplicationKey)
+    local currentJobId = rcall('GET', deduplicationKey)
+    if currentJobId and currentJobId == jobId then
+      return rcall("DEL", deduplicationKey)
+    end
   end
 end

--- a/src/commands/includes/removeDeduplicationKeyIfNeeded.lua
+++ b/src/commands/includes/removeDeduplicationKeyIfNeeded.lua
@@ -2,13 +2,20 @@
   Function to remove deduplication key if needed.
 ]]
 
-local function removeDeduplicationKeyIfNeeded(prefixKey, deduplicationId)
+local function removeDeduplicationKeyIfNeeded(prefixKey, deduplicationId, jobId)
   if deduplicationId then
     local deduplicationKey = prefixKey .. "de:" .. deduplicationId
     local pttl = rcall("PTTL", deduplicationKey)
 
-    if pttl == 0 or pttl == -1 then
-      rcall("DEL", deduplicationKey)
+    if pttl == 0 then
+      return rcall("DEL", deduplicationKey)
+    end
+
+    if pttl == -1 then
+      local currentJobId = rcall('GET', deduplicationKey)
+      if currentJobId and currentJobId == jobId then
+        return rcall("DEL", deduplicationKey)
+      end
     end
   end
 end

--- a/src/commands/includes/removeDeduplicationKeyIfNeededOnFinalization.lua
+++ b/src/commands/includes/removeDeduplicationKeyIfNeededOnFinalization.lua
@@ -1,8 +1,10 @@
 --[[
-  Function to remove deduplication key if needed.
+  Function to remove deduplication key if needed
+  when a job is moved to completed or failed states.
 ]]
 
-local function removeDeduplicationKeyIfNeeded(prefixKey, deduplicationId, jobId)
+local function removeDeduplicationKeyIfNeededOnFinalization(prefixKey,
+  deduplicationId, jobId)
   if deduplicationId then
     local deduplicationKey = prefixKey .. "de:" .. deduplicationId
     local pttl = rcall("PTTL", deduplicationKey)

--- a/src/commands/includes/removeDeduplicationKeyIfNeededOnRemoval.lua
+++ b/src/commands/includes/removeDeduplicationKeyIfNeededOnRemoval.lua
@@ -1,8 +1,10 @@
 --[[
-  Function to remove deduplication key.
+  Function to remove deduplication key if needed
+  when a job is being removed.
 ]]
 
-local function removeDeduplicationKey(prefixKey, jobKey, jobId)
+local function removeDeduplicationKeyIfNeededOnRemoval(prefixKey,
+  jobKey, jobId)
   local deduplicationId = rcall("HGET", jobKey, "deid")
   if deduplicationId then
     local deduplicationKey = prefixKey .. "de:" .. deduplicationId

--- a/src/commands/includes/removeJob.lua
+++ b/src/commands/includes/removeJob.lua
@@ -11,7 +11,7 @@ local function removeJob(jobId, hard, baseKey, shouldRemoveDeduplicationKey)
   local jobKey = baseKey .. jobId
   removeParentDependencyKey(jobKey, hard, nil, baseKey)
   if shouldRemoveDeduplicationKey then
-    removeDeduplicationKey(baseKey, jobKey)
+    removeDeduplicationKey(baseKey, jobKey, jobId)
   end
   removeJobKeys(jobKey)
 end

--- a/src/commands/includes/removeJob.lua
+++ b/src/commands/includes/removeJob.lua
@@ -3,7 +3,7 @@
 ]]
 
 -- Includes
---- @include "removeDeduplicationKey"
+--- @include "removeDeduplicationKeyIfNeededOnRemoval"
 --- @include "removeJobKeys"
 --- @include "removeParentDependencyKey"
 
@@ -11,7 +11,7 @@ local function removeJob(jobId, hard, baseKey, shouldRemoveDeduplicationKey)
   local jobKey = baseKey .. jobId
   removeParentDependencyKey(jobKey, hard, nil, baseKey)
   if shouldRemoveDeduplicationKey then
-    removeDeduplicationKey(baseKey, jobKey, jobId)
+    removeDeduplicationKeyIfNeededOnRemoval(baseKey, jobKey, jobId)
   end
   removeJobKeys(jobKey)
 end

--- a/src/commands/includes/removeJobWithChildren.lua
+++ b/src/commands/includes/removeJobWithChildren.lua
@@ -12,7 +12,7 @@ local rcall = redis.call
 --- @include "destructureJobKey"
 --- @include "getOrSetMaxEvents"
 --- @include "isJobSchedulerJob"
---- @include "removeDeduplicationKey"
+--- @include "removeDeduplicationKeyIfNeededOnRemoval"
 --- @include "removeJobFromAnyState"
 --- @include "removeJobKeys"
 --- @include "removeParentDependencyKey"
@@ -84,7 +84,7 @@ removeJobWithChildren = function(prefix, meta, jobId, parentKey, options)
         end
 
         local prev = removeJobFromAnyState(prefix, jobId)
-        removeDeduplicationKey(prefix, jobKey, jobId)
+        removeDeduplicationKeyIfNeededOnRemoval(prefix, jobKey, jobId)
         if removeJobKeys(jobKey) > 0 then
             local maxEvents = getOrSetMaxEvents(meta)
             rcall("XADD", prefix .. "events", "MAXLEN", "~", maxEvents, "*", "event", "removed",

--- a/src/commands/includes/removeJobWithChildren.lua
+++ b/src/commands/includes/removeJobWithChildren.lua
@@ -84,7 +84,7 @@ removeJobWithChildren = function(prefix, meta, jobId, parentKey, options)
         end
 
         local prev = removeJobFromAnyState(prefix, jobId)
-        removeDeduplicationKey(prefix, jobKey)
+        removeDeduplicationKey(prefix, jobKey, jobId)
         if removeJobKeys(jobKey) > 0 then
             local maxEvents = getOrSetMaxEvents(meta)
             rcall("XADD", prefix .. "events", "MAXLEN", "~", maxEvents, "*", "event", "removed",

--- a/src/commands/moveStalledJobsToWait-9.lua
+++ b/src/commands/moveStalledJobsToWait-9.lua
@@ -27,7 +27,7 @@ local rcall = redis.call
 --- @include "includes/batches"
 --- @include "includes/getTargetQueueList"
 --- @include "includes/moveChildFromDependenciesIfNeeded"
---- @include "includes/removeDeduplicationKeyIfNeeded"
+--- @include "includes/removeDeduplicationKeyIfNeededOnFinalization"
 --- @include "includes/removeJobsOnFail"
 --- @include "includes/trimEvents"
 
@@ -84,7 +84,7 @@ if (#stalling > 0) then
                         local rawParentData = jobAttributes[2]
                         local opts = cjson.decode(rawOpts)
                         rcall("ZADD", failedKey, timestamp, jobId)
-                        removeDeduplicationKeyIfNeeded(queueKeyPrefix, jobAttributes[3], jobId)
+                        removeDeduplicationKeyIfNeededOnFinalization(queueKeyPrefix, jobAttributes[3], jobId)
 
                         local failedReason = "job stalled more than allowable limit"
                         rcall("HMSET", jobKey, "failedReason", failedReason, "finishedOn", timestamp)

--- a/src/commands/moveStalledJobsToWait-9.lua
+++ b/src/commands/moveStalledJobsToWait-9.lua
@@ -84,7 +84,7 @@ if (#stalling > 0) then
                         local rawParentData = jobAttributes[2]
                         local opts = cjson.decode(rawOpts)
                         rcall("ZADD", failedKey, timestamp, jobId)
-                        removeDeduplicationKeyIfNeeded(queueKeyPrefix, jobAttributes[3])
+                        removeDeduplicationKeyIfNeeded(queueKeyPrefix, jobAttributes[3], jobId)
 
                         local failedReason = "job stalled more than allowable limit"
                         rcall("HMSET", jobKey, "failedReason", failedReason, "finishedOn", timestamp)

--- a/src/commands/moveToFinished-14.lua
+++ b/src/commands/moveToFinished-14.lua
@@ -130,7 +130,7 @@ if rcall("EXISTS", jobIdKey) == 1 then -- Make sure job exists
 
     local prefix = ARGV[7]
 
-    removeDeduplicationKeyIfNeeded(prefix, jobAttributes[3])
+    removeDeduplicationKeyIfNeeded(prefix, jobAttributes[3], jobId)
 
     -- If job has a parent we need to
     -- 1) remove this job id from parents dependencies

--- a/src/commands/moveToFinished-14.lua
+++ b/src/commands/moveToFinished-14.lua
@@ -67,7 +67,7 @@ local rcall = redis.call
 --- @include "includes/moveChildFromDependenciesIfNeeded"
 --- @include "includes/prepareJobForProcessing"
 --- @include "includes/promoteDelayedJobs"
---- @include "includes/removeDeduplicationKeyIfNeeded"
+--- @include "includes/removeDeduplicationKeyIfNeededOnFinalization"
 --- @include "includes/removeJobKeys"
 --- @include "includes/removeJobsByMaxAge"
 --- @include "includes/removeJobsByMaxCount"
@@ -130,7 +130,7 @@ if rcall("EXISTS", jobIdKey) == 1 then -- Make sure job exists
 
     local prefix = ARGV[7]
 
-    removeDeduplicationKeyIfNeeded(prefix, jobAttributes[3], jobId)
+    removeDeduplicationKeyIfNeededOnFinalization(prefix, jobAttributes[3], jobId)
 
     -- If job has a parent we need to
     -- 1) remove this job id from parents dependencies

--- a/src/commands/moveToWaitingChildren-8.lua
+++ b/src/commands/moveToWaitingChildren-8.lua
@@ -37,7 +37,7 @@ local jobId = ARGV[4]
 
 --- Includes
 --- @include "includes/moveChildFromDependenciesIfNeeded"
---- @include "includes/removeDeduplicationKeyIfNeeded"
+--- @include "includes/removeDeduplicationKeyIfNeededOnFinalization"
 --- @include "includes/removeJobsOnFail"
 --- @include "includes/removeLock"
 
@@ -61,7 +61,7 @@ if rcall("EXISTS", jobKey) == 1 then
     -- TODO: refactor this logic in an include later
     local jobAttributes = rcall("HMGET", jobKey, "parent", "deid", "opts")
 
-    removeDeduplicationKeyIfNeeded(ARGV[5], jobAttributes[2], jobId)
+    removeDeduplicationKeyIfNeededOnFinalization(ARGV[5], jobAttributes[2], jobId)
   
     local failedReason = "children are failed"
     rcall("ZADD", failedKey, timestamp, jobId)

--- a/src/commands/moveToWaitingChildren-8.lua
+++ b/src/commands/moveToWaitingChildren-8.lua
@@ -61,7 +61,7 @@ if rcall("EXISTS", jobKey) == 1 then
     -- TODO: refactor this logic in an include later
     local jobAttributes = rcall("HMGET", jobKey, "parent", "deid", "opts")
 
-    removeDeduplicationKeyIfNeeded(ARGV[5], jobAttributes[2])
+    removeDeduplicationKeyIfNeeded(ARGV[5], jobAttributes[2], jobId)
   
     local failedReason = "children are failed"
     rcall("ZADD", failedKey, timestamp, jobId)

--- a/tests/test_events.ts
+++ b/tests/test_events.ts
@@ -511,6 +511,70 @@ describe('events', function () {
 
           expect(debouncedCounter).to.be.equal(2);
         });
+
+        describe('when manual removal on a deduplicated job in finished state', function () {
+          it('does not remove deduplication key', async function () {
+            const testName = 'test';
+
+            const job = await queue.add(
+              testName,
+              { foo: 'bar' },
+              { deduplication: { id: 'a1', ttl: 200 } },
+            );
+
+            const worker = new Worker(
+              queueName,
+              async () => {
+                await delay(200);
+              },
+              {
+                autorun: false,
+                connection,
+                prefix,
+              },
+            );
+
+            await worker.waitUntilReady();
+
+            const completion = new Promise<void>(resolve => {
+              worker.once('completed', () => {
+                resolve();
+              });
+            });
+
+            worker.run();
+
+            await completion;
+
+            let deduplicatedCounter = 0;
+            const deduplication = new Promise<void>(resolve => {
+              queueEvents.on('deduplicated', () => {
+                deduplicatedCounter++;
+                if (deduplicatedCounter == 1) {
+                  resolve();
+                }
+              });
+            });
+
+            await queue.add(
+              testName,
+              { foo: 'bar' },
+              { deduplication: { id: 'a1', ttl: 200 } },
+            );
+
+            await job.remove();
+
+            await queue.add(
+              testName,
+              { foo: 'bar' },
+              { deduplication: { id: 'a1', ttl: 200 } },
+            );
+
+            await deduplication;
+
+            expect(deduplicatedCounter).to.be.equal(1);
+          });
+        });
       });
     });
 
@@ -867,6 +931,70 @@ describe('events', function () {
           await deduplication;
 
           expect(deduplicatedCounter).to.be.equal(2);
+        });
+
+        describe('when manual removal on a deduplicated job in finished state', function () {
+          it('does not remove deduplication key', async function () {
+            const testName = 'test';
+
+            const job = await queue.add(
+              testName,
+              { foo: 'bar' },
+              { deduplication: { id: 'a1' } },
+            );
+
+            const worker = new Worker(
+              queueName,
+              async () => {
+                await delay(100);
+              },
+              {
+                autorun: false,
+                connection,
+                prefix,
+              },
+            );
+
+            await worker.waitUntilReady();
+
+            const completion = new Promise<void>(resolve => {
+              worker.once('completed', () => {
+                resolve();
+              });
+            });
+
+            worker.run();
+
+            await completion;
+
+            let deduplicatedCounter = 0;
+            const deduplication = new Promise<void>(resolve => {
+              queueEvents.on('deduplicated', () => {
+                deduplicatedCounter++;
+                if (deduplicatedCounter == 1) {
+                  resolve();
+                }
+              });
+            });
+
+            await queue.add(
+              testName,
+              { foo: 'bar' },
+              { deduplication: { id: 'a1' } },
+            );
+
+            await job.remove();
+
+            await queue.add(
+              testName,
+              { foo: 'bar' },
+              { deduplication: { id: 'a1' } },
+            );
+
+            await deduplication;
+
+            expect(deduplicatedCounter).to.be.equal(1);
+          });
         });
       });
     });


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? When manual removal is used, job can remove deduplication key even if there is a new job with the same deduplication id already

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Validate that jobId being saved matches with the one that is being deleted

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
ref https://github.com/taskforcesh/bullmq/issues/3232
