### PR TITLE
Prevent unecessary tryCatch() calls in Job::getTraces()

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -1499,6 +1499,9 @@ export class Job<
 }
 
 function getTraces(stacktrace: string[]) {
+  if (stacktrace === undefined || stacktrace === '') {
+    return []
+  }
   const traces = tryCatch(JSON.parse, JSON, [stacktrace]);
 
   if (traces === errorObject || !(traces instanceof Array)) {


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
When debugging an application that uses BullMQ, this code gets called continuously and triggers "Pause on caught exceptions" breakpoints making debugging actual exceptions very difficult.

This does basic input checking to avoid even attempting JSON.parse if the input is bad thus avoiding dozens of exceptions becoming generated and triggering the breakpoints.


### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
