### PR TITLE
feat(job): add moveToCompleted method [python]

### DIFF
--- a/python/bullmq/job.py
+++ b/python/bullmq/job.py
@@ -137,7 +137,7 @@ class Job:
 
     async def moveToCompleted(self, return_value, token:str, fetchNext:bool = False):
         stringified_return_value = json.dumps(return_value, separators=(',', ':'), allow_nan=False)
-        self.returnvalue = returnValue or None
+        self.returnvalue = return_value or None
         result = await self.scripts.moveToCompleted(
                     self, stringified_return_value, self.opts.get("removeOnComplete", False), token,
                     fetchNext)

--- a/python/bullmq/job.py
+++ b/python/bullmq/job.py
@@ -138,10 +138,17 @@ class Job:
     async def moveToCompleted(self, return_value, token:str, fetchNext:bool = False):
         stringified_return_value = json.dumps(return_value, separators=(',', ':'), allow_nan=False)
         self.returnvalue = return_value or None
-        result = await self.scripts.moveToCompleted(
-                    self, stringified_return_value, self.opts.get("removeOnComplete", False), token,
-                    fetchNext)
+
+        keys, args = self.scripts.moveToCompletedArgs(
+                    self, stringified_return_value, self.opts.get("removeOnFail", False),
+                    token, fetchNext
+                )
+
+        result = await self.scripts.moveToFinished(
+                    self.id, keys, args)
+        self.finishedOn = args[1]
         self.attemptsMade = self.attemptsMade + 1
+
         return result
 
     async def moveToFailed(self, err, token:str, fetchNext:bool = False):

--- a/python/bullmq/job.py
+++ b/python/bullmq/job.py
@@ -135,6 +135,14 @@ class Job:
     def isInList(self, list_name: str):
         return self.scripts.isJobInList(self.scripts.toKey(list_name), self.id)
 
+    async def moveToCompleted(self, return_value, token:str, fetchNext:bool = False):
+        stringified_return_value = json.dumps(return_value, separators=(',', ':'), allow_nan=False)
+        result = await self.scripts.moveToCompleted(
+                    self, stringified_return_value, self.opts.get("removeOnComplete", False), token,
+                    fetchNext)
+
+        return result
+
     async def moveToFailed(self, err, token:str, fetchNext:bool = False):
         error_message = str(err)
         self.failedReason = error_message
@@ -174,7 +182,7 @@ class Job:
             if move_to_failed:
                 keys, args = self.scripts.moveToFailedArgs(
                     self, error_message, self.opts.get("removeOnFail", False),
-                    token, self.opts, fetchNext
+                    token, fetchNext
                 )
                 await self.scripts.commands["moveToFinished"](keys=keys, args=args, client=pipe)
                 finished_on = args[1]

--- a/python/bullmq/job.py
+++ b/python/bullmq/job.py
@@ -137,10 +137,11 @@ class Job:
 
     async def moveToCompleted(self, return_value, token:str, fetchNext:bool = False):
         stringified_return_value = json.dumps(return_value, separators=(',', ':'), allow_nan=False)
+        self.returnvalue = returnValue or None
         result = await self.scripts.moveToCompleted(
                     self, stringified_return_value, self.opts.get("removeOnComplete", False), token,
                     fetchNext)
-
+        self.attemptsMade = self.attemptsMade + 1
         return result
 
     async def moveToFailed(self, err, token:str, fetchNext:bool = False):

--- a/python/bullmq/scripts.py
+++ b/python/bullmq/scripts.py
@@ -483,11 +483,11 @@ class Scripts:
 
         return raw2NextJobData(result)
 
-    def moveToCompleted(self, job: Job, val: Any, removeOnComplete, token: str, opts: dict, fetchNext=True):
-        return self.moveToFinished(job, val, "returnvalue", removeOnComplete, "completed", token, opts, fetchNext)
+    def moveToCompleted(self, job: Job, val: Any, removeOnComplete, token: str, fetchNext=True):
+        return self.moveToFinished(job, val, "returnvalue", removeOnComplete, "completed", token, fetchNext)
 
     def moveToFailed(self, job: Job, failedReason: str, removeOnFailed, token: str, opts: dict, fetchNext=True):
-        return self.moveToFinished(job, failedReason, "failedReason", removeOnFailed, "failed", token, opts, fetchNext)
+        return self.moveToFinished(job, failedReason, "failedReason", removeOnFailed, "failed", token, fetchNext)
 
     async def updateProgress(self, job_id: str, progress):
         keys = [self.toKey(job_id), self.keys['events'], self.keys['meta']]
@@ -501,7 +501,7 @@ class Scripts:
         return None
 
     def moveToFinishedArgs(self, job: Job, val: Any, propVal: str, shouldRemove, target, token: str,
-                           opts: dict, fetchNext=True) -> list[Any] | None:
+        fetchNext=True) -> list[Any] | None:
         transformed_value = json.dumps(val, separators=(',', ':'), allow_nan=False)
         timestamp = round(time.time() * 1000)
         metricsKey = self.toKey('metrics:' + target)
@@ -540,7 +540,7 @@ class Scripts:
             "lockDuration": opts.get("lockDuration"),
             "attempts": job.attempts,
             "attemptsMade": job.attemptsMade,
-            "maxMetricsSize": getMetricsSize(opts),
+            "maxMetricsSize": getMetricsSize(job.queue.opts),
             "fpof": opts.get("failParentOnFailure", False),
             "cpof": opts.get("continueParentOnFailure", False),
             "idof": opts.get("ignoreDependencyOnFailure", False)
@@ -550,14 +550,14 @@ class Scripts:
                 fetchNext and "1" or "", self.keys[''], packedOpts]
         return (keys, args)
 
-    def moveToFailedArgs(self, job: Job, failed_reason: str, shouldRemove, token: str, opts: dict, fetchNext=True):
+    def moveToFailedArgs(self, job: Job, failed_reason: str, shouldRemove, token: str, fetchNext=True):
         return self.moveToFinishedArgs(
             job, failed_reason, 'failedReason', shouldRemove, 'failed',
-            token, opts, fetchNext
+            token, fetchNext
         )
 
     async def moveToFinished(self, job: Job, val: Any, propVal: str, shouldRemove, target, token: str, opts: dict, fetchNext=True) -> list[Any] | None:
-        keys, args = self.moveToFinishedArgs(job, val, propVal, shouldRemove, target, token, opts, fetchNext)
+        keys, args = self.moveToFinishedArgs(job, val, propVal, shouldRemove, target, token, fetchNext)
 
         result = await self.commands["moveToFinished"](keys=keys, args=args)
 

--- a/python/bullmq/scripts.py
+++ b/python/bullmq/scripts.py
@@ -486,7 +486,7 @@ class Scripts:
     def moveToCompleted(self, job: Job, val: Any, removeOnComplete, token: str, fetchNext=True):
         return self.moveToFinished(job, val, "returnvalue", removeOnComplete, "completed", token, fetchNext)
 
-    def moveToFailed(self, job: Job, failedReason: str, removeOnFailed, token: str, opts: dict, fetchNext=True):
+    def moveToFailed(self, job: Job, failedReason: str, removeOnFailed, token: str, fetchNext=True):
         return self.moveToFinished(job, failedReason, "failedReason", removeOnFailed, "failed", token, fetchNext)
 
     async def updateProgress(self, job_id: str, progress):
@@ -552,10 +552,8 @@ class Scripts:
         return (keys, args)
 
     def moveToFailedArgs(self, job: Job, failed_reason: str, shouldRemove, token: str, fetchNext=True):
-        return self.moveToFinishedArgs(
-            job, failed_reason, 'failedReason', shouldRemove, 'failed',
-            token, fetchNext
-        )
+        return self.moveToFinishedArgs(job, failed_reason, 'failedReason', shouldRemove, 'failed',
+            token, fetchNext)
 
     async def moveToFinished(self, job: Job, val: Any, propVal: str, shouldRemove, target, token: str, fetchNext=True) -> list[Any] | None:
         keys, args = self.moveToFinishedArgs(job, val, propVal, shouldRemove, target, token, fetchNext)

--- a/python/bullmq/scripts.py
+++ b/python/bullmq/scripts.py
@@ -559,7 +559,7 @@ class Scripts:
         return self.moveToFinished(job.id, keys, args)
 
     def moveToFailed(self, job: Job, failedReason: str, removeOnFailed, token: str, fetchNext=True):
-        keys, args = self.moveToCompletedArgs(job, failedReason, removeOnFailed, token, fetchNext)
+        keys, args = self.moveToFailedArgs(job, failedReason, removeOnFailed, token, fetchNext)
 
         return self.moveToFinished(job.id, keys, args)
 

--- a/python/bullmq/scripts.py
+++ b/python/bullmq/scripts.py
@@ -533,6 +533,7 @@ class Scripts:
 
         keepJobs = getKeepJobs(shouldRemove)
 
+        opts = job.queue.opts
         packedOpts = msgpack.packb({
             "token": token,
             "keepJobs": keepJobs,
@@ -540,7 +541,7 @@ class Scripts:
             "lockDuration": opts.get("lockDuration"),
             "attempts": job.attempts,
             "attemptsMade": job.attemptsMade,
-            "maxMetricsSize": getMetricsSize(job.queue.opts),
+            "maxMetricsSize": getMetricsSize(opts),
             "fpof": opts.get("failParentOnFailure", False),
             "cpof": opts.get("continueParentOnFailure", False),
             "idof": opts.get("ignoreDependencyOnFailure", False)
@@ -556,7 +557,7 @@ class Scripts:
             token, fetchNext
         )
 
-    async def moveToFinished(self, job: Job, val: Any, propVal: str, shouldRemove, target, token: str, opts: dict, fetchNext=True) -> list[Any] | None:
+    async def moveToFinished(self, job: Job, val: Any, propVal: str, shouldRemove, target, token: str, fetchNext=True) -> list[Any] | None:
         keys, args = self.moveToFinishedArgs(job, val, propVal, shouldRemove, target, token, fetchNext)
 
         result = await self.commands["moveToFinished"](keys=keys, args=args)

--- a/python/bullmq/scripts.py
+++ b/python/bullmq/scripts.py
@@ -483,12 +483,6 @@ class Scripts:
 
         return raw2NextJobData(result)
 
-    def moveToCompleted(self, job: Job, val: Any, removeOnComplete, token: str, fetchNext=True):
-        return self.moveToFinished(job, val, "returnvalue", removeOnComplete, "completed", token, fetchNext)
-
-    def moveToFailed(self, job: Job, failedReason: str, removeOnFailed, token: str, fetchNext=True):
-        return self.moveToFinished(job, failedReason, "failedReason", removeOnFailed, "failed", token, fetchNext)
-
     async def updateProgress(self, job_id: str, progress):
         keys = [self.toKey(job_id), self.keys['events'], self.keys['meta']]
         progress_json = json.dumps(progress, separators=(',', ':'), allow_nan=False)
@@ -551,18 +545,30 @@ class Scripts:
                 fetchNext and "1" or "", self.keys[''], packedOpts]
         return (keys, args)
 
+    def moveToCompletedArgs(self, job: Job, return_value: str, shouldRemove, token: str, fetchNext=True):
+        return self.moveToFinishedArgs(job, return_value, 'returnvalue', shouldRemove, 'completed',
+            token, fetchNext)
+
     def moveToFailedArgs(self, job: Job, failed_reason: str, shouldRemove, token: str, fetchNext=True):
         return self.moveToFinishedArgs(job, failed_reason, 'failedReason', shouldRemove, 'failed',
             token, fetchNext)
 
-    async def moveToFinished(self, job: Job, val: Any, propVal: str, shouldRemove, target, token: str, fetchNext=True) -> list[Any] | None:
-        keys, args = self.moveToFinishedArgs(job, val, propVal, shouldRemove, target, token, fetchNext)
+    def moveToCompleted(self, job: Job, val: Any, removeOnComplete, token: str, fetchNext=True):
+        keys, args = self.moveToCompletedArgs(job, val, removeOnComplete, token, fetchNext)
 
+        return self.moveToFinished(job.id, keys, args)
+
+    def moveToFailed(self, job: Job, failedReason: str, removeOnFailed, token: str, fetchNext=True):
+        keys, args = self.moveToCompletedArgs(job, failedReason, removeOnFailed, token, fetchNext)
+
+        return self.moveToFinished(job.id, keys, args)
+
+    async def moveToFinished(self, id: str, keys, args) -> list[Any] | None:
         result = await self.commands["moveToFinished"](keys=keys, args=args)
 
         if result is not None:
             if type(result) == int and result < 0:
-                raise self.finishedErrors(result, job.id, 'finished', 'active')
+                raise self.finishedErrors(result, id, 'moveToFinished', 'active')
             return raw2NextJobData(result)
         return None
 

--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -55,8 +55,9 @@ class Worker(EventEmitter):
         self.drained = False
         self.qualifiedName = self.scripts.queue_keys.getQueueQualifiedName(name)
 
-        if opts.get("autorun", True):
-            asyncio.ensure_future(self.run())
+        if processor:
+            if opts.get("autorun", True):
+                asyncio.ensure_future(self.run())
 
     async def run(self):
         if self.running:

--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -197,8 +197,8 @@ class Worker(EventEmitter):
             result = await self.processor(job, token)
             if not self.forceClosing:
                 # Currently we do not support pre-fetching jobs as in NodeJS version.
-                # nextJob = await self.scripts.moveToCompleted(job, result, job.opts.get("removeOnComplete", False), token, self.opts, fetchNext=not self.closing)
-                await self.scripts.moveToCompleted(job, result, job.opts.get("removeOnComplete", False), token, self.opts, fetchNext=False)
+                # nextJob = await self.scripts.moveToCompleted(job, result, job.opts.get("removeOnComplete", False), token, fetchNext=not self.closing)
+                await self.scripts.moveToCompleted(job, result, job.opts.get("removeOnComplete", False), token, fetchNext=False)
                 job.returnvalue = result
                 job.attemptsMade = job.attemptsMade + 1
             self.emit("completed", job, result)

--- a/tests/test_worker.ts
+++ b/tests/test_worker.ts
@@ -4166,7 +4166,7 @@ describe('workers', function () {
 
       expect(isCompleted).to.be.equal(true);
       expect(job.attemptsMade).to.be.equal(1);
-      expect(job.finishedOn).to.be.fulfilled;
+      expect(job.finishedOn).to.be.a('number');
 
       await worker.close();
     });

--- a/tests/test_worker.ts
+++ b/tests/test_worker.ts
@@ -4167,7 +4167,7 @@ describe('workers', function () {
       expect(isCompleted).to.be.equal(true);
       expect(job.attemptsMade).to.be.equal(1);
       expect(job.finishedOn).to.be.a('number');
-      expect(job.returnvalue).to.be.a('return value');
+      expect(job.returnvalue).to.be.equal('return value');
 
       await worker.close();
     });
@@ -4520,7 +4520,7 @@ describe('workers', function () {
       expect(isFailed).to.be.equal(true);
       expect(job.attemptsMade).to.be.equal(1);
       expect(job.finishedOn).to.be.a('number');
-      expect(job.failedReason).to.be.a('job failed for some reason');
+      expect(job.failedReason).to.be.equal('job failed for some reason');
 
       await worker.close();
     });

--- a/tests/test_worker.ts
+++ b/tests/test_worker.ts
@@ -4167,6 +4167,7 @@ describe('workers', function () {
       expect(isCompleted).to.be.equal(true);
       expect(job.attemptsMade).to.be.equal(1);
       expect(job.finishedOn).to.be.a('number');
+      expect(job.returnvalue).to.be.a('return value');
 
       await worker.close();
     });
@@ -4517,6 +4518,9 @@ describe('workers', function () {
 
       expect(isCompleted).to.be.equal(false);
       expect(isFailed).to.be.equal(true);
+      expect(job.attemptsMade).to.be.equal(1);
+      expect(job.finishedOn).to.be.a('number');
+      expect(job.failedReason).to.be.a('job failed for some reason');
 
       await worker.close();
     });

--- a/tests/test_worker.ts
+++ b/tests/test_worker.ts
@@ -4165,6 +4165,8 @@ describe('workers', function () {
       const isCompleted = await job.isCompleted();
 
       expect(isCompleted).to.be.equal(true);
+      expect(job.attemptsMade).to.be.equal(1);
+      expect(job.finishedOn).to.be.fulfilled;
 
       await worker.close();
     });


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? In order to provide a way to do manual processing. moveToComplete method is not exposed in job instance

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Add moveToCompleted method in job instance and allow manual processing

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
