### PR TITLE
perf(delayed): add marker once when promoting delayed jobs

### DIFF
--- a/src/commands/includes/addJobWithPriority.lua
+++ b/src/commands/includes/addJobWithPriority.lua
@@ -4,10 +4,10 @@
 
 -- Includes
 --- @include "addPriorityMarkerIfNeeded"
+--- @include "getPriorityScore"
 
 local function addJobWithPriority(waitKey, prioritizedKey, priority, paused, jobId, priorityCounterKey)
-  local prioCounter = rcall("INCR", priorityCounterKey)
-  local score = priority * 0x100000000 + bit.band(prioCounter, 0xffffffffffff)
+  local score = getPriorityScore(priority, priorityCounterKey)
   rcall("ZADD", prioritizedKey, score, jobId)
   if not paused then
     addPriorityMarkerIfNeeded(waitKey)

--- a/src/commands/includes/getPriorityScore.lua
+++ b/src/commands/includes/getPriorityScore.lua
@@ -1,0 +1,7 @@
+--[[
+  Function to get priority score.
+]]
+local function getPriorityScore(priority, priorityCounterKey)
+  local prioCounter = rcall("INCR", priorityCounterKey)
+  return priority * 0x100000000 + prioCounter % 0x100000000
+end


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? Base on https://github.com/taskforcesh/bullmq/pull/3096

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
