### PR TITLE
fix(job-scheduler): correct parameter for repeatStrategy in nextMillis calculation

### DIFF
--- a/src/classes/job-scheduler.ts
+++ b/src/classes/job-scheduler.ts
@@ -108,7 +108,7 @@ export class JobScheduler extends QueueBase {
         nextMillis = prevSlot;
       }
     } else if (pattern) {
-      nextMillis = await this.repeatStrategy(now, repeatOpts, jobName);
+      nextMillis = await this.repeatStrategy(startMillis, repeatOpts, jobName);
 
       if (nextMillis < now) {
         nextMillis = now;

--- a/tests/test_job_scheduler.ts
+++ b/tests/test_job_scheduler.ts
@@ -689,7 +689,7 @@ describe('Job Scheduler', function () {
     );
     const delayStub = sinon.stub(worker, 'delay').callsFake(async () => {});
 
-    await queue.upsertJobScheduler(
+    const scheduler = await queue.upsertJobScheduler(
       'test',
       {
         pattern: '*/2 * * * * *',
@@ -697,6 +697,9 @@ describe('Job Scheduler', function () {
       },
       { data: { foo: 'bar' } },
     );
+
+    expect(scheduler).to.be.ok;
+    expect(scheduler!.delay).to.be.eq(6000);
 
     this.clock.tick(nextTick + delay);
 


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
This change improves the scheduling logic in `JobScheduler` by ensuring that the next scheduled job time (`nextMillis`) is always set to a valid future time, especially when using cron patterns. Previously, when using a pattern, the `nextMillis` was always calculated using `now`, which would not properly set the next schedule in case the `startDate` was set at some point in the future.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
- Updated the logic in `upsertJobScheduler` to have `nextMillis` use `startMillis` when using a cron `pattern`. `startMillis` will be `now` if the `startDate` is in the past, or the epoch time for `startDate` if it is in the future.

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
- No breaking changes.
- No new dependencies introduced.