### PR TITLE
fix(repeat): use legacy updateRepeatableJob script when old format is present

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -821,7 +821,7 @@ will never work with more accuracy than 1ms. */
       // Add next scheduled job if necessary.
       if (job.opts.repeat && !job.nextRepeatableJobId) {
         // Use new job scheduler if possible
-        if (job.repeatJobKey) {
+        if (job.repeatJobKey && job.repeatJobKey.split(':').length < 5) {
           const jobScheduler = await this.jobScheduler;
           await jobScheduler.upsertJobScheduler(
             job.repeatJobKey,


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? Legacy format is not respected because is using new job scheduler scripts

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Need to validate repeat key that is having the right format in order to use legacy scripts


### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
Fixes https://github.com/taskforcesh/bullmq/issues/3275