### PR TITLE
fix(deduplication): validate id option is provided

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -1475,6 +1475,19 @@ export class Job<
       }
     }
 
+    if (this.opts.deduplication) {
+      if (!this.opts.deduplication?.id) {
+        throw new Error('Deduplication id must be provided');
+      }
+    }
+
+    // TODO: remove in v6
+    if (this.opts.debounce) {
+      if (!this.opts.debounce?.id) {
+        throw new Error('Debounce id must be provided');
+      }
+    }
+
     if (
       typeof this.opts.backoff === 'object' &&
       typeof this.opts.backoff.jitter === 'number'

--- a/tests/test_deduplication.ts
+++ b/tests/test_deduplication.ts
@@ -310,6 +310,7 @@ describe('deduplication', function () {
   describe('when job is deduplicated when added again with same debounce id', function () {
     it('emits deduplicated event', async function () {
       const testName = 'test';
+      const dedupId = 'dedupId';
       const worker = new Worker(
         queueName,
         async () => {
@@ -325,7 +326,7 @@ describe('deduplication', function () {
           ({ jobId, deduplicationId, deduplicatedJobId }) => {
             try {
               expect(jobId).to.be.equal('a1');
-              expect(deduplicationId).to.be.equal('dedupKey');
+              expect(deduplicationId).to.be.equal(dedupId);
               expect(deduplicatedJobId).to.be.equal('a2');
               resolve();
             } catch (error) {
@@ -335,15 +336,15 @@ describe('deduplication', function () {
         );
       });
 
-      const firstJob = await queue.add(
+      await queue.add(
         testName,
         { foo: 'bar' },
-        { jobId: 'a1', deduplication: { id: 'dedupKey' } },
+        { jobId: 'a1', deduplication: { id: dedupId } },
       );
-      const secondJob = await queue.add(
+      await queue.add(
         testName,
         { foo: 'bar' },
-        { jobId: 'a2', deduplication: { id: 'dedupKey' } },
+        { jobId: 'a2', deduplication: { id: dedupId } },
       );
 
       await waitingEvent;

--- a/tests/test_job.ts
+++ b/tests/test_job.ts
@@ -198,6 +198,26 @@ describe('Job', function () {
       });
     });
 
+    describe('when deduplication id option is provided as empty string', () => {
+      it('throws an error', async () => {
+        const data = { foo: 'bar' };
+        const opts = { deduplication: { id: '' } };
+        await expect(Job.create(queue, 'test', data, opts)).to.be.rejectedWith(
+          'Deduplication id must be provided',
+        );
+      });
+    });
+
+    describe('when debounce id option is provided as empty string', () => {
+      it('throws an error', async () => {
+        const data = { foo: 'bar' };
+        const opts = { debounce: { id: '' } };
+        await expect(Job.create(queue, 'test', data, opts)).to.be.rejectedWith(
+          'Debounce id must be provided',
+        );
+      });
+    });
+
     describe('when jitter backoff option is provided with a value lesser than 0', () => {
       it('throws an error', async () => {
         const data = { foo: 'bar' };


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? It's failing to use an invalid value of deduplication/debounce id

### How
<!--
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
  1. How did you implement this? Add new validation for deduplication/debounce id to validate that is present

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
fixes https://github.com/taskforcesh/bullmq/issues/3432