### PR TITLE
fix(worker): fix bzpopmin race condition

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -715,8 +715,14 @@ will never work with more accuracy than 1ms. */
           // We cannot trust that the blocking connection stays blocking forever
           // due to issues in Redis and IORedis, so we will reconnect if we
           // don't get a response in the expected time.
-          timeout = setTimeout(async () => {
-            bclient.disconnect(!this.closing);
+          timeout = setTimeout(() => {
+            // If the event-loop was stuck for more than 1s at the time of completion,
+            // leading this setTimeout and the bzpopmin below to execute at the same time,
+            // this function is going to run first. The next setTimeout is there to give
+            // a bit of room to bzpopmin to resolve if it can.
+            timeout = setTimeout(() => {
+              bclient.disconnect(!this.closing);
+            }, 0);
           }, blockTimeout * 1000 + 1000);
 
           this.updateDelays(); // reset delays to avoid reusing same values in next iteration


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
As explained in #2619, the resolution order of setTimeout and bzpopmin under certain conditions is wrong.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
To reestablish the correct order, I'm scheduling the disconnection for the next tick to let bzpopmin eventually resolve properly.

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
I'm honestly not sure how to add non-regression testing on this, I'd like some advice on this if possible.

I also removed the async modifier of the timeout callback, not really sure why it was there.