### PR TITLE
feat(job): Add `getIgnoredChildrenFailures` to the wrapper of sandboxed jobs

### DIFF
--- a/src/classes/child-processor.ts
+++ b/src/classes/child-processor.ts
@@ -183,6 +183,24 @@ export class ChildProcessor {
           'getChildrenValues',
         );
       },
+
+      /**
+       * Proxy `getIgnoredChildrenFailures` function.
+       */
+      getIgnoredChildrenFailures: async () => {
+        const requestId = Math.random().toString(36).substring(2, 15);
+        await send({
+          requestId,
+          cmd: ParentCommand.GetIgnoredChildrenFailures,
+        });
+
+        return waitResponse(
+          requestId,
+          this.receiver,
+          RESPONSE_TIMEOUT,
+          'getIgnoredChildrenFailures',
+        );
+      },
     };
 
     return wrappedJob;

--- a/src/classes/child-processor.ts
+++ b/src/classes/child-processor.ts
@@ -186,6 +186,12 @@ export class ChildProcessor {
 
       /**
        * Proxy `getIgnoredChildrenFailures` function.
+       * 
+       * This method sends a request to retrieve the failures of ignored children
+       * and waits for a response from the parent process.
+       * 
+       * @returns {Promise<any>} A promise that resolves with the ignored children failures.
+       * The exact structure of the returned data depends on the parent process implementation.
        */
       getIgnoredChildrenFailures: async () => {
         const requestId = Math.random().toString(36).substring(2, 15);

--- a/src/classes/child-processor.ts
+++ b/src/classes/child-processor.ts
@@ -190,7 +190,7 @@ export class ChildProcessor {
        * This method sends a request to retrieve the failures of ignored children
        * and waits for a response from the parent process.
        * 
-       * @returns {Promise<any>} A promise that resolves with the ignored children failures.
+       * @returns - A promise that resolves with the ignored children failures.
        * The exact structure of the returned data depends on the parent process implementation.
        */
       getIgnoredChildrenFailures: async () => {

--- a/src/classes/sandbox.ts
+++ b/src/classes/sandbox.ts
@@ -65,6 +65,16 @@ const sandbox = <T, R, N extends string>(
                       });
                     }
                     break;
+                  case ParentCommand.GetIgnoredChildrenFailures:
+                    {
+                      const value = await job.getIgnoredChildrenFailures();
+                      child.send({
+                        requestId: msg.requestId,
+                        cmd: ChildCommand.GetIgnoredChildrenFailuresResponse,
+                        value,
+                      });
+                    }
+                    break;
                 }
               } catch (err) {
                 reject(err);

--- a/src/enums/child-command.ts
+++ b/src/enums/child-command.ts
@@ -3,4 +3,5 @@ export enum ChildCommand {
   Start,
   Stop,
   GetChildrenValuesResponse,
+  GetIgnoredChildrenFailuresResponse,
 }

--- a/src/enums/parent-command.ts
+++ b/src/enums/parent-command.ts
@@ -9,4 +9,5 @@ export enum ParentCommand {
   Progress,
   Update,
   GetChildrenValues,
+  GetIgnoredChildrenFailures,
 }

--- a/tests/fixtures/fixture_processor_get_children_failures.js
+++ b/tests/fixtures/fixture_processor_get_children_failures.js
@@ -1,0 +1,10 @@
+/**
+ * A processor file to be used in tests.
+ *
+ */
+'use strict';
+
+module.exports = async function (job) {
+  const values = await job.getIgnoredChildrenFailures();
+  return values;
+};

--- a/tests/fixtures/fixture_processor_get_children_failures_child.js
+++ b/tests/fixtures/fixture_processor_get_children_failures_child.js
@@ -1,0 +1,9 @@
+/**
+ * A processor file to be used in tests.
+ *
+ */
+'use strict';
+
+module.exports = function (job) {
+  throw new Error('child error');
+};


### PR DESCRIPTION
### Why
The wrapper is missing a couple of functions that exist on the job when it is not sandboxed. This PR tries to add one missing wrapper: `job.getIgnoredChildrenFailures()`

### How
- Add missing wrapper
- Add child/parent commands
- Add tests
- ??
- Profit!

### Additional Notes (Optional)
If this PR is succesful I will add the others missing wrappers too. There is also https://github.com/taskforcesh/bullmq/pull/3231, which hasn't added test, but I can also redo with tests.
