### PR TITLE
perf(worker): do not wait rate limit when fetching jobs

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -465,7 +465,6 @@ export class Worker<
 
   private async waitForRateLimit(): Promise<void> {
     const limitUntil = this.limitUntil;
-
     if (limitUntil > Date.now()) {
       this.abortDelayController?.abort();
       this.abortDelayController = new AbortController();

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -465,6 +465,7 @@ export class Worker<
 
   private async waitForRateLimit(): Promise<void> {
     const limitUntil = this.limitUntil;
+
     if (limitUntil > Date.now()) {
       this.abortDelayController?.abort();
       this.abortDelayController = new AbortController();
@@ -561,7 +562,8 @@ export class Worker<
             this.opts.runRetryDelay,
           ),
         );
-      } else {
+      } else if (asyncFifoQueue.numTotal() < 1) {
+        // only when there are no more jobs to be processed
         await this.waitForRateLimit();
       }
     }

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -561,8 +561,7 @@ export class Worker<
             this.opts.runRetryDelay,
           ),
         );
-      } else if (asyncFifoQueue.numTotal() < 1) {
-        // only when there are no more jobs to be processed
+      } else {
         await this.waitForRateLimit();
       }
     }

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -561,7 +561,7 @@ export class Worker<
             this.opts.runRetryDelay,
           ),
         );
-      } else {
+      } else if (asyncFifoQueue.numQueued() < 1) {
         await this.waitForRateLimit();
       }
     }

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -561,7 +561,7 @@ export class Worker<
             this.opts.runRetryDelay,
           ),
         );
-      } else if (this.isRateLimited()) {
+      } else {
         await this.waitForRateLimit();
       }
     }
@@ -635,8 +635,9 @@ export class Worker<
         this.waiting = null;
       }
     } else {
-      await this.waitForRateLimit();
-      return this.moveToActive(client, token, this.opts.name);
+      if (!this.isRateLimited()) {
+        return this.moveToActive(client, token, this.opts.name);
+      }
     }
   }
 

--- a/src/commands/includes/prepareJobForProcessing.lua
+++ b/src/commands/includes/prepareJobForProcessing.lua
@@ -16,7 +16,7 @@ local function prepareJobForProcessing(keyPrefix, rateLimiterKey, eventStreamKey
   -- Check if we need to perform rate limiting.
   if maxJobs then
     local jobCounter = tonumber(rcall("INCR", rateLimiterKey))
-    
+
     if jobCounter == 1 then
       local limiterDuration = opts['limiter'] and opts['limiter']['duration']
       local integerDuration = math.floor(math.abs(limiterDuration))

--- a/src/commands/includes/prepareJobForProcessing.lua
+++ b/src/commands/includes/prepareJobForProcessing.lua
@@ -16,11 +16,10 @@ local function prepareJobForProcessing(keyPrefix, rateLimiterKey, eventStreamKey
   -- Check if we need to perform rate limiting.
   if maxJobs then
     local jobCounter = tonumber(rcall("INCR", rateLimiterKey))
-
-    local limiterDuration = opts['limiter'] and opts['limiter']['duration']
-    local integerDuration = math.floor(math.abs(limiterDuration))
     
     if jobCounter == 1 then
+      local limiterDuration = opts['limiter'] and opts['limiter']['duration']
+      local integerDuration = math.floor(math.abs(limiterDuration))
       rcall("PEXPIRE", rateLimiterKey, integerDuration)
     end
   end

--- a/src/commands/includes/prepareJobForProcessing.lua
+++ b/src/commands/includes/prepareJobForProcessing.lua
@@ -19,10 +19,22 @@ local function getRateLimitDelay(rateLimiterKey, maxJobs, limiterOpts)
     
     if jobCounter == 1 then
       rcall("PEXPIRE", rateLimiterKey, integerDuration)
+
+      if maxJobs == 1 then
+        return integerDuration
+      end
     end
 
     if maxJobs <= jobCounter then
-      return integerDuration
+      local pttl = rcall("PTTL", rateLimiterKey)
+
+      if pttl == 0 then
+        rcall("DEL", rateLimiterKey)
+      end
+
+      if pttl > 0 then
+        return pttl
+      end
     end
   end
 

--- a/tests/test_rate_limiter.ts
+++ b/tests/test_rate_limiter.ts
@@ -150,11 +150,6 @@ describe('Rate Limiter', function () {
       worker.on('completed', async job => {
         try {
           completedCount++;
-          console.log(
-            completedCount,
-            job.id,
-            job.finishedOn! - job.processedOn!,
-          );
           expect(job.finishedOn! - job.processedOn!).to.be.lte(1000);
           if (completedCount === numJobs) {
             resolve();

--- a/tests/test_rate_limiter.ts
+++ b/tests/test_rate_limiter.ts
@@ -150,6 +150,11 @@ describe('Rate Limiter', function () {
       worker.on('completed', async job => {
         try {
           completedCount++;
+          console.log(
+            completedCount,
+            job.id,
+            job.finishedOn! - job.processedOn!,
+          );
           expect(job.finishedOn! - job.processedOn!).to.be.lte(1000);
           if (completedCount === numJobs) {
             resolve();

--- a/tests/test_rate_limiter.ts
+++ b/tests/test_rate_limiter.ts
@@ -147,21 +147,17 @@ describe('Rate Limiter', function () {
 
     let completedCount = 0;
     const result = new Promise<void>((resolve, reject) => {
-      worker.on(
-        'completed',
-        // after every job has been completed
-        async job => {
-          try {
-            completedCount++;
-            expect(job.finishedOn! - job.processedOn!).to.be.lte(1000);
-            if (completedCount === numJobs) {
-              resolve();
-            }
-          } catch (err) {
-            reject(err);
+      worker.on('completed', async job => {
+        try {
+          completedCount++;
+          expect(job.finishedOn! - job.processedOn!).to.be.lte(1000);
+          if (completedCount === numJobs) {
+            resolve();
           }
-        },
-      );
+        } catch (err) {
+          reject(err);
+        }
+      });
 
       queueEvents.on('failed', async err => {
         await worker.close();

--- a/tests/test_rate_limiter.ts
+++ b/tests/test_rate_limiter.ts
@@ -79,7 +79,7 @@ describe('Rate Limiter', function () {
   });
 
   it('should obey the rate limit', async function () {
-    this.timeout(20000);
+    this.timeout(15000);
 
     const numJobs = 10;
 
@@ -114,6 +114,61 @@ describe('Rate Limiter', function () {
     });
 
     const startTime = new Date().getTime();
+    const jobs = Array.from(Array(numJobs).keys()).map(() => ({
+      name: 'rate test',
+      data: {},
+    }));
+    await queue.addBulk(jobs);
+
+    await result;
+    await worker.close();
+  });
+
+  it('should respect processing time without adding limiter delay', async function () {
+    this.timeout(12000);
+
+    const numJobs = 40;
+
+    const worker = new Worker(
+      queueName,
+      async () => {
+        await delay(Math.floor(1 + Math.random() * 4));
+      },
+      {
+        connection,
+        prefix,
+        concurrency: 5,
+        limiter: {
+          max: 4,
+          duration: 1000,
+        },
+      },
+    );
+
+    let completedCount = 0;
+    const result = new Promise<void>((resolve, reject) => {
+      worker.on(
+        'completed',
+        // after every job has been completed
+        async job => {
+          try {
+            completedCount++;
+            expect(job.finishedOn! - job.processedOn!).to.be.lte(1000);
+            if (completedCount === numJobs) {
+              resolve();
+            }
+          } catch (err) {
+            reject(err);
+          }
+        },
+      );
+
+      queueEvents.on('failed', async err => {
+        await worker.close();
+        reject(err);
+      });
+    });
+
     const jobs = Array.from(Array(numJobs).keys()).map(() => ({
       name: 'rate test',
       data: {},


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
1. Why is this change necessary? We should only wait for the rate limit when there are no more task to process
### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Only wait for rate limit when needed.


### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
