### PR TITLE
fix(worker): add missing processor type export

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,4 +6,5 @@ export * from './job-options';
 export * from './job-scheduler-template-options';
 export * from './job-type';
 export * from './job-progress';
+export * from './processor';
 export * from './repeat-strategy';


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->

Started getting the following error:

> error TS2694: Namespace '"/node_modules/bullmq/dist/esm/index"' has no exported member 'Processor'.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->

Added missing processor type export to the types index

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->

