### PR TITLE
perf(stalled): fail stalled jobs in a lazy way

### DIFF
--- a/python/bullmq/scripts.py
+++ b/python/bullmq/scripts.py
@@ -44,7 +44,7 @@ class Scripts:
             "getState": self.redisClient.register_script(self.getScript("getState-8.lua")),
             "getStateV2": self.redisClient.register_script(self.getScript("getStateV2-8.lua")),
             "isJobInList": self.redisClient.register_script(self.getScript("isJobInList-1.lua")),
-            "moveStalledJobsToWait": self.redisClient.register_script(self.getScript("moveStalledJobsToWait-9.lua")),
+            "moveStalledJobsToWait": self.redisClient.register_script(self.getScript("moveStalledJobsToWait-8.lua")),
             "moveToActive": self.redisClient.register_script(self.getScript("moveToActive-11.lua")),
             "moveToDelayed": self.redisClient.register_script(self.getScript("moveToDelayed-8.lua")),
             "moveToFinished": self.redisClient.register_script(self.getScript("moveToFinished-14.lua")),
@@ -578,7 +578,7 @@ class Scripts:
         return self.commands["extendLock"](keys, args, client)
 
     def moveStalledJobsToWait(self, maxStalledCount: int, stalledInterval: int):
-        keys = self.getKeys(['stalled', 'wait', 'active', 'failed',
+        keys = self.getKeys(['stalled', 'wait', 'active',
                             'stalled-check', 'meta', 'paused', 'marker', 'events'])
         args = [maxStalledCount, self.keys[''], round(
             time.time() * 1000), stalledInterval]

--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -234,10 +234,7 @@ class Worker(EventEmitter):
 
     async def runStalledJobsCheck(self):
         try:
-            failed, stalled = await self.scripts.moveStalledJobsToWait(self.opts.get("maxStalledCount"), self.opts.get("stalledInterval"))
-            for jobId in failed:
-                self.emit("failed", jobId,
-                          "job stalled more than allowable limit")
+            stalled = await self.scripts.moveStalledJobsToWait(self.opts.get("maxStalledCount"), self.opts.get("stalledInterval"))
             for jobId in stalled:
                 self.emit("stalled", jobId)
 

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -1442,7 +1442,6 @@ export class Scripts {
       this.queue.keys.stalled,
       this.queue.keys.wait,
       this.queue.keys.active,
-      this.queue.keys.failed,
       this.queue.keys['stalled-check'],
       this.queue.keys.meta,
       this.queue.keys.paused,
@@ -1468,7 +1467,7 @@ export class Scripts {
    * (e.g. if the job handler keeps crashing),
    * we limit the number stalled job recoveries to settings.maxStalledCount.
    */
-  async moveStalledJobsToWait(): Promise<[string[], string[]]> {
+  async moveStalledJobsToWait(): Promise<string[]> {
     const client = await this.queue.client;
 
     const args = this.moveStalledJobsToWaitArgs();

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -1242,7 +1242,7 @@ will never work with more accuracy than 1ms. */
       'moveStalledJobsToWait',
       this.name,
       async span => {
-        const [stalled] = await this.scripts.moveStalledJobsToWait();
+        const stalled = await this.scripts.moveStalledJobsToWait();
 
         span?.setAttributes({
           [TelemetryAttributes.WorkerId]: this.id,

--- a/src/commands/moveStalledJobsToWait-8.lua
+++ b/src/commands/moveStalledJobsToWait-8.lua
@@ -5,12 +5,11 @@
       KEYS[1] 'stalled' (SET)
       KEYS[2] 'wait',   (LIST)
       KEYS[3] 'active', (LIST)
-      KEYS[4] 'failed', (ZSET)
-      KEYS[5] 'stalled-check', (KEY)
-      KEYS[6] 'meta', (KEY)
-      KEYS[7] 'paused', (LIST)
-      KEYS[8] 'marker'
-      KEYS[9] 'event stream' (STREAM)
+      KEYS[4] 'stalled-check', (KEY)
+      KEYS[5] 'meta', (KEY)
+      KEYS[6] 'paused', (LIST)
+      KEYS[7] 'marker'
+      KEYS[8] 'event stream' (STREAM)
 
       ARGV[1]  Max stalled job count
       ARGV[2]  queue.toKey('')
@@ -31,19 +30,18 @@ local rcall = redis.call
 local stalledKey = KEYS[1]
 local waitKey = KEYS[2]
 local activeKey = KEYS[3]
-local failedKey = KEYS[4] -- TODO: remove it
-local stalledCheckKey = KEYS[5]
-local metaKey = KEYS[6]
-local pausedKey = KEYS[7]
-local markerKey = KEYS[8]
-local eventStreamKey = KEYS[9]
+local stalledCheckKey = KEYS[4]
+local metaKey = KEYS[5]
+local pausedKey = KEYS[6]
+local markerKey = KEYS[7]
+local eventStreamKey = KEYS[8]
 local maxStalledJobCount = tonumber(ARGV[1])
 local queueKeyPrefix = ARGV[2]
 local timestamp = ARGV[3]
 local maxCheckTime = ARGV[4]
 
 if rcall("EXISTS", stalledCheckKey) == 1 then
-    return {{}, {}}
+    return {}
 end
 
 rcall("SET", stalledCheckKey, timestamp, "PX", maxCheckTime)
@@ -108,4 +106,4 @@ if (#active > 0) then
     end
 end
 
-return {stalled}
+return stalled

--- a/tests/test_stalled_jobs.ts
+++ b/tests/test_stalled_jobs.ts
@@ -272,7 +272,9 @@ describe('stalled jobs', function () {
         worker2.on(
           'failed',
           after(concurrency, async (job, failedReason, prev) => {
-            expect(job).to.be.undefined;
+            expect(job?.attemptsStarted).to.be.equal(2);
+            expect(job?.attemptsMade).to.be.equal(1);
+            expect(job?.stalledCounter).to.be.equal(1);
             expect(prev).to.be.equal('active');
             expect(failedReason.message).to.be.equal(errorMessage);
             resolve();
@@ -350,7 +352,9 @@ describe('stalled jobs', function () {
             worker.on(
               'failed',
               after(concurrency, async (job, failedReason, prev) => {
-                expect(job).to.be.undefined;
+                expect(job?.attemptsStarted).to.be.equal(4);
+                expect(job?.attemptsMade).to.be.equal(1);
+                expect(job?.stalledCounter).to.be.equal(3);
                 expect(prev).to.be.equal('active');
                 expect(failedReason.message).to.be.equal(errorMessage);
                 resolve();
@@ -819,7 +823,7 @@ describe('stalled jobs', function () {
               const failedCount = await queue.getFailedCount();
               expect(failedCount).to.equal(3);
 
-              expect(job.data.index).to.be.equal(3);
+              expect(job.data.index).to.be.equal(0);
               expect(prev).to.be.equal('active');
               expect(failedReason.message).to.be.equal(errorMessage);
               resolve();
@@ -886,7 +890,9 @@ describe('stalled jobs', function () {
           worker2.on(
             'failed',
             after(concurrency, async (job, failedReason, prev) => {
-              expect(job).to.be.undefined;
+              expect(job?.attemptsStarted).to.be.equal(2);
+              expect(job?.attemptsMade).to.be.equal(1);
+              expect(job?.stalledCounter).to.be.equal(1);
               const failedCount = await queue.getFailedCount();
               expect(failedCount).to.equal(2);
 


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
1. Why is this change necessary? Now that we have a deferredFailure attribute, we can fail our stalled jobs in a lazy way. So failed event in workers will contain a job instance and not be undefined

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
