### PR TITLE
chore: refactor lock management into separate class

### DIFF
--- a/src/classes/lock-manager.ts
+++ b/src/classes/lock-manager.ts
@@ -1,0 +1,337 @@
+import { LockManagerOptions } from '../interfaces';
+import { Scripts } from './scripts';
+import { QueueBase } from './queue-base';
+import { SpanKind, TelemetryAttributes } from '../enums';
+import { IoredisListener } from '../interfaces';
+
+export interface LockManagerListener extends IoredisListener {
+  /**
+   * Listen to 'error' event.
+   *
+   * This event is triggered when an error occurs during lock operations.
+   */
+  error: (error: Error) => void;
+
+  /**
+   * Listen to 'lockRenewalFailed' event.
+   *
+   * This event is triggered when lock renewal fails for one or more jobs.
+   */
+  lockRenewalFailed: (jobIds: string[]) => void;
+
+  /**
+   * Listen to 'stalledJobs' event.
+   *
+   * This event is triggered when stalled jobs are detected and moved back to waiting.
+   */
+  stalledJobs: (jobIds: string[]) => void;
+
+  /**
+   * Listen to 'locksRenewed' event.
+   *
+   * This event is triggered when locks are successfully renewed.
+   */
+  locksRenewed: (data: { count: number; jobIds: string[] }) => void;
+}
+
+/**
+ * Manages lock renewal and stalled job detection for BullMQ workers.
+ * This class extracts the lock management logic from the Worker class
+ * to provide a cleaner, more maintainable architecture.
+ */
+export class LockManager extends QueueBase {
+  protected scripts: Scripts;
+  protected lockRenewalTimer?: NodeJS.Timeout;
+  protected stalledJobsTimer?: NodeJS.Timeout;
+
+  // Maps job ids with their timestamps
+  protected trackedJobs = new Map<string, { token: string; ts: number }>();
+  protected closed = false;
+
+  private stalledCheckStopper?: () => void;
+  private paused = false;
+
+  constructor(queueName: string, public opts: LockManagerOptions) {
+    super(queueName, opts);
+  }
+
+  /**
+   * Starts the lock manager timers for lock renewal and stalled job detection.
+   * This replaces the existing timer-based approach in the Worker class.
+   */
+  start(): void {
+    if (this.closed) {
+      return;
+    }
+
+    // Start lock renewal timer if not disabled
+    if (!this.opts.skipLockRenewal && this.opts.lockRenewTime > 0) {
+      this.startLockExtenderTimer();
+    }
+
+    // Start stalled job detection timer if not disabled
+    if (!this.opts.skipStalledCheck && this.opts.stalledInterval > 0) {
+      this.startStalledCheckTimer();
+    }
+  }
+
+  private async stalledChecker() {
+    while (!(this.closing || this.paused)) {
+      try {
+        await this.checkConnectionError(() => this.moveStalledJobsToWait());
+      } catch (err) {
+        this.emit('error', <Error>err);
+      }
+
+      await new Promise<void>(resolve => {
+        const timeout = setTimeout(resolve, this.opts.stalledInterval);
+        this.stalledCheckStopper = () => {
+          clearTimeout(timeout);
+          resolve();
+        };
+      });
+    }
+  }
+
+  protected async extendLocks(jobIds: string[]) {
+    await this.trace<void>(
+      SpanKind.INTERNAL,
+      'extendLocks',
+      this.name,
+      async span => {
+        span?.setAttributes({
+          [TelemetryAttributes.WorkerId]: this.opts.workerId,
+          [TelemetryAttributes.WorkerName]: this.opts.workerName,
+          [TelemetryAttributes.WorkerJobsToExtendLocks]: jobIds,
+        });
+
+        try {
+          const jobTokens = jobIds.map(
+            id => this.trackedJobs.get(id)?.token || '',
+          );
+
+          const erroredJobIds = await this.scripts.extendLocks(
+            jobIds,
+            jobTokens,
+            this.opts.lockDuration,
+          );
+
+          for (const jobId of erroredJobIds) {
+            // TODO: Send signal to process function that the job has been lost.
+
+            this.emit(
+              'error',
+              new Error(`could not renew lock for job ${jobId}`),
+            );
+          }
+        } catch (err) {
+          this.emit('error', <Error>err);
+        }
+      },
+    );
+  }
+
+  private startLockExtenderTimer(): void {
+    if (!this.opts.skipLockRenewal) {
+      clearTimeout(this.lockRenewalTimer);
+
+      if (!this.closed) {
+        this.lockRenewalTimer = setTimeout(async () => {
+          // Get all the jobs whose locks expire in less than 1/2 of the lockRenewTime
+          const now = Date.now();
+          const jobsToExtend: string[] = [];
+
+          for (const jobId of this.trackedJobs.keys()) {
+            const { ts, token } = this.trackedJobs.get(jobId)!;
+            if (!ts) {
+              this.trackedJobs.set(jobId, { token, ts: now });
+              continue;
+            }
+
+            if (ts + this.opts.lockRenewTime / 2 < now) {
+              this.trackedJobs.set(jobId, { token, ts: now });
+              jobsToExtend.push(jobId);
+            }
+          }
+
+          try {
+            if (jobsToExtend.length) {
+              await this.extendLocks(jobsToExtend);
+            }
+          } catch (err) {
+            this.emit('error', <Error>err);
+          }
+
+          this.startLockExtenderTimer();
+        }, this.opts.lockRenewTime / 2);
+      }
+    }
+  }
+
+  async startStalledCheckTimer(): Promise<void> {
+    if (!this.closing) {
+      await this.trace<void>(
+        SpanKind.INTERNAL,
+        'startStalledCheckTimer',
+        this.name,
+        async span => {
+          span?.setAttributes({
+            [TelemetryAttributes.WorkerId]: this.opts.workerId,
+            [TelemetryAttributes.WorkerName]: this.opts.workerName,
+          });
+
+          this.stalledChecker().catch(err => {
+            this.emit('error', <Error>err);
+          });
+        },
+      );
+    }
+  }
+
+  async pauseStalledChecker() {
+    this.paused = true;
+
+    await new Promise<void>(resolve => {
+      const timeout = setTimeout(resolve, this.opts.stalledInterval);
+      this.stalledCheckStopper = () => {
+        clearTimeout(timeout);
+        resolve();
+      };
+    });
+  }
+
+  resumeStalledChecker() {
+    this.paused = false;
+    this.stalledChecker().catch(err => {
+      this.emit('error', <Error>err);
+    });
+  }
+
+  private async moveStalledJobsToWait() {
+    await this.trace<void>(
+      SpanKind.INTERNAL,
+      'moveStalledJobsToWait',
+      this.name,
+      async span => {
+        const stalled = await this.scripts.moveStalledJobsToWait();
+
+        span?.setAttributes({
+          [TelemetryAttributes.WorkerId]: this.opts.workerId,
+          [TelemetryAttributes.WorkerName]: this.opts.name,
+          [TelemetryAttributes.WorkerStalledJobs]: stalled,
+        });
+
+        if (stalled.length > 0) {
+          this.emit('stalledJobs', stalled);
+        }
+      },
+    );
+  }
+
+  /**
+   * Stops the lock manager and clears all timers.
+   */
+  async close(): Promise<void> {
+    this.closing = new Promise(resolve => {
+      if (this.lockRenewalTimer) {
+        clearInterval(this.lockRenewalTimer);
+        this.lockRenewalTimer = undefined;
+      }
+
+      if (this.stalledCheckStopper) {
+        this.stalledCheckStopper();
+      }
+
+      this.trackedJobs.clear();
+
+      resolve();
+    });
+
+    await this.closing;
+  }
+
+  /**
+   * Adds a job to be tracked for lock renewal.
+   */
+  trackJob(jobId: string, token: string, ts: number): void {
+    if (!this.closed && jobId) {
+      this.trackedJobs.set(jobId, { token, ts });
+    }
+  }
+
+  /**
+   * Removes a job from lock renewal tracking.
+   */
+  untrackJob(jobId: string): void {
+    this.trackedJobs.delete(jobId);
+  }
+
+  /**
+   * Renews locks for all active jobs.
+   * This replaces the extendLocks method in the Worker class.
+   */
+  protected async renewLocks(): Promise<void> {
+    if (this.closed || this.trackedJobs.size === 0) {
+      return;
+    }
+
+    const jobIds = Array.from(this.trackedJobs.keys());
+    const renewedJobIds: string[] = [];
+    const failedJobIds: string[] = [];
+
+    // Renew locks for all jobs
+    for (const id of jobIds) {
+      if (!id) {continue;}
+
+      try {
+        const result = await this.scripts.extendLock(
+          id,
+          this.opts.workerId,
+          this.opts.lockDuration,
+        );
+
+        if (result === 1) {
+          renewedJobIds.push(id);
+        } else {
+          failedJobIds.push(id);
+          // Remove job from tracking if lock renewal failed
+          this.untrackJob(id);
+        }
+      } catch (error) {
+        failedJobIds.push(id);
+        // Remove job from tracking if lock renewal failed
+        this.untrackJob(id);
+      }
+    }
+
+    // Emit events for monitoring
+    if (renewedJobIds.length > 0) {
+      this.emit('locksRenewed', {
+        count: renewedJobIds.length,
+        jobIds: renewedJobIds,
+      });
+    }
+
+    if (failedJobIds.length > 0) {
+      this.emit('lockRenewalFailed', failedJobIds);
+    }
+  }
+
+  /**
+   * Gets the number of jobs currently being tracked.
+   */
+  getActiveJobCount(): number {
+    return this.trackedJobs.size;
+  }
+
+  /**
+   * Checks if the lock manager is running.
+   */
+  isRunning(): boolean {
+    return (
+      !this.closed &&
+      (this.lockRenewalTimer !== undefined ||
+        this.stalledJobsTimer !== undefined)
+    );
+  }
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -27,3 +27,4 @@ export * from './sandboxed-options';
 export * from './worker-options';
 export * from './telemetry';
 export * from './receiver';
+export * from './lock-manager-options';

--- a/src/interfaces/lock-manager-options.ts
+++ b/src/interfaces/lock-manager-options.ts
@@ -1,0 +1,6 @@
+import { WorkerOptions } from './worker-options';
+
+export interface LockManagerOptions extends WorkerOptions {
+  workerId: string;
+  workerName: string;
+}

--- a/src/interfaces/worker-options.ts
+++ b/src/interfaces/worker-options.ts
@@ -146,6 +146,18 @@ export interface WorkerOptions extends QueueBaseOptions, SandboxedOptions {
   useWorkerThreads?: boolean;
 
   /**
+   * Use a dedicated worker thread for lock renewal and stalled job detection.
+   * This prevents long-running jobs from blocking critical lock management operations.
+   * When enabled, lock renewal and stalled job checking will run in a separate thread
+   * from the main job processing.
+   *
+   * Note: This feature requires Node.js worker_threads support.
+   *
+   * @defaultValue false
+   */
+  useDedicatedLockThread?: boolean;
+
+  /**
    * Telemetry Addon
    */
   telemetry?: Telemetry;

--- a/tests/test_lock_manager.ts
+++ b/tests/test_lock_manager.ts
@@ -1,0 +1,242 @@
+import { Queue, Worker } from '../src/classes';
+import { delay, removeAllQueueData } from '../src/utils';
+import { default as IORedis } from 'ioredis';
+import { beforeEach, describe, it, before, after as afterAll } from 'mocha';
+import { v4 } from 'uuid';
+import { expect } from 'chai';
+
+describe('Lock Manager', function () {
+  const redisHost = process.env.REDIS_HOST || 'localhost';
+  const prefix = process.env.BULLMQ_TEST_PREFIX || 'bull';
+  let queue: Queue;
+  let queueName: string;
+  let connection: IORedis;
+
+  before(async function () {
+    connection = new IORedis(redisHost, { maxRetriesPerRequest: null });
+  });
+
+  beforeEach(async function () {
+    queueName = `test-${v4()}`;
+    queue = new Queue(queueName, { connection, prefix });
+  });
+
+  afterEach(async function () {
+    await queue.close();
+    await removeAllQueueData(new IORedis(redisHost), queueName);
+  });
+
+  afterAll(async function () {
+    await connection.quit();
+  });
+
+  describe('Sharing worker thread', function () {
+    it('should use lock manager for basic job processing', async function () {
+      this.timeout(3000);
+
+      let completedJobs = 0;
+
+      const worker = new Worker(
+        queueName,
+        async job => {
+          await delay(10);
+          return { success: true, id: job.id };
+        },
+        {
+          connection,
+          prefix,
+          lockDuration: 500,
+          lockRenewTime: 200,
+        },
+      );
+
+      worker.on('completed', () => {
+        completedJobs++;
+      });
+
+      await worker.waitUntilReady();
+
+      // Add a job first to trigger worker main loop
+      const job = await queue.add('test-job', { data: 'test' });
+
+      // Give some time for the worker to start
+      await delay(100);
+
+      // Check that lock manager is initialized
+      expect(worker.isLockManagerRunning()).to.be.true;
+
+      // Wait for completion
+      await delay(500);
+
+      expect(completedJobs).to.equal(1);
+
+      await worker.close();
+    });
+
+    it('should handle job tracking correctly', async function () {
+      this.timeout(3000);
+
+      let jobsProcessed = 0;
+      const jobProcessingTimes: number[] = [];
+
+      const worker = new Worker(
+        queueName,
+        async job => {
+          const start = Date.now();
+          await delay(50); // Simulate some work
+          jobProcessingTimes.push(Date.now() - start);
+          jobsProcessed++;
+          return { success: true };
+        },
+        {
+          connection,
+          prefix,
+          lockDuration: 500,
+          lockRenewTime: 200,
+        },
+      );
+
+      await worker.waitUntilReady();
+
+      // Add multiple jobs
+      const promises: any[] = [];
+      for (let i = 0; i < 3; i++) {
+        promises.push(queue.add(`job-${i}`, { index: i }));
+      }
+      await Promise.all(promises);
+
+      // Wait for all jobs to complete
+      await delay(1000);
+
+      expect(jobsProcessed).to.equal(3);
+      expect(worker['lockManager']?.getActiveJobCount()).to.equal(0); // All jobs should be removed after completion
+
+      await worker.close();
+    });
+
+    it('should handle concurrent jobs with lock management', async function () {
+      this.timeout(3000);
+
+      let completedJobs = 0;
+
+      const worker = new Worker(
+        queueName,
+        async job => {
+          // Variable processing time
+          const processingTime = 20 + Math.random() * 30;
+          await delay(processingTime);
+          return { success: true, processingTime };
+        },
+        {
+          connection,
+          prefix,
+          concurrency: 3, // Process multiple jobs concurrently
+          lockDuration: 500,
+          lockRenewTime: 200,
+        },
+      );
+
+      worker.on('completed', () => {
+        completedJobs++;
+      });
+
+      await worker.waitUntilReady();
+
+      // Add multiple jobs
+      const jobCount = 6;
+      for (let i = 0; i < jobCount; i++) {
+        await queue.add(`concurrent-job-${i}`, { index: i });
+      }
+
+      // Wait for completion
+      await delay(1000);
+
+      expect(completedJobs).to.equal(jobCount);
+
+      await worker.close();
+    });
+
+    it('should handle errors gracefully', async function () {
+      this.timeout(3000);
+
+      let completedJobs = 0;
+      let failedJobs = 0;
+      const errors: Error[] = [];
+
+      const worker = new Worker(
+        queueName,
+        async job => {
+          if (job.data.shouldFail) {
+            throw new Error('Intentional failure');
+          }
+          await delay(10);
+          return { success: true };
+        },
+        {
+          connection,
+          prefix,
+          lockDuration: 500,
+          lockRenewTime: 200,
+        },
+      );
+
+      worker.on('completed', () => {
+        completedJobs++;
+      });
+
+      worker.on('failed', () => {
+        failedJobs++;
+      });
+
+      worker.on('error', error => {
+        errors.push(error);
+      });
+
+      await worker.waitUntilReady();
+
+      // Add mix of successful and failing jobs
+      await queue.add('success-1', { shouldFail: false });
+      await queue.add('fail-1', { shouldFail: true });
+      await queue.add('success-2', { shouldFail: false });
+
+      await delay(500);
+
+      expect(completedJobs).to.be.greaterThan(0);
+      expect(failedJobs).to.be.greaterThan(0);
+
+      await worker.close();
+    });
+
+    it('should properly clean up resources', async function () {
+      this.timeout(2000);
+
+      const worker = new Worker(
+        queueName,
+        async job => {
+          await delay(10);
+          return { success: true };
+        },
+        {
+          connection,
+          prefix,
+          lockDuration: 500,
+          lockRenewTime: 200,
+        },
+      );
+
+      await worker.waitUntilReady();
+
+      // Add a dummy job to start the lock manager
+      await queue.add('test-job', { data: 'test' });
+      await delay(100);
+
+      // Verify lock manager is running
+      expect(worker.isLockManagerRunning()).to.be.true;
+
+      await worker.close();
+
+      // Verify lock manager is stopped
+      expect(worker.isLockManagerRunning()).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
This PR aims to provide a new option when instantiating Workers, so that it is possible to use a dedicated thread for lock extension and job stalling detection. The reason for allowing this, is so that we can have a safer lock renewal mechanism even in the cases where the jobs are not respecting the best practice of not keeping the event loop busy for long periods of time.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
We refactor the lock handling in a separate class "LockManager" and then we add support to this class to run in a separate thread that communicates with the main process. Note that this approach is not a fail proof solution to the issue of jobs that keep the event loop busy, as it could also happen that the communication between the main thread and the lock extension thread stalls and issues related to locks may still happen, however it should reduce the number of cases when this happens.

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
