### PR TITLE
perf(woker): keep lower blockTimeout when consuming delayed markers

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -728,7 +728,13 @@ will never work with more accuracy than 1ms. */
             const [_key, member, score] = result;
 
             if (member) {
-              return parseInt(score);
+              const newBlockUntil = parseInt(score);
+              // Use by pro version as rate limited groups could generate lower blockUntil values
+              // markers only return delays for delayed jobs
+              if (blockUntil && newBlockUntil > blockUntil) {
+                return blockUntil;
+              }
+              return newBlockUntil;
             }
           }
         }


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
_Enter your explanation here._

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
