### PR TITLE
docs: update bullmq-pro changelog for version v7.38.4

### DIFF
--- a/docs/gitbook/bullmq-pro/changelog.md
+++ b/docs/gitbook/bullmq-pro/changelog.md
@@ -1,3 +1,13 @@
+## [7.38.4](https://github.com/taskforcesh/bullmq-pro/compare/v7.38.3...v7.38.4) (2025-08-14)
+
+
+### Bug Fixes
+
+* **deps:** upgrade bullmq to v5.56.10 ([#365](https://github.com/taskforcesh/bullmq-pro/issues/365)) ([48937d5](https://github.com/taskforcesh/bullmq-pro/commit/48937d52d6511808b140e58c492f038dd803f088))
+
+
+
+
 ## [7.30.4](https://github.com/taskforcesh/bullmq-pro/compare/v7.30.3...v7.30.4) (2025-03-01)
 
 


### PR DESCRIPTION
Automated update of BullMQ Pro changelog for version v7.38.4

  This PR updates the BullMQ Pro changelog with the latest release notes.