### PR TITLE
docs(fail-parent): clarify lazy failures when using failParentOnFailure option

### DIFF
--- a/docs/gitbook/guide/flows/fail-parent.md
+++ b/docs/gitbook/guide/flows/fail-parent.md
@@ -57,7 +57,7 @@ const originalTree = await flow.add({
 ```
 
 {% hint style="info" %}
-As soon as a _child_ with this option fails, the parent job will be marked as failed lazily — a worker must process the parent job before it transitions to the failed state with an _UnrecoverableError_ with the following message **child {childKey} failed**. Also, this option will be validated recursively, so a grandparent could be failed and so on.
+As soon as a _child_ with this option fails, the parent job will be marked as failed lazily. A worker must process the parent job before it transitions to the failed state. The failure will result in an _UnrecoverableError_ with the message **child {childKey} failed**. Additionally, this option will be validated recursively, meaning a grandparent or higher-level ancestor could also fail depending on the configuration.
 {% endhint %}
 
 ### How it Works


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? Failing a parent is using a lazy movement strategy that needs to be clarified in our documentation

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
