### PR TITLE
fix: avoid circular reference between scripts and queue

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -23,6 +23,7 @@ import {
   JobProgress,
 } from '../types';
 import {
+  createScripts,
   errorObject,
   isEmpty,
   getParentKey,
@@ -256,7 +257,7 @@ export class Job<
       : this.debounceId;
 
     this.toKey = queue.toKey.bind(queue);
-    this.createScripts();
+    this.scripts = createScripts(queue);
 
     this.queueQualifiedName = queue.qualifiedName;
   }
@@ -422,20 +423,6 @@ export class Job<
     }
 
     return job;
-  }
-
-  protected createScripts() {
-    const queue = this.queue;
-    this.scripts = new Scripts({
-      keys: this.queue.keys,
-      client: this.queue.client,
-      get redisVersion() {
-        return queue.redisVersion;
-      },
-      toKey: this.queue.toKey,
-      opts: this.queue.opts,
-      closing: this.queue.closing,
-    });
   }
 
   static optsFromJSON(

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -256,7 +256,7 @@ export class Job<
       : this.debounceId;
 
     this.toKey = queue.toKey.bind(queue);
-    this.setScripts();
+    this.createScripts();
 
     this.queueQualifiedName = queue.qualifiedName;
   }
@@ -424,7 +424,7 @@ export class Job<
     return job;
   }
 
-  protected setScripts() {
+  protected createScripts() {
     this.scripts = new Scripts({
       keys: this.queue.keys,
       client: this.queue.client,

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -425,10 +425,13 @@ export class Job<
   }
 
   protected createScripts() {
+    const queue = this.queue;
     this.scripts = new Scripts({
       keys: this.queue.keys,
       client: this.queue.client,
-      redisVersion: this.queue.redisVersion,
+      get redisVersion() {
+        return queue.redisVersion;
+      },
       toKey: this.queue.toKey,
       opts: this.queue.opts,
       closing: this.queue.closing,

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -425,7 +425,14 @@ export class Job<
   }
 
   protected setScripts() {
-    this.scripts = new Scripts(this.queue);
+    this.scripts = new Scripts({
+      keys: this.queue.keys,
+      client: this.queue.client,
+      redisVersion: this.queue.redisVersion,
+      toKey: this.queue.toKey,
+      opts: this.queue.opts,
+      closing: this.queue.closing,
+    });
   }
 
   static optsFromJSON(

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -257,7 +257,7 @@ export class Job<
       : this.debounceId;
 
     this.toKey = queue.toKey.bind(queue);
-    this.scripts = createScripts(queue);
+    this.createScripts();
 
     this.queueQualifiedName = queue.qualifiedName;
   }
@@ -423,6 +423,10 @@ export class Job<
     }
 
     return job;
+  }
+
+  protected createScripts() {
+    this.scripts = createScripts(this.queue);
   }
 
   static optsFromJSON(

--- a/src/classes/queue-base.ts
+++ b/src/classes/queue-base.ts
@@ -79,7 +79,7 @@ export class QueueBase extends EventEmitter implements MinimalQueue {
     this.qualifiedName = queueKeys.getQueueQualifiedName(name);
     this.keys = queueKeys.getKeys(name);
     this.toKey = (type: string) => queueKeys.toKey(name, type);
-    this.scripts = createScripts(this);
+    this.createScripts();
   }
 
   /**
@@ -87,6 +87,10 @@ export class QueueBase extends EventEmitter implements MinimalQueue {
    */
   get client(): Promise<RedisClient> {
     return this.connection.client;
+  }
+
+  protected createScripts() {
+    this.scripts = createScripts(this);
   }
 
   /**

--- a/src/classes/queue-base.ts
+++ b/src/classes/queue-base.ts
@@ -78,7 +78,7 @@ export class QueueBase extends EventEmitter implements MinimalQueue {
     this.qualifiedName = queueKeys.getQueueQualifiedName(name);
     this.keys = queueKeys.getKeys(name);
     this.toKey = (type: string) => queueKeys.toKey(name, type);
-    this.setScripts();
+    this.createScripts();
   }
 
   /**
@@ -88,15 +88,11 @@ export class QueueBase extends EventEmitter implements MinimalQueue {
     return this.connection.client;
   }
 
-  protected setScripts() {
-    this.scripts = this.createScripts();
-  }
-
   /**
    * Factory method to create a Scripts object.
    */
-  protected createScripts(): Scripts {
-    return new Scripts({
+  protected createScripts() {
+    this.scripts = new Scripts({
       keys: this.keys,
       client: this.client,
       redisVersion: this.redisVersion,

--- a/src/classes/queue-base.ts
+++ b/src/classes/queue-base.ts
@@ -89,7 +89,14 @@ export class QueueBase extends EventEmitter implements MinimalQueue {
   }
 
   protected setScripts() {
-    this.scripts = new Scripts({
+    this.scripts = this.createScripts();
+  }
+
+  /**
+   * Factory method to create a Scripts object.
+   */
+  protected createScripts(): Scripts {
+    return new Scripts({
       keys: this.keys,
       client: this.client,
       redisVersion: this.redisVersion,

--- a/src/classes/queue-base.ts
+++ b/src/classes/queue-base.ts
@@ -92,10 +92,13 @@ export class QueueBase extends EventEmitter implements MinimalQueue {
    * Factory method to create a Scripts object.
    */
   protected createScripts() {
+    const queue = this;
     this.scripts = new Scripts({
       keys: this.keys,
       client: this.client,
-      redisVersion: this.redisVersion,
+      get redisVersion() {
+        return queue.redisVersion;
+      },
       toKey: this.toKey,
       opts: this.opts,
       closing: this.closing,

--- a/src/classes/queue-base.ts
+++ b/src/classes/queue-base.ts
@@ -3,6 +3,7 @@ import { QueueBaseOptions, RedisClient, Span } from '../interfaces';
 import { MinimalQueue } from '../types';
 
 import {
+  createScripts,
   delay,
   DELAY_TIME_5,
   isNotConnectionError,
@@ -78,7 +79,7 @@ export class QueueBase extends EventEmitter implements MinimalQueue {
     this.qualifiedName = queueKeys.getQueueQualifiedName(name);
     this.keys = queueKeys.getKeys(name);
     this.toKey = (type: string) => queueKeys.toKey(name, type);
-    this.createScripts();
+    this.scripts = createScripts(this);
   }
 
   /**
@@ -86,23 +87,6 @@ export class QueueBase extends EventEmitter implements MinimalQueue {
    */
   get client(): Promise<RedisClient> {
     return this.connection.client;
-  }
-
-  /**
-   * Factory method to create a Scripts object.
-   */
-  protected createScripts() {
-    const queue = this;
-    this.scripts = new Scripts({
-      keys: this.keys,
-      client: this.client,
-      get redisVersion() {
-        return queue.redisVersion;
-      },
-      toKey: this.toKey,
-      opts: this.opts,
-      closing: this.closing,
-    });
   }
 
   /**

--- a/src/classes/queue-base.ts
+++ b/src/classes/queue-base.ts
@@ -89,7 +89,14 @@ export class QueueBase extends EventEmitter implements MinimalQueue {
   }
 
   protected setScripts() {
-    this.scripts = new Scripts(this);
+    this.scripts = new Scripts({
+      keys: this.keys,
+      client: this.client,
+      redisVersion: this.redisVersion,
+      toKey: this.toKey,
+      opts: this.opts,
+      closing: this.closing,
+    });
   }
 
   /**

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -32,7 +32,7 @@ import {
   JobType,
   FinishedStatus,
   FinishedPropValAttribute,
-  MinimalScriptQueue,
+  ScriptQueueContext,
   RedisJobOptions,
   JobProgress,
 } from '../types';
@@ -52,7 +52,7 @@ export class Scripts {
 
   moveToFinishedKeys: (string | undefined)[];
 
-  constructor(protected queue: MinimalScriptQueue) {
+  constructor(protected queue: ScriptQueueContext) {
     const queueKeys = this.queue.keys;
 
     this.moveToFinishedKeys = [

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -32,7 +32,7 @@ import {
   JobType,
   FinishedStatus,
   FinishedPropValAttribute,
-  MinimalQueue,
+  MinimalScriptQueue,
   RedisJobOptions,
   JobProgress,
 } from '../types';
@@ -52,7 +52,7 @@ export class Scripts {
 
   moveToFinishedKeys: (string | undefined)[];
 
-  constructor(protected queue: MinimalQueue) {
+  constructor(protected queue: MinimalScriptQueue) {
     const queueKeys = this.queue.keys;
 
     this.moveToFinishedKeys = [

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -206,6 +206,13 @@ export class Worker<
     super(
       name,
       {
+        drainDelay: 5,
+        concurrency: 1,
+        lockDuration: 30000,
+        maxStalledCount: 1,
+        stalledInterval: 30000,
+        autorun: true,
+        runRetryDelay: 15000,
         ...opts,
         blockingConnection: true,
       },
@@ -215,17 +222,6 @@ export class Worker<
     if (!opts || !opts.connection) {
       throw new Error('Worker requires a connection');
     }
-
-    this.opts = {
-      drainDelay: 5,
-      concurrency: 1,
-      lockDuration: 30000,
-      maxStalledCount: 1,
-      stalledInterval: 30000,
-      autorun: true,
-      runRetryDelay: 15000,
-      ...this.opts,
-    };
 
     if (
       typeof this.opts.maxStalledCount !== 'number' ||

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,3 +7,4 @@ export * from './job-scheduler-template-options';
 export * from './job-type';
 export * from './repeat-strategy';
 export * from './job-progress';
+export * from './script-queue-context';

--- a/src/types/minimal-queue.ts
+++ b/src/types/minimal-queue.ts
@@ -16,8 +16,3 @@ export type MinimalQueue = Pick<
   | 'redisVersion'
   | 'trace'
 >;
-
-export type MinimalScriptQueue = Pick<
-  QueueBase,
-  'client' | 'toKey' | 'keys' | 'opts' | 'closing' | 'redisVersion'
->;

--- a/src/types/minimal-queue.ts
+++ b/src/types/minimal-queue.ts
@@ -16,3 +16,8 @@ export type MinimalQueue = Pick<
   | 'redisVersion'
   | 'trace'
 >;
+
+export type MinimalScriptQueue = Pick<
+  QueueBase,
+  'client' | 'toKey' | 'keys' | 'opts' | 'closing' | 'redisVersion'
+>;

--- a/src/types/script-queue-context.ts
+++ b/src/types/script-queue-context.ts
@@ -1,0 +1,6 @@
+import { QueueBase } from '../classes/queue-base';
+
+export type ScriptQueueContext = Pick<
+  QueueBase,
+  'client' | 'toKey' | 'keys' | 'opts' | 'closing' | 'redisVersion'
+>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,10 +14,12 @@ import {
   Span,
   Tracer,
 } from './interfaces';
+import { Scripts } from './classes/scripts';
 import { EventEmitter } from 'events';
 import * as semver from 'semver';
 
 import { SpanKind, TelemetryAttributes } from './enums';
+import { MinimalQueue } from './types';
 
 export const errorObject: { [index: string]: any } = { value: null };
 
@@ -231,6 +233,22 @@ export const childSend = (
   proc: NodeJS.Process,
   msg: ChildMessage,
 ): Promise<void> => asyncSend<NodeJS.Process>(proc, msg);
+
+/**
+ * Factory method to create a Scripts object.
+ */
+export const createScripts = (queue: MinimalQueue) => {
+  return new Scripts({
+    keys: queue.keys,
+    client: queue.client,
+    get redisVersion() {
+      return queue.redisVersion;
+    },
+    toKey: queue.toKey,
+    opts: queue.opts,
+    closing: queue.closing,
+  });
+};
 
 export const isRedisVersionLowerThan = (
   currentVersion: string,

--- a/tests/test_events.ts
+++ b/tests/test_events.ts
@@ -573,6 +573,7 @@ describe('events', function () {
             await deduplication;
 
             expect(deduplicatedCounter).to.be.equal(1);
+            await worker.close();
           });
         });
       });
@@ -994,6 +995,7 @@ describe('events', function () {
             await deduplication;
 
             expect(deduplicatedCounter).to.be.equal(1);
+            await worker.close();
           });
         });
       });


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? Queue instance incluyes scripts instance, but it's also passed as an instance of Scripts

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
