### PR TITLE
fix(queue.ts): preserve Job type inference when no explicit type for JobBase

### DIFF
--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -90,8 +90,8 @@ export interface QueueListener<JobBase extends Job = Job>
 
 /**
  * IsAny<T> A type helper to determine if a given type `T` is `any`.
- * This works by uing `any` type with the intersection
- * operator (`&`). If `T` Ifis `any`, then `1 & T` resolves to `any`, and since `0`
+ * This works by using `any` type with the intersection
+ * operator (`&`). If `T` is `any`, then `1 & T` resolves to `any`, and since `0`
  * is assignable to `any`, the conditional type returns `true`.
  */
 type IsAny<T> = 0 extends 1 & T ? true : false;

--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -88,7 +88,12 @@ export interface QueueListener<JobBase extends Job = Job>
   waiting: (job: JobBase) => void;
 }
 
-// Helper to check if a type is 'any'
+/**
+ * IsAny<T> A type helper to determine if a given type `T` is `any`.
+ * This works by uing `any` type with the intersection
+ * operator (`&`). If `T` Ifis `any`, then `1 & T` resolves to `any`, and since `0`
+ * is assignable to `any`, the conditional type returns `true`.
+ */
 type IsAny<T> = 0 extends 1 & T ? true : false;
 // Helper for JobBase type
 type JobBase<T, ResultType, NameType extends string> = IsAny<T> extends true

--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -88,12 +88,12 @@ export interface QueueListener<JobBase extends Job = Job>
   waiting: (job: JobBase) => void;
 }
 
+// Helper to check if a type is 'any'
+type IsAny<T> = 0 extends 1 & T ? true : false;
 // Helper for JobBase type
-type JobBase<T, ResultType, NameType extends string> = T extends Job<
-  any,
-  any,
-  any
->
+type JobBase<T, ResultType, NameType extends string> = IsAny<T> extends true
+  ? Job<T, ResultType, NameType>
+  : T extends Job<any, any, any>
   ? T
   : Job<T, ResultType, NameType>;
 

--- a/tests/test_queue.ts
+++ b/tests/test_queue.ts
@@ -50,6 +50,17 @@ describe('queues', function () {
       expect(job2?.data.bar).to.be.eql(1);
       await queue.close();
     });
+
+    it('should resolve Job<any, any, string> when no generics provided', async function () {
+      const defaultQueue = new Queue(queueName, { prefix, connection });
+
+      await defaultQueue.add('test-job', { foo: 'bar', num: 123 });
+      const jobs = await defaultQueue.getJobs(['waiting']);
+      expect(jobs).to.be.an('array');
+      expect(jobs.length).to.be.at.least(1);
+      expect(jobs[0]).to.be.instanceOf(Job);
+      await defaultQueue.close();
+    });
   });
 
   it('should return the queue version', async () => {


### PR DESCRIPTION
Fixed by simplifying JobBase to always wrap data types in Job instances

<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
When T = any (default), TypeScript couldn't reliably resolve this to Job<any, any, string>.
```typescript
type JobBase<T, ResultType, NameType extends string> = T extends Job<any, any, any>
  ? T
  : Job<T, ResultType, NameType>;
```
since `any extends Job<any, any, any>` would always true.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->

Add a check if user T is any, fall back to the Job<any, any, string>


