### PR TITLE
fix(connection): ignore info command when skipVersionCheck is provided as true

### DIFF
--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -360,28 +360,32 @@ export class RedisConnection extends EventEmitter {
   }
 
   private async getRedisVersion() {
-    const doc = await this._client.info();
-    const redisPrefix = 'redis_version:';
-    const maxMemoryPolicyPrefix = 'maxmemory_policy:';
-    const lines = doc.split(/\r?\n/);
-    let redisVersion;
+    if (this.skipVersionCheck) {
+      return RedisConnection.minimumVersion;
+    } else {
+      const doc = await this._client.info();
+      const redisPrefix = 'redis_version:';
+      const maxMemoryPolicyPrefix = 'maxmemory_policy:';
+      const lines = doc.split(/\r?\n/);
+      let redisVersion;
 
-    for (let i = 0; i < lines.length; i++) {
-      if (lines[i].indexOf(maxMemoryPolicyPrefix) === 0) {
-        const maxMemoryPolicy = lines[i].substr(maxMemoryPolicyPrefix.length);
-        if (maxMemoryPolicy !== 'noeviction') {
-          console.warn(
-            `IMPORTANT! Eviction policy is ${maxMemoryPolicy}. It should be "noeviction"`,
-          );
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i].indexOf(maxMemoryPolicyPrefix) === 0) {
+          const maxMemoryPolicy = lines[i].substr(maxMemoryPolicyPrefix.length);
+          if (maxMemoryPolicy !== 'noeviction') {
+            console.warn(
+              `IMPORTANT! Eviction policy is ${maxMemoryPolicy}. It should be "noeviction"`,
+            );
+          }
+        }
+
+        if (lines[i].indexOf(redisPrefix) === 0) {
+          redisVersion = lines[i].substr(redisPrefix.length);
         }
       }
 
-      if (lines[i].indexOf(redisPrefix) === 0) {
-        redisVersion = lines[i].substr(redisPrefix.length);
-      }
+      return redisVersion;
     }
-
-    return redisVersion;
   }
 
   get redisVersion(): string {

--- a/tests/test_connection.ts
+++ b/tests/test_connection.ts
@@ -43,6 +43,17 @@ describe('RedisConnection', () => {
       const connection = new RedisConnection({}, options);
       expect((connection as any).extraOptions).to.deep.include(options);
     });
+
+    describe('when skipVersionCheck is set as true', () => {
+      it('initializes version as minimum', async () => {
+        const connection = new RedisConnection({
+          skipVersionCheck: true,
+        });
+        await (connection as any).initializing;
+
+        expect((connection as any).redisVersion).to.be.equal('5.0.0');
+      });
+    });
   });
 
   describe('blocking option', () => {


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
Why is this change necessary? When info command is not allowed to be called, even using skipVersionCheck, this command is called.

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Use minimum version by default when passing skipVersionCheck as true

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
Fixes https://github.com/taskforcesh/bullmq/issues/3341