### PR TITLE
feat(flow): support ignored children in getFlow and getDependencies methods

### DIFF
--- a/docs/gitbook/guide/flows/README.md
+++ b/docs/gitbook/guide/flows/README.md
@@ -206,6 +206,32 @@ const dependencies = await job.getDependencies();
 
 it will return all the **direct** **dependencies** (i.e. the children of a given job).
 
+Or if you want to get specific types of children:
+
+```typescript
+// cursors are used in pagination
+const { processed, nextProcessedCursor } = await job.getDependencies({
+  processed: {
+    count: 5,
+    cursor: 0,
+  },
+});
+
+const { unprocessed, nextUnprocessedCursor } = await job.getDependencies({
+  unprocessed: {
+    count: 5,
+    cursor: 0,
+  },
+});
+
+const { ignored, nextIgnoredCursor } = await job.getDependencies({
+  ignored: {
+    count: 5,
+    cursor: 0,
+  },
+});
+```
+
 The `Job` class also provides another method that we presented above to get all the values produced by the children of a given job:
 
 ```typescript
@@ -283,3 +309,4 @@ await queue.remove(job.id);
 - 📋 [Divide large jobs using flows](https://blog.taskforce.sh/splitting-heavy-jobs-using-bullmq-flows/)
 - 💡 [FlowProducer API Reference](https://api.docs.bullmq.io/classes/v5.FlowProducer.html)
 - 💡 [Job API Reference](https://api.docs.bullmq.io/classes/v5.Job.html)
+- 💡 [Get Dependencies API Reference](https://api.docs.bullmq.io/classes/v5.Job.html#getDependencies)

--- a/src/classes/flow-producer.ts
+++ b/src/classes/flow-producer.ts
@@ -462,22 +462,31 @@ export class FlowProducer extends EventEmitter {
     const job = await this.Job.fromId(queue, node.id);
 
     if (job) {
-      const { processed = {}, unprocessed = [] } = await job.getDependencies({
+      const {
+        processed = {},
+        unprocessed = [],
+        ignored = {},
+      } = await job.getDependencies({
         processed: {
           count: node.maxChildren,
         },
         unprocessed: {
           count: node.maxChildren,
         },
+        ignored: {
+          count: node.maxChildren,
+        },
       });
       const processedKeys = Object.keys(processed);
+      const ignoredKeys = Object.keys(ignored);
 
-      const childrenCount = processedKeys.length + unprocessed.length;
+      const childrenCount =
+        processedKeys.length + unprocessed.length + ignoredKeys.length;
       const newDepth = node.depth - 1;
       if (childrenCount > 0 && newDepth) {
         const children = await this.getChildren(
           client,
-          [...processedKeys, ...unprocessed],
+          [...processedKeys, ...unprocessed, ...ignoredKeys],
           newDepth,
           node.maxChildren,
         );

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -1008,8 +1008,9 @@ export class Job<
    * on processed/unprocessed dependencies, since v7.2 you must consider that count
    * won't have any effect until processed/unprocessed dependencies have a length
    * greater than 127
-   * @see https://redis.io/docs/management/optimization/memory-optimization/#redis--72
-   * @returns dependencies separated by processed and unprocessed.
+   * @see {@link https://redis.io/docs/management/optimization/memory-optimization/#redis--72}
+   * @see {@link https://docs.bullmq.io/guide/flows#getters}
+   * @returns dependencies separated by processed, unprocessed and ignored.
    */
   async getDependencies(opts: DependenciesOpts = {}): Promise<{
     nextIgnoredCursor?: number;

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -1012,6 +1012,8 @@ export class Job<
    * @returns dependencies separated by processed and unprocessed.
    */
   async getDependencies(opts: DependenciesOpts = {}): Promise<{
+    nextIgnoredCursor?: number;
+    ignored?: Record<string, any>;
     nextProcessedCursor?: number;
     processed?: Record<string, any>;
     nextUnprocessedCursor?: number;
@@ -1019,25 +1021,32 @@ export class Job<
   }> {
     const client = await this.queue.client;
     const multi = client.multi();
-    if (!opts.processed && !opts.unprocessed) {
+    if (!opts.processed && !opts.unprocessed && !opts.ignored) {
       multi.hgetall(this.toKey(`${this.id}:processed`));
       multi.smembers(this.toKey(`${this.id}:dependencies`));
+      multi.hgetall(this.toKey(`${this.id}:failed`));
 
-      const [[err1, processed], [err2, unprocessed]] = (await multi.exec()) as [
-        [null | Error, { [jobKey: string]: string }],
-        [null | Error, string[]],
-      ];
+      const [[err1, processed], [err2, unprocessed], [err3, ignored]] =
+        (await multi.exec()) as [
+          [null | Error, { [jobKey: string]: string }],
+          [null | Error, string[]],
+          [null | Error, { [jobKey: string]: string }],
+        ];
 
-      const transformedProcessed = parseObjectValues(processed);
-
-      return { processed: transformedProcessed, unprocessed };
+      return {
+        processed: parseObjectValues(processed),
+        unprocessed,
+        ignored: parseObjectValues(ignored),
+      };
     } else {
       const defaultOpts = {
         cursor: 0,
         count: 20,
       };
 
+      const childrenResultOrder = [];
       if (opts.processed) {
+        childrenResultOrder.push('processed');
         const processedOpts = Object.assign({ ...defaultOpts }, opts.processed);
         multi.hscan(
           this.toKey(`${this.id}:processed`),
@@ -1048,6 +1057,7 @@ export class Job<
       }
 
       if (opts.unprocessed) {
+        childrenResultOrder.push('unprocessed');
         const unprocessedOpts = Object.assign(
           { ...defaultOpts },
           opts.unprocessed,
@@ -1060,35 +1070,78 @@ export class Job<
         );
       }
 
-      const [result1, result2] = (await multi.exec()) as [
+      if (opts.ignored) {
+        childrenResultOrder.push('ignored');
+        const ignoredOpts = Object.assign({ ...defaultOpts }, opts.ignored);
+        multi.hscan(
+          this.toKey(`${this.id}:failed`),
+          ignoredOpts.cursor,
+          'COUNT',
+          ignoredOpts.count,
+        );
+      }
+
+      const results = (await multi.exec()) as [
         Error,
         [number[], string[] | undefined],
       ][];
 
-      const [processedCursor, processed = []] = opts.processed
-        ? result1[1]
-        : [];
-      const [unprocessedCursor, unprocessed = []] = opts.unprocessed
-        ? opts.processed
-          ? result2[1]
-          : result1[1]
-        : [];
+      let processedCursor,
+        processed,
+        unprocessedCursor,
+        unprocessed,
+        ignoredCursor,
+        ignored;
+      childrenResultOrder.forEach((key, index) => {
+        switch (key) {
+          case 'processed': {
+            processedCursor = results[index][1][0];
+            const rawProcessed = results[index][1][1];
+            const transformedProcessed: Record<string, any> = {};
 
-      const transformedProcessed: Record<string, any> = {};
+            for (let ind = 0; ind < rawProcessed.length; ++ind) {
+              if (ind % 2) {
+                transformedProcessed[rawProcessed[ind - 1]] = JSON.parse(
+                  rawProcessed[ind],
+                );
+              }
+            }
+            processed = transformedProcessed;
+            break;
+          }
+          case 'ignored': {
+            ignoredCursor = results[index][1][0];
 
-      for (let index = 0; index < processed.length; ++index) {
-        if (index % 2) {
-          transformedProcessed[processed[index - 1]] = JSON.parse(
-            processed[index],
-          );
+            const rawIgnored = results[index][1][1];
+            const transformedIgnored: Record<string, any> = {};
+
+            for (let ind = 0; ind < rawIgnored.length; ++ind) {
+              if (ind % 2) {
+                transformedIgnored[rawIgnored[ind - 1]] = rawIgnored[ind];
+              }
+            }
+            ignored = transformedIgnored;
+            break;
+          }
+          case 'unprocessed': {
+            unprocessedCursor = results[index][1][0];
+            unprocessed = results[index][1][1];
+            break;
+          }
         }
-      }
+      });
 
       return {
         ...(processedCursor
           ? {
-              processed: transformedProcessed,
+              processed,
               nextProcessedCursor: Number(processedCursor),
+            }
+          : {}),
+        ...(ignoredCursor
+          ? {
+              ignored,
+              nextIgnoredCursor: Number(ignoredCursor),
             }
           : {}),
         ...(unprocessedCursor

--- a/src/interfaces/minimal-job.ts
+++ b/src/interfaces/minimal-job.ts
@@ -21,6 +21,10 @@ export interface MoveToWaitingChildrenOpts {
 }
 
 export interface DependenciesOpts {
+  ignored?: {
+    cursor?: number;
+    count?: number;
+  };
   processed?: {
     cursor?: number;
     count?: number;

--- a/src/interfaces/minimal-job.ts
+++ b/src/interfaces/minimal-job.ts
@@ -20,19 +20,30 @@ export interface MoveToWaitingChildrenOpts {
   };
 }
 
+export interface DependencyOpts {
+  /**
+   * Cursor value to be passed for pagination
+   */
+  cursor?: number;
+  /**
+   * Max quantity of jobs to be retrieved
+   */
+  count?: number;
+}
+
 export interface DependenciesOpts {
-  ignored?: {
-    cursor?: number;
-    count?: number;
-  };
-  processed?: {
-    cursor?: number;
-    count?: number;
-  };
-  unprocessed?: {
-    cursor?: number;
-    count?: number;
-  };
+  /**
+   * Options for ignored child pagination
+   */
+  ignored?: DependencyOpts;
+  /**
+   * Options for processed child pagination
+   */
+  processed?: DependencyOpts;
+  /**
+   * Options for unprocessed child pagination
+   */
+  unprocessed?: DependencyOpts;
 }
 
 /**


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
1. Why is this change necessary? getFlorw and getDependencies methods are missing to retrieve ignored children jobs
  
### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Add extra logic on these methods to retrieve data from jobKey:failed

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
ref https://github.com/taskforcesh/bullmq/issues/3213
