### PR TITLE
fix(events): set prev param as active when calling retryJob script

### DIFF
--- a/src/commands/retryJob-11.lua
+++ b/src/commands/retryJob-11.lua
@@ -80,7 +80,7 @@ if rcall("EXISTS", jobKey) == 1 then
 
   -- Emit waiting event
   rcall("XADD", KEYS[6], "MAXLEN", "~", maxEvents, "*", "event", "waiting",
-    "jobId", ARGV[4], "prev", "failed")
+    "jobId", ARGV[4], "prev", "active")
 
   return 0
 else

--- a/tests/test_worker.ts
+++ b/tests/test_worker.ts
@@ -3290,6 +3290,9 @@ describe('workers', function () {
         worker.on('completed', () => {
           reject(new Error('Failed job was retried more than it should be!'));
         });
+        queueEvents.on('waiting', async ({ prev }) => {
+          expect(prev).to.eql('active');
+        });
         queueEvents.on('retries-exhausted', async ({ jobId, attemptsMade }) => {
           expect(jobId).to.eql(job.id);
           expect(3).to.eql(Number(attemptsMade));


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? RetryJob script is called when a job is active, so prev value should reflect that and not failed state

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
