### PR TITLE
fix(scheduler): fix slot calculation when using every

### DIFF
--- a/src/classes/job-scheduler.ts
+++ b/src/classes/job-scheduler.ts
@@ -95,15 +95,24 @@ export class JobScheduler extends QueueBase {
     let nextMillis: number;
     let newOffset: number | null = null;
     if (every) {
-      const prevSlot = Math.floor(startMillis / every) * every;
+      if (typeof offset === 'number') {
+        const prevSlot = Math.floor((startMillis - offset) / every) * every;
 
-      newOffset = typeof offset === 'number' ? offset : startMillis - prevSlot;
+        newOffset = offset;
 
-      const nextSlot = prevSlot + every;
-      if (prevMillis || offset) {
+        const nextSlot = prevSlot + every;
         nextMillis = nextSlot;
       } else {
-        nextMillis = prevSlot;
+        const prevSlot = Math.floor(startMillis / every) * every;
+
+        newOffset = startMillis - prevSlot;
+
+        const nextSlot = prevSlot + every;
+        if (prevMillis) {
+          nextMillis = nextSlot;
+        } else {
+          nextMillis = prevSlot;
+        }
       }
     } else if (pattern) {
       nextMillis = await this.repeatStrategy(now, repeatOpts, jobName);

--- a/src/classes/job-scheduler.ts
+++ b/src/classes/job-scheduler.ts
@@ -95,24 +95,16 @@ export class JobScheduler extends QueueBase {
     let nextMillis: number;
     let newOffset: number | null = null;
     if (every) {
-      if (typeof offset === 'number') {
-        const prevSlot = Math.floor((startMillis - offset) / every) * every;
+      const prevSlot =
+        Math.floor((startMillis - (offset || 0)) / every) * every;
 
-        newOffset = offset;
+      newOffset = typeof offset === 'number' ? offset : startMillis - prevSlot;
 
-        const nextSlot = prevSlot + every;
+      const nextSlot = prevSlot + every;
+      if (prevMillis || offset) {
         nextMillis = nextSlot;
       } else {
-        const prevSlot = Math.floor(startMillis / every) * every;
-
-        newOffset = startMillis - prevSlot;
-
-        const nextSlot = prevSlot + every;
-        if (prevMillis) {
-          nextMillis = nextSlot;
-        } else {
-          nextMillis = prevSlot;
-        }
+        nextMillis = prevSlot;
       }
     } else if (pattern) {
       nextMillis = await this.repeatStrategy(now, repeatOpts, jobName);

--- a/tests/test_job_scheduler_stress.ts
+++ b/tests/test_job_scheduler_stress.ts
@@ -219,6 +219,7 @@ describe('Job Scheduler Stress', function () {
   describe("when using 'every' option and jobs are moved to active some time after delay", function () {
     it('should repeat every 2 seconds and start immediately', async function () {
       let iterationCount = 0;
+      const MINIMUM_DELAY_THRESHOLD_MS = 1850;
       const worker = new Worker(
         queueName,
         async job => {
@@ -226,13 +227,12 @@ describe('Job Scheduler Stress', function () {
             if (iterationCount++ === 0) {
               expect(job.opts.delay).to.be.eq(0);
             } else {
-              expect(job.opts.delay).to.be.gte(1850);
+              expect(job.opts.delay).to.be.gte(MINIMUM_DELAY_THRESHOLD_MS);
             }
           } catch (err) {
             console.log(err);
             throw err;
           }
-          iterationCount++;
         },
         { autorun: false, connection, prefix },
       );
@@ -245,7 +245,9 @@ describe('Job Scheduler Stress', function () {
           try {
             if (prev) {
               expect(prev.timestamp).to.be.lte(job.timestamp);
-              expect(job.processedOn! - prev.processedOn!).to.be.gte(1850);
+              expect(job.processedOn! - prev.processedOn!).to.be.gte(
+                MINIMUM_DELAY_THRESHOLD_MS,
+              );
             }
             prev = job;
             counter++;

--- a/tests/test_job_scheduler_stress.ts
+++ b/tests/test_job_scheduler_stress.ts
@@ -224,11 +224,12 @@ describe('Job Scheduler Stress', function () {
         queueName,
         async job => {
           try {
-            if (iterationCount++ === 0) {
+            if (iterationCount === 0) {
               expect(job.opts.delay).to.be.eq(0);
             } else {
               expect(job.opts.delay).to.be.gte(MINIMUM_DELAY_THRESHOLD_MS);
             }
+            iterationCount++;
           } catch (err) {
             console.log(err);
             throw err;

--- a/tests/test_job_scheduler_stress.ts
+++ b/tests/test_job_scheduler_stress.ts
@@ -222,10 +222,15 @@ describe('Job Scheduler Stress', function () {
       const worker = new Worker(
         queueName,
         async job => {
-          if (iterationCount === 0) {
-            expect(job.opts.delay).to.be.eq(0);
-          } else {
-            expect(job.opts.delay).to.be.gte(1850);
+          try {
+            if (iterationCount++ === 0) {
+              expect(job.opts.delay).to.be.eq(0);
+            } else {
+              expect(job.opts.delay).to.be.gte(1850);
+            }
+          } catch (err) {
+            console.log(err);
+            throw err;
           }
           iterationCount++;
         },
@@ -240,7 +245,7 @@ describe('Job Scheduler Stress', function () {
           try {
             if (prev) {
               expect(prev.timestamp).to.be.lte(job.timestamp);
-              expect(job.processedOn! - prev.processedOn!).to.be.gte(1900);
+              expect(job.processedOn! - prev.processedOn!).to.be.gte(1850);
             }
             prev = job;
             counter++;


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? When calculating delay, there is an opportunity where startMillis + offset is slightly higher than current next slot. As startMillis for subsequent delayed jobs should already contain offset value, we can subtract this value to get a more accurate delay and not skip one iteration

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
