### PR TITLE
fix(worker): reject promise if retrieving a Redis client fails

### DIFF
--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -247,7 +247,7 @@ export class Queue<
   }
 
   get repeat(): Promise<Repeat> {
-    return new Promise<Repeat>(async resolve => {
+    return (async () => {
       if (!this._repeat) {
         this._repeat = new Repeat(this.name, {
           ...this.opts,
@@ -255,12 +255,12 @@ export class Queue<
         });
         this._repeat.on('error', e => this.emit.bind(this, e));
       }
-      resolve(this._repeat);
-    });
+      return this._repeat;
+    })();
   }
 
   get jobScheduler(): Promise<JobScheduler> {
-    return new Promise<JobScheduler>(async resolve => {
+    return (async () => {
       if (!this._jobScheduler) {
         this._jobScheduler = new JobScheduler(this.name, {
           ...this.opts,
@@ -268,8 +268,8 @@ export class Queue<
         });
         this._jobScheduler.on('error', e => this.emit.bind(this, e));
       }
-      resolve(this._jobScheduler);
-    });
+      return this._jobScheduler;
+    })();
   }
 
   /**

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -406,31 +406,29 @@ export class Worker<
   }
 
   get repeat(): Promise<Repeat> {
-    return new Promise<Repeat>(async resolve => {
+    return (async () => {
       if (!this._repeat) {
-        const connection = await this.client;
         this._repeat = new Repeat(this.name, {
           ...this.opts,
-          connection,
+          connection: await this.client,
         });
         this._repeat.on('error', e => this.emit.bind(this, e));
       }
-      resolve(this._repeat);
-    });
+      return this._repeat;
+    })();
   }
 
   get jobScheduler(): Promise<JobScheduler> {
-    return new Promise<JobScheduler>(async resolve => {
+    return (async () => {
       if (!this._jobScheduler) {
-        const connection = await this.client;
         this._jobScheduler = new JobScheduler(this.name, {
           ...this.opts,
-          connection,
+          connection: await this.client,
         });
         this._jobScheduler.on('error', e => this.emit.bind(this, e));
       }
-      resolve(this._jobScheduler);
-    });
+      return this._jobScheduler;
+    })();
   }
 
   async run() {


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why

<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
I noticed that if `await this._client` throws, the outer `Promise` doesn't get rejected, nor resolved.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
As it isn't possible to make a `get` async, the change creates an async anonymous function and immediately executes it.

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
In the future, we could consider not using a `getter` but a regular function. Additionally, the logic is duplicated in both `Queue` and `Worker`.
