### PR TITLE
fix(job): prevent unnecessary tryCatch calls in getTraces

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -1499,7 +1499,11 @@ export class Job<
   }
 }
 
-function getTraces(stacktrace: string[]) {
+function getTraces(stacktrace?: string) {
+  if (!stacktrace) {
+    return [];
+  }
+
   const traces = tryCatch(JSON.parse, JSON, [stacktrace]);
 
   if (traces === errorObject || !(traces instanceof Array)) {

--- a/src/interfaces/job-json.ts
+++ b/src/interfaces/job-json.ts
@@ -38,7 +38,7 @@ export interface JobJsonRaw {
   priority: string;
   timestamp: string;
   failedReason: string;
-  stacktrace: string[];
+  stacktrace?: string;
   returnvalue: string;
   parentKey?: string;
   parent?: string;

--- a/tests/test_job.ts
+++ b/tests/test_job.ts
@@ -676,7 +676,7 @@ describe('Job', function () {
       const data = { foo: 'bar' };
       const parent = await Job.create(parentQueue, 'testParent', data);
       const parentKey = getParentKey({
-        id: parent.id,
+        id: parent.id!,
         queue: `${prefix}:${parentQueueName}`,
       });
       const client = await queue.client;
@@ -687,7 +687,7 @@ describe('Job', function () {
       });
       await Job.create(queue, 'testJob2', values[1], {
         parent: {
-          id: parent.id,
+          id: parent.id!,
           queue: `${prefix}:${parentQueueName}`,
         },
       });
@@ -1693,7 +1693,7 @@ describe('Job', function () {
         const completed = new Promise<void>((resolve, reject) => {
           worker.on('completed', async (job: Job) => {
             try {
-              const gotJob = await queue.getJob(job.id);
+              const gotJob = await queue.getJob(job.id!);
               expect(gotJob).to.be.equal(undefined);
               const counts = await queue.getJobCounts('completed');
               expect(counts.completed).to.be.equal(0);
@@ -1713,7 +1713,7 @@ describe('Job', function () {
         await completed;
 
         await expect(job.waitUntilFinished(queueEvents)).to.be.rejectedWith(
-          `Missing key for job ${queue.toKey(job.id)}. isFinished`,
+          `Missing key for job ${queue.toKey(job.id!)}. isFinished`,
         );
 
         await worker.close();


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? stacktrace is undefined at first iterations and when it's being retrieved by Redis is a plain string. No need to execute tryCatch but return an empty string in this case

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
