### PR TITLE
feat(job): Add moveToWaitingChildren to the wrapper of sandboxed jobs

### DIFF
--- a/src/classes/child-processor.ts
+++ b/src/classes/child-processor.ts
@@ -125,7 +125,7 @@ export class ChildProcessor {
   ): SandboxedJob {
     const wrappedJob = {
       ...job,
-      queueQualifiedName: job.prefix + ':' + job.queueName,
+      queueQualifiedName: job.queueQualifiedName,
       data: JSON.parse(job.data || '{}'),
       opts: job.opts,
       returnValue: JSON.parse(job.returnvalue || '{}'),

--- a/src/classes/child-processor.ts
+++ b/src/classes/child-processor.ts
@@ -174,7 +174,7 @@ export class ChildProcessor {
        * Proxy `moveToWaitingChildren` function.
        */
       moveToWaitingChildren: async (
-        token: string,
+        token?: string,
         opts: MoveToWaitingChildrenOpts = {},
       ): Promise<boolean> => {
         const requestId = Math.random().toString(36).substring(2, 15);

--- a/src/classes/child-processor.ts
+++ b/src/classes/child-processor.ts
@@ -1,5 +1,9 @@
 import { ParentCommand } from '../enums';
-import { SandboxedJob, Receiver } from '../interfaces';
+import {
+  MoveToWaitingChildrenOpts,
+  Receiver,
+  SandboxedJob,
+} from '../interfaces';
 import { JobJsonSandbox, JobProgress } from '../types';
 import { errorToJSON } from '../utils';
 
@@ -121,6 +125,7 @@ export class ChildProcessor {
   ): SandboxedJob {
     const wrappedJob = {
       ...job,
+      queueQualifiedName: job.prefix + ':' + job.queueName,
       data: JSON.parse(job.data || '{}'),
       opts: job.opts,
       returnValue: JSON.parse(job.returnvalue || '{}'),
@@ -164,6 +169,29 @@ export class ChildProcessor {
           value: { token },
         });
       },
+
+      /*
+       * Proxy `moveToWaitingChildren` function.
+       */
+      moveToWaitingChildren: async (
+        token: string,
+        opts: MoveToWaitingChildrenOpts = {},
+      ): Promise<boolean> => {
+        const requestId = Math.random().toString(36).substring(2, 15);
+        await send({
+          requestId,
+          cmd: ParentCommand.MoveToWaitingChildren,
+          value: { token, opts },
+        });
+
+        return waitResponse(
+          requestId,
+          this.receiver,
+          RESPONSE_TIMEOUT,
+          'moveToWaitingChildren',
+        ) as Promise<boolean>;
+      },
+
       /*
        * Proxy `updateData` function.
        */

--- a/src/classes/child-processor.ts
+++ b/src/classes/child-processor.ts
@@ -175,7 +175,7 @@ export class ChildProcessor {
        */
       moveToWaitingChildren: async (
         token?: string,
-        opts: MoveToWaitingChildrenOpts = {},
+        opts?: MoveToWaitingChildrenOpts,
       ): Promise<boolean> => {
         const requestId = Math.random().toString(36).substring(2, 15);
         await send({

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -581,6 +581,7 @@ export class Job<
     return {
       ...this.asJSON(),
       queueName: this.queueName,
+      queueQualifiedName: this.queueQualifiedName,
       prefix: this.prefix,
     };
   }

--- a/src/classes/sandbox.ts
+++ b/src/classes/sandbox.ts
@@ -55,6 +55,19 @@ const sandbox = <T, R, N extends string>(
                   case ParentCommand.MoveToWait:
                     await job.moveToWait(msg.value?.token);
                     break;
+                  case ParentCommand.MoveToWaitingChildren:
+                    {
+                      const value = await job.moveToWaitingChildren(
+                        msg.value?.token,
+                        msg.value?.opts,
+                      );
+                      child.send({
+                        requestId: msg.requestId,
+                        cmd: ChildCommand.MoveToWaitingChildrenResponse,
+                        value,
+                      });
+                    }
+                    break;
                   case ParentCommand.Update:
                     await job.updateData(msg.value);
                     break;

--- a/src/enums/child-command.ts
+++ b/src/enums/child-command.ts
@@ -4,4 +4,5 @@ export enum ChildCommand {
   Stop,
   GetChildrenValuesResponse,
   GetIgnoredChildrenFailuresResponse,
+  MoveToWaitingChildrenResponse,
 }

--- a/src/enums/parent-command.ts
+++ b/src/enums/parent-command.ts
@@ -11,4 +11,5 @@ export enum ParentCommand {
   Update,
   GetChildrenValues,
   GetIgnoredChildrenFailures,
+  MoveToWaitingChildren,
 }

--- a/src/interfaces/sandboxed-job.ts
+++ b/src/interfaces/sandboxed-job.ts
@@ -1,4 +1,5 @@
 import { JobJsonSandbox, JobProgress, JobsOptions } from '../types';
+import { MoveToWaitingChildrenOpts } from './minimal-job';
 
 /**
  * @see {@link https://docs.bullmq.io/guide/workers/sandboxed-processors}
@@ -7,8 +8,13 @@ export interface SandboxedJob<T = any, R = any>
   extends Omit<JobJsonSandbox, 'data' | 'opts' | 'returnValue'> {
   data: T;
   opts: JobsOptions;
+  queueQualifiedName: string;
   moveToDelayed: (timestamp: number, token?: string) => Promise<void>;
   moveToWait: (token?: string) => Promise<void>;
+  moveToWaitingChildren: (
+    token?: string,
+    opts?: MoveToWaitingChildrenOpts,
+  ) => Promise<boolean>;
   log: (row: any) => void;
   updateData: (data: any) => Promise<void>;
   updateProgress: (value: JobProgress) => Promise<void>;

--- a/src/types/job-json-sandbox.ts
+++ b/src/types/job-json-sandbox.ts
@@ -2,5 +2,6 @@ import { JobJson } from '../interfaces';
 
 export type JobJsonSandbox = JobJson & {
   queueName: string;
+  queueQualifiedName: string;
   prefix: string;
 };

--- a/tests/fixtures/fixture_processor_move_to_wait_for_children.js
+++ b/tests/fixtures/fixture_processor_move_to_wait_for_children.js
@@ -1,0 +1,61 @@
+/**
+ * A processor file to be used in tests.
+ *
+ */
+'use strict';
+
+const { WaitingChildrenError, Queue } = require('../../dist/cjs/classes');
+const IORedis = require('ioredis');
+const delay = require('./delay');
+
+const Step = {
+  Initial: 'initial',
+  WaitingChildren: 'waiting-children',
+  Finish: 'finish',
+};
+
+module.exports = async function (job, token) {
+  let step = job.data.step ?? Step.Initial;
+  while (step !== Step.Finish) {
+    switch (step) {
+      case Step.Initial: {
+        await addChildJob(job);
+        step = Step.WaitingChildren;
+        await job.updateData({ ...job.data, step });
+        break;
+      }
+      case Step.WaitingChildren: {
+        const shouldWait = await job.moveToWaitingChildren(token);
+        if (!shouldWait) {
+          step = Step.Finish;
+          await job.updateData({ ...job.data, step });
+          return 'finished';
+        } else {
+          throw new WaitingChildrenError();
+        }
+      }
+      default: {
+        throw new Error('invalid step');
+      }
+    }
+  }
+};
+
+async function addChildJob(job) {
+  const connection = new IORedis(job.data.redisHost, {
+    maxRetriesPerRequest: null,
+  });
+  const queue = new Queue(job.data.queueName, { connection });
+  await queue.add(
+    'child-job',
+    { foo: 'bar' },
+    {
+      parent: {
+        id: job.id,
+        queue: job.queueQualifiedName,
+      },
+    },
+  );
+  await queue.close();
+  await connection.quit();
+}

--- a/tests/fixtures/fixture_processor_move_to_wait_for_children.js
+++ b/tests/fixtures/fixture_processor_move_to_wait_for_children.js
@@ -45,7 +45,10 @@ async function addChildJob(job) {
   const connection = new IORedis(job.data.redisHost, {
     maxRetriesPerRequest: null,
   });
-  const queue = new Queue(job.data.queueName, { connection });
+  const queue = new Queue(job.data.queueName, {
+    connection,
+    prefix: job.prefix,
+  });
   await queue.add(
     'child-job',
     { foo: 'bar' },

--- a/tests/test_sandboxed_process.ts
+++ b/tests/test_sandboxed_process.ts
@@ -1071,11 +1071,6 @@ function sandboxProcessTests(
         },
       );
       const childQueue = new Queue(childQueueName, { connection, prefix });
-      const childQueueEvents = new QueueEvents(childQueueName, {
-        connection,
-        prefix,
-      });
-      await childQueueEvents.waitUntilReady();
 
       const waitingParent = new Promise<void>((resolve, reject) => {
         queueEvents.on('waiting-children', async ({ jobId }) => {
@@ -1122,7 +1117,6 @@ function sandboxProcessTests(
       await parentWorker.close();
       await childWorker.close();
       await childQueue.close();
-      await childQueueEvents.close();
       await removeAllQueueData(new IORedis(redisHost), childQueueName);
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7034,7 +7034,7 @@ tinyglobby@^0.2.12:
     fdir "^6.4.4"
     picomatch "^4.0.2"
 
-tmp@0.2.4, tmp@^0.0.33:
+tmp@0.3.3, tmp@^0.0.33:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.4.tgz#c6db987a2ccc97f812f17137b36af2b6521b0d13"
   integrity sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7034,7 +7034,7 @@ tinyglobby@^0.2.12:
     fdir "^6.4.4"
     picomatch "^4.0.2"
 
-tmp@0.3.3, tmp@^0.0.33:
+tmp@0.2.4, tmp@^0.0.33:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.4.tgz#c6db987a2ccc97f812f17137b36af2b6521b0d13"
   integrity sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==


### PR DESCRIPTION
### Why

Currently it is impossible to implement https://docs.bullmq.io/patterns/process-step-jobs#waiting-children pattern in sandboxed jobs due to:
- missing `moveToWaitingChildren` method
- missing `queueQualifiedName`


### How

This is built on top of #3231, but adds tests following the waiting for children pattern in the linked documentation.
It fixes #3230

1. Added `queueQualifiedName` and `moveToWaitingChildren` to `SandboxedJob`
2. Implemented a unit test