### PR TITLE
fix(flow): add new error code when parent has failed children

### DIFF
--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -1688,7 +1688,7 @@ export class Scripts {
         return new Error(
           `Job ${jobId} is not in the ${state} state. ${command}`,
         );
-      case ErrorCode.JobPendingDependencies:
+      case ErrorCode.JobPendingChildren:
         return new Error(`Job ${jobId} has pending dependencies. ${command}`);
       case ErrorCode.ParentJobNotExist:
         return new Error(`Missing key for parent job ${parentKey}. ${command}`);
@@ -1704,6 +1704,8 @@ export class Scripts {
         return new Error(
           `Job ${jobId} belongs to a job scheduler and cannot be removed directly. ${command}`,
         );
+      case ErrorCode.JobFailedChildren:
+        return new Error(`Job ${jobId} has failed children. ${command}`);
       default:
         return new Error(`Unknown code ${code} error for ${jobId}. ${command}`);
     }

--- a/src/commands/includes/moveChildFromDependenciesIfNeeded.lua
+++ b/src/commands/includes/moveChildFromDependenciesIfNeeded.lua
@@ -8,9 +8,7 @@
 --- @include "moveParentToWait"
 --- @include "removeJobsOnFail"
 
-local moveParentToFailedIfNeeded
-local moveChildFromDependenciesIfNeeded
-moveParentToFailedIfNeeded = function (parentQueueKey, parentKey, parentId, jobIdKey, timestamp)
+local moveParentToFailedIfNeeded = function (parentQueueKey, parentKey, parentId, jobIdKey, timestamp)
   if rcall("EXISTS", parentKey) == 1 then
     local parentWaitingChildrenKey = parentQueueKey .. ":waiting-children"
     local parentDelayedKey = parentQueueKey .. ":delayed"
@@ -42,7 +40,7 @@ moveParentToFailedIfNeeded = function (parentQueueKey, parentKey, parentId, jobI
   end
 end
 
-moveChildFromDependenciesIfNeeded = function (rawParentData, childKey, failedReason, timestamp)
+local moveChildFromDependenciesIfNeeded = function (rawParentData, childKey, failedReason, timestamp)
   if rawParentData then
     local parentData = cjson.decode(rawParentData)
     local parentKey = parentData['queueKey'] .. ':' .. parentData['id']

--- a/src/commands/includes/moveParentToWait.lua
+++ b/src/commands/includes/moveParentToWait.lua
@@ -19,9 +19,6 @@ local function moveParentToWait(parentQueueKey, parentKey, parentId, timestamp)
     local priority = tonumber(jobAttributes[1]) or 0
     local delay = tonumber(jobAttributes[2]) or 0
 
-    -- ignore dependencies if any left
-    rcall("HSET", parentKey, "igdp", 1)
-
     if delay > 0 then
         local delayedTimestamp = tonumber(timestamp) + delay
         local score = delayedTimestamp * 0x1000

--- a/src/enums/error-code.ts
+++ b/src/enums/error-code.ts
@@ -2,9 +2,10 @@ export enum ErrorCode {
   JobNotExist = -1,
   JobLockNotExist = -2,
   JobNotInState = -3,
-  JobPendingDependencies = -4,
+  JobPendingChildren = -4,
   ParentJobNotExist = -5,
   JobLockMismatch = -6,
   ParentJobCannotBeReplaced = -7,
   JobBelongsToJobScheduler = -8,
+  JobFailedChildren = -9,
 }

--- a/tests/test_flow.ts
+++ b/tests/test_flow.ts
@@ -1177,6 +1177,102 @@ describe('flows', () => {
         await queueEvents.close();
         await removeAllQueueData(new IORedis(redisHost), childrenQueueName);
       });
+
+      describe('when parent has pending children to be processed when trying to move it to completed', () => {
+        it('should fail parent with pending dependencies error', async function () {
+          const childrenQueueName = `children-queue-${v4()}`;
+
+          enum Step {
+            Initial,
+            Second,
+            Third,
+            Finish,
+          }
+
+          const flow = new FlowProducer({ connection, prefix });
+
+          const childrenWorker = new Worker(
+            childrenQueueName,
+            () => {
+              throw new Error('failure');
+            },
+            {
+              connection,
+              prefix,
+            },
+          );
+          const worker = new Worker(
+            queueName,
+            async (job: Job, token?: string) => {
+              let step = job.data.step;
+              while (step !== Step.Finish) {
+                switch (step) {
+                  case Step.Initial: {
+                    await flow.add({
+                      name: 'child-job',
+                      queueName: childrenQueueName,
+                      data: {},
+                      opts: {
+                        parent: {
+                          id: job.id!,
+                          queue: job.queueQualifiedName,
+                        },
+                        failParentOnFailure: true,
+                      },
+                    });
+                    await job.updateData({
+                      step: Step.Second,
+                    });
+                    step = Step.Second;
+                    break;
+                  }
+                  case Step.Second: {
+                    await delay(100);
+                    await job.updateData({
+                      step: Step.Finish,
+                    });
+                    step = Step.Finish;
+                    break;
+                  }
+                  default: {
+                    throw new Error('invalid step');
+                  }
+                }
+              }
+            },
+            { autorun: false, connection, prefix },
+          );
+          const queueEvents = new QueueEvents(queueName, {
+            connection,
+            prefix,
+          });
+          await queueEvents.waitUntilReady();
+          await worker.waitUntilReady();
+
+          const job = await queue.add('test', { step: Step.Initial });
+
+          const failed = new Promise<void>(resolve => {
+            queueEvents.on('failed', async ({ jobId, failedReason, prev }) => {
+              if (jobId === job.id) {
+                expect(prev).to.be.equal('active');
+                expect(failedReason).to.be.equal(
+                  `Job ${jobId} has failed children. moveToFinished`,
+                );
+                resolve();
+              }
+            });
+          });
+
+          worker.run();
+          await failed;
+
+          await flow.close();
+          await worker.close();
+          await childrenWorker.close();
+          await queueEvents.close();
+          await removeAllQueueData(new IORedis(redisHost), childrenQueueName);
+        });
+      });
     });
 
     describe('when parent is not in waiting-children state when one child with failParentOnFailure failed', () => {


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? When a parent is moved to completed, failed children are ignored. That cause that a parent could be completed when a hard dependency failed. This is wrong as a parent should moved to failed in this situation

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Validate that there are no unsuccessful children before trying to move it to completed

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
