### PR TITLE
docs: update bullmq-pro changelog for version v7.38.5

### DIFF
--- a/docs/gitbook/bullmq-pro/changelog.md
+++ b/docs/gitbook/bullmq-pro/changelog.md
@@ -1,3 +1,13 @@
+## [7.38.5](https://github.com/taskforcesh/bullmq-pro/compare/v7.38.4...v7.38.5) (2025-09-05)
+
+
+### Bug Fixes
+
+* **includes:** replace missing base includes with pro ([#368](https://github.com/taskforcesh/bullmq-pro/issues/368)) ([e51bb10](https://github.com/taskforcesh/bullmq-pro/commit/e51bb100d02cf420480f97420b9d49fe3086d358))
+
+
+
+
 ## [7.38.4](https://github.com/taskforcesh/bullmq-pro/compare/v7.38.3...v7.38.4) (2025-08-14)
 
 


### PR DESCRIPTION
Automated update of BullMQ Pro changelog for version v7.38.5

  This PR updates the BullMQ Pro changelog with the latest release notes.