### PR TITLE
fix(retry): reset attemptsMade and attemptsStarted (python)

### DIFF
--- a/src/commands/reprocessJob-8.lua
+++ b/src/commands/reprocessJob-8.lua
@@ -32,7 +32,7 @@ local jobKey = KEYS[1]
 if rcall("EXISTS", jobKey) == 1 then
   local jobId = ARGV[1]
   if (rcall("ZREM", KEYS[3], jobId) == 1) then
-    rcall("HDEL", jobKey, "finishedOn", "processedOn", ARGV[3])
+    rcall("HDEL", jobKey, "finishedOn", "processedOn", "atm", "ats", ARGV[3])
 
     local target, isPausedOrMaxed = getTargetQueueList(KEYS[5], KEYS[7], KEYS[4], KEYS[6])
     addJobInTargetList(target, KEYS[8], ARGV[2], isPausedOrMaxed, jobId)

--- a/src/interfaces/worker-options.ts
+++ b/src/interfaces/worker-options.ts
@@ -73,20 +73,20 @@ export interface WorkerOptions extends QueueBaseOptions, SandboxedOptions {
   removeOnFail?: KeepJobs;
 
   /**
-   *  Skip stalled check for this worker. Note that other workers could still
-   *  perform stalled checkd and move jobs back to wait for jobs being processed
-   *  by this worker.
+   * Skip stalled check for this worker. Note that other workers could still
+   * perform stalled checkd and move jobs back to wait for jobs being processed
+   * by this worker.
    *
-   *  @defaultValue false
+   * @defaultValue false
    */
   skipStalledCheck?: boolean;
 
   /**
-   *  Skip lock renewal for this worker. If set to true, the lock will expire
-   *  after lockDuration and moved back to the wait queue (if the stalled check is
-   *  not disabled)
+   * Skip lock renewal for this worker. If set to true, the lock will expire
+   * after lockDuration and moved back to the wait queue (if the stalled check is
+   * not disabled)
    *
-   *  @defaultValue false
+   * @defaultValue false
    */
   skipLockRenewal?: boolean;
 


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 

  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? When retrying a job, attempsMade used for backoff strategy was not reseted or attemptsStarted

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
