### PR TITLE
fix(job): do not parse ignored failures in getDependencies

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -1064,7 +1064,7 @@ export class Job<
         processed: parseObjectValues(processed),
         unprocessed,
         failed,
-        ignored: parseObjectValues(ignored),
+        ignored,
       };
     } else {
       const defaultOpts = {

--- a/tests/test_flow.ts
+++ b/tests/test_flow.ts
@@ -3423,6 +3423,9 @@ describe('flows', () => {
           `child ${prefix}:${grandChildrenQueueName}:${updatedGrandchildJob.id} failed`,
         );
 
+        const values = await tree.job.getDependencies();
+        expect(Object.keys(values.ignored!).length).to.be.equal(1);
+
         const updatedGrandparentJob = await parentQueue.getJob(job.id);
         const updatedGrandparentState = await updatedGrandparentJob.getState();
 


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
 1. Why is this change necessary? Ignored failures are not stringified, they are saved as plain strings

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? By not trying to parse those values

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
fixes https://github.com/taskforcesh/bullmq/issues/3283
