### PR TITLE
fix(worker): do not keep active jobs when pausing or closing

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -491,7 +491,7 @@ export class Worker<
 
     let tokenPostfix = 0;
 
-    while (!(this.closing || this.paused) || asyncFifoQueue.numTotal() > 0) {
+    while ((!this.closing && !this.paused) || asyncFifoQueue.numTotal() > 0) {
       let numTotal = asyncFifoQueue.numTotal();
 
       /**

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -491,7 +491,7 @@ export class Worker<
 
     let tokenPostfix = 0;
 
-    while (!this.closing && !this.paused) {
+    while (!(this.closing || this.paused) || asyncFifoQueue.numTotal() > 0) {
       let numTotal = asyncFifoQueue.numTotal();
 
       /**
@@ -565,8 +565,6 @@ export class Worker<
         await this.waitForRateLimit();
       }
     }
-
-    return asyncFifoQueue.waitAll();
   }
 
   /**
@@ -1018,7 +1016,10 @@ will never work with more accuracy than 1ms. */
 
         if (!this.paused) {
           this.paused = true;
-          await (!doNotWaitActive && this.whenCurrentJobsFinished());
+          if (!doNotWaitActive) {
+            await this.whenCurrentJobsFinished();
+          }
+          //console.log('here', this.name)
           this.stalledCheckStopper?.();
           this.emit('paused');
         }

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -492,8 +492,6 @@ export class Worker<
     let tokenPostfix = 0;
 
     while ((!this.closing && !this.paused) || asyncFifoQueue.numTotal() > 0) {
-      let numTotal = asyncFifoQueue.numTotal();
-
       /**
        * This inner loop tries to fetch jobs concurrently, but if we are waiting for a job
        * to arrive at the queue we should not try to fetch more jobs (as it would be pointless)
@@ -502,7 +500,7 @@ export class Worker<
         !this.closing &&
         !this.paused &&
         !this.waiting &&
-        numTotal < this._concurrency &&
+        asyncFifoQueue.numTotal() < this._concurrency &&
         !this.isRateLimited()
       ) {
         const token = `${this.id}:${tokenPostfix++}`;
@@ -517,9 +515,7 @@ export class Worker<
         );
         asyncFifoQueue.add(fetchedJob);
 
-        numTotal = asyncFifoQueue.numTotal();
-
-        if (this.waiting && numTotal > 1) {
+        if (this.waiting && asyncFifoQueue.numTotal() > 1) {
           // We are waiting for jobs but we have others that we could start processing already
           break;
         }
@@ -529,7 +525,7 @@ export class Worker<
         const job = await fetchedJob;
 
         // No more jobs waiting but we have others that could start processing already
-        if (!job && numTotal > 1) {
+        if (!job && asyncFifoQueue.numTotal() > 1) {
           break;
         }
 

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -1019,7 +1019,6 @@ will never work with more accuracy than 1ms. */
           if (!doNotWaitActive) {
             await this.whenCurrentJobsFinished();
           }
-          //console.log('here', this.name)
           this.stalledCheckStopper?.();
           this.emit('paused');
         }


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? While pausing or closing a worker, both method wait for pending jobs to be processed before resolving. But we are only taking in count those jobs that are currently active (calling processor method). These jobs that are currently processing can return a new job instance as part of a raise condition where fetch next boolean was set as true when moving these jobs to completed or failed. Job instances being returned will be in active state, so we need to try to process them as well, in these way we are waiting for all jobs (currently processed and pending ones - returned by processors)

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Instead of calling waitAll method that only waits for pending methods that could possible return job instances, just keep looping in main while loop. Our asynchronous queue instance still will execute pending promises in parallel, but we will be able to consume those jobs being returned and apply a processor. At the end we will wait for all pending and processed jobs. Take in count that as soon as a worker is paused or closing, we won't try to fetch new jobs using bzpopmin.

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
fixes https://github.com/taskforcesh/bullmq/issues/3349
