### PR TITLE
fix(job): pass stacktrace into scripts on failures [python]

### DIFF
--- a/python/bullmq/error_code.py
+++ b/python/bullmq/error_code.py
@@ -9,3 +9,4 @@ class ErrorCode(Enum):
     ParentJobNotExist = -5
     JobLockMismatch = -6
     ParentJobCannotBeReplaced = -7
+    JobFailedChildren = -9

--- a/python/bullmq/job.py
+++ b/python/bullmq/job.py
@@ -182,7 +182,7 @@ class Job:
                     delay,
                     token,
                     {
-                        'fieldsToUpdate': fields_to_update
+                        "fieldsToUpdate": fields_to_update
                     }
                 )
             else:
@@ -191,7 +191,7 @@ class Job:
                     self.opts.get("lifo", False),
                     token,
                     {
-                        'fieldsToUpdate': fields_to_update
+                        "fieldsToUpdate": fields_to_update
                     }
                 )
         else:

--- a/python/bullmq/job.py
+++ b/python/bullmq/job.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import List, Any, TYPE_CHECKING
+from bullmq.custom_errors import UnrecoverableError
 from bullmq.scripts import Scripts
 from bullmq.backoffs import Backoffs
 if TYPE_CHECKING:
@@ -160,46 +161,49 @@ class Job:
         delay = 0
         command = 'moveToFailed'
 
-        async with self.queue.redisConnection.conn.pipeline(transaction=True) as pipe:
-            await self.saveStacktrace(pipe, error_message)
-            if (self.attemptsMade + 1) < self.opts.get('attempts') and not self.discarded:
-                delay = await Backoffs.calculate(
-                    self.opts.get('backoff'), self.attemptsMade + 1,
-                    err, self, self.queue.opts.get("settings") and self.queue.opts['settings'].get("backoffStrategy")
-                    )
-                if delay == -1:
-                    move_to_failed = True
-                elif delay:
-                    keys, args = self.scripts.moveToDelayedArgs(
-                        self.id,
-                        round(time.time() * 1000),
-                        token,
-                        delay
-                    )
+        self.saveStacktrace()
+        fields_to_update = {
+            'failedReason': self.failedReason,
+            'stacktrace': json.dumps(self.stacktrace, separators=(',', ':'), allow_nan=False)
+        }
 
-                    await self.scripts.commands["moveToDelayed"](keys=keys, args=args, client=pipe)
-                    command = 'delayed'
-                else:
-                    keys, args = self.scripts.retryJobArgs(self.id, self.opts.get("lifo", False), token)
-
-                    await self.scripts.commands["retryJob"](keys=keys, args=args, client=pipe)
-                    command = 'retryJob'
-            else:
-                move_to_failed = True
-
-            if move_to_failed:
-                keys, args = self.scripts.moveToFailedArgs(
-                    self, error_message, self.opts.get("removeOnFail", False),
-                    token, fetchNext
+        result = None
+        if (self.attemptsMade + 1) < self.opts.get('attempts') and not isinstance(err, UnrecoverableError):
+            delay = await Backoffs.calculate(
+                self.opts.get('backoff'), self.attemptsMade + 1,
+                err, self, self.queue.opts.get("settings") and self.queue.opts['settings'].get("backoffStrategy")
                 )
-                await self.scripts.commands["moveToFinished"](keys=keys, args=args, client=pipe)
-                finished_on = args[1]
+            if delay == -1:
+                move_to_failed = True
+            elif delay:
+                result = async self.scripts.moveToDelayed(
+                    self.id,
+                    round(time.time() * 1000),
+                    delay,
+                    token,
+                    {
+                        'fieldsToUpdate': fields_to_update
+                    }
+                )
+            else:
+                result = async self.scripts.retryJob(
+                    self.id,
+                    self.opts.get("lifo", False),
+                    token,
+                    {
+                        'fieldsToUpdate': fields_to_update
+                    }
+                )
+        else:
+            move_to_failed = True
 
-            results = await pipe.execute()
-            code = results[1]
-
-            if code < 0:
-                raise self.scripts.finishedErrors(code, self.id, command, 'active')
+        if move_to_failed:
+            keys, args = self.scripts.moveToFailedArgs(
+                self, error_message, self.opts.get("removeOnFail", False),
+                token, fetchNext, fields_to_update
+            )
+            result = await self.scripts.moveToFinished(self.id, keys, args)
+            finished_on = args[1]
 
         if finished_on and type(finished_on) == int:
             self.finishedOn = finished_on
@@ -212,19 +216,16 @@ class Job:
     def log(self, logRow: str):
         return Job.addJobLog(self.queue, self.id, logRow, self.opts.get("keepLogs", 0))
 
-    async def saveStacktrace(self, pipe, err:str):
+    def updateStacktrace(self):
         stacktrace = traceback.format_exc()
         stackTraceLimit = self.opts.get("stackTraceLimit")
 
         if stacktrace:
             self.stacktrace.append(stacktrace)
-            if self.opts.get("stackTraceLimit"):
+            if self.opts.get("stackTraceLimit") == 0:
+                self.stacktrace = []
+            elif self.opts.get("stackTraceLimit"):
                 self.stacktrace = self.stacktrace[-(stackTraceLimit-1):stackTraceLimit]
-
-        keys, args = self.scripts.saveStacktraceArgs(
-            self.id, json.dumps(self.stacktrace, separators=(',', ':'), allow_nan=False), err)
-
-        await self.scripts.commands["saveStacktrace"](keys=keys, args=args, client=pipe)
 
     def moveToWaitingChildren(self, token, opts:dict):
         return self.scripts.moveToWaitingChildren(self.id, token, opts)

--- a/python/bullmq/scripts.py
+++ b/python/bullmq/scripts.py
@@ -580,12 +580,12 @@ class Scripts:
 
         return self.moveToFinished(job.id, keys, args)
 
-    async def moveToFinished(self, id: str, keys, args) -> list[Any] | None:
+    async def moveToFinished(self, job_id: str, keys, args) -> list[Any] | None:
         result = await self.commands["moveToFinished"](keys=keys, args=args)
 
         if result is not None:
             if type(result) == int and result < 0:
-                raise self.finishedErrors(result, id, 'moveToFinished', 'active')
+                raise self.finishedErrors(result, job_id, 'moveToFinished', 'active')
             return raw2NextJobData(result)
         return None
 

--- a/python/bullmq/scripts.py
+++ b/python/bullmq/scripts.py
@@ -566,7 +566,7 @@ class Scripts:
         return self.moveToFinishedArgs(job, return_value, 'returnvalue', shouldRemove, 'completed',
             token, fetchNext)
 
-    def moveToFailedArgs(self, job: Job, failed_reason: str, shouldRemove, token: str, fetchNext=True):
+    def moveToFailedArgs(self, job: Job, failed_reason: str, shouldRemove, token: str, fetchNext=True, fields_to_update = None):
         return self.moveToFinishedArgs(job, failed_reason, 'failedReason', shouldRemove, 'failed',
             token, fetchNext, fields_to_update)
 

--- a/python/bullmq/scripts.py
+++ b/python/bullmq/scripts.py
@@ -292,8 +292,8 @@ class Scripts:
 
         return (keys, args)
 
-    async def moveToDelayed(self, job_id: str, timestamp: int, delay: int, token: str = "0"):
-        keys, args = self.moveToDelayedArgs(job_id, timestamp, token, delay)
+    async def moveToDelayed(self, job_id: str, timestamp: int, delay: int, token: str = "0", opts: dict = {}):
+        keys, args = self.moveToDelayedArgs(job_id, timestamp, token, delay, opts)
 
         result = await self.commands["moveToDelayed"](keys=keys, args=args)
 

--- a/python/bullmq/utils.py
+++ b/python/bullmq/utils.py
@@ -1,3 +1,4 @@
+from typing import Any
 import semver
 import traceback
 import json
@@ -16,7 +17,7 @@ def extract_result(job_task, emit_callback):
             traceback.print_exc()
             emit_callback("error", e)
 
-def get_parent_key(opts: dict):
+def get_parent_key(opts: dict[str, str]):
     if opts:
         return f"{opts.get('queue')}:{opts.get('id')}"
 

--- a/python/bullmq/utils.py
+++ b/python/bullmq/utils.py
@@ -23,7 +23,16 @@ def get_parent_key(opts: dict):
 def parse_json_string_values(input_dict: dict[str, str]) -> dict[str, dict]:
     return {key: json.loads(value) for key, value in input_dict.items()}
 
-def object_to_flat_array(obj: dict):
+def object_to_flat_array(obj: dict[str, Any]) -> list[Any]:
+    """
+    Converts a dictionary into a flat array where each key is followed by its value.
+
+    Args:
+        obj (dict[str, Any]): The input dictionary to flatten.
+
+    Returns:
+        list[Any]: A flat list containing keys and values from the dictionary in order.
+    """
     arr = []
     for key, value in obj.items():
         arr.append(key)

--- a/python/bullmq/utils.py
+++ b/python/bullmq/utils.py
@@ -22,3 +22,10 @@ def get_parent_key(opts: dict):
 
 def parse_json_string_values(input_dict: dict[str, str]) -> dict[str, dict]:
     return {key: json.loads(value) for key, value in input_dict.items()}
+
+def object_to_flat_array(obj: dict):
+    arr = []
+    for key, value in obj.items():
+        arr.append(key)
+        arr.append(value)
+    return arr

--- a/python/tests/queue_test.py
+++ b/python/tests/queue_test.py
@@ -189,7 +189,7 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
 
         failed_count = await queue.getFailedCount()
 
-        self.assertEqual(failed_count, 8)
+        self.assertEqual(failed_count, job_count)
 
         order = 0
 
@@ -212,7 +212,7 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
         worker.off('completed', completing)
 
         completed_count = await queue.getJobCounts('completed')
-        self.assertEqual(completed_count['completed'], 8)
+        self.assertEqual(completed_count['completed'], job_count)
 
         await queue.close()
         await worker.close()


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
1. Why is this change necessary? Stacktrace is being saved on moveToFinished script, also it's a performance change that do not require an extra round trip calling Redis

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Use same logic as in node, removing pipe logic

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
