### PR TITLE
ci: use GH_TOKEN for GitHub CLI in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: write # for release publishing
       pull-requests: write # for creating PRs
+      issues: write # additional permission that might be needed
 
     name: Release
     env:
@@ -40,6 +41,7 @@ jobs:
         if: ${{ success() && steps.semantic_release.outcome == 'success' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Check if there are any changes to commit
           if [[ -n $(git status --porcelain) ]]; then


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
The GitHub token was not properly passed to the GH cli and therefore the creation of the PR with changelog, etc was failing after a release.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
Just pass the GitHub token into the GH_TOKEN variable

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
