### PR TITLE
fix(scheduler): throw error when duplicated job being generated in addJobScheduler

### DIFF
--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -400,7 +400,20 @@ export class Scripts {
       producerId ? this.queue.toKey(producerId) : '',
     ];
 
-    return this.execCommand(client, 'addJobScheduler', keys.concat(args));
+    const result = await this.execCommand(
+      client,
+      'addJobScheduler',
+      keys.concat(args),
+    );
+
+    if (result < 0) {
+      throw this.finishedErrors({
+        code: result,
+        command: 'addJobScheduler',
+      });
+    }
+
+    return result;
   }
 
   async updateRepeatableJobMillis(
@@ -1709,6 +1722,10 @@ export class Scripts {
       case ErrorCode.JobHasFailedChildren:
         return new UnrecoverableError(
           `Cannot complete job ${jobId} because it has at least one failed child. ${command}`,
+        );
+      case ErrorCode.JobSchedulerCannotBeAdded:
+        return new Error(
+          `Cannot add job scheduler while job already existed and it is not in delayed state. ${command}`,
         );
       default:
         return new Error(`Unknown code ${code} error for ${jobId}. ${command}`);

--- a/src/commands/addJobScheduler-11.lua
+++ b/src/commands/addJobScheduler-11.lua
@@ -88,10 +88,7 @@ end
 if rcall("EXISTS", nextDelayedJobKey) == 1 then
     if not removeJobFromScheduler(prefixKey, delayedKey, prioritizedKey, waitKey, pausedKey,
         nextDelayedJobId, metaKey, eventsKey) then
-        rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event",
-            "duplicated", "jobId", nextDelayedJobId)
-
-        return nextDelayedJobId .. "" -- convert to string
+        return -10
     end
 end
 

--- a/src/enums/error-code.ts
+++ b/src/enums/error-code.ts
@@ -8,4 +8,5 @@ export enum ErrorCode {
   ParentJobCannotBeReplaced = -7,
   JobBelongsToJobScheduler = -8,
   JobHasFailedChildren = -9,
+  JobSchedulerCannotBeAdded = -10,
 }

--- a/tests/test_job_scheduler.ts
+++ b/tests/test_job_scheduler.ts
@@ -251,7 +251,7 @@ describe('Job Scheduler', function () {
 
     describe('when next delayed job already exists and it is not in waiting or delayed states', function () {
       describe('when job scheduler is being added', function () {
-        describe('when using pattern', function () {
+        describe('when using every', function () {
           it('emits duplicated event and does not update scheduler', async function () {
             const date = new Date('2017-02-07T09:24:00.000+05:30');
             this.clock.setSystemTime(date);

--- a/tests/test_job_scheduler.ts
+++ b/tests/test_job_scheduler.ts
@@ -250,49 +250,110 @@ describe('Job Scheduler', function () {
     });
 
     describe('when next delayed job already exists and it is not in waiting or delayed states', function () {
-      it('emits duplicated event and does not update scheduler', async function () {
-        const date = new Date('2017-02-07T09:24:00.000+05:30');
-        this.clock.setSystemTime(date);
-        const worker = new Worker(queueName, void 0, { connection, prefix });
-        const token = 'my-token';
+      describe('when job scheduler is being added', function () {
+        describe('when using pattern', function () {
+          it('emits duplicated event and does not update scheduler', async function () {
+            const date = new Date('2017-02-07T09:24:00.000+05:30');
+            this.clock.setSystemTime(date);
+            const worker = new Worker(queueName, void 0, {
+              connection,
+              prefix,
+            });
+            const token = 'my-token';
 
-        await worker.waitUntilReady();
+            await worker.waitUntilReady();
 
-        const jobSchedulerId = 'test';
-        await queue.upsertJobScheduler(jobSchedulerId, {
-          every: ONE_MINUTE * 1,
-        });
+            const jobSchedulerId = 'test';
+            await queue.upsertJobScheduler(jobSchedulerId, {
+              every: ONE_MINUTE * 1,
+            });
 
-        const duplicating = new Promise<void>(resolve => {
-          queueEvents.once('duplicated', () => {
-            resolve();
+            const duplicating = new Promise<void>(resolve => {
+              queueEvents.once('duplicated', () => {
+                resolve();
+              });
+            });
+
+            (await worker.getNextJob(token)) as Job;
+
+            await queue.upsertJobScheduler(jobSchedulerId, {
+              every: ONE_MINUTE * 2,
+            });
+
+            await duplicating;
+
+            const repeatableJobs = await queue.getJobSchedulers();
+            expect(repeatableJobs.length).to.be.eql(1);
+
+            expect(repeatableJobs[0]).to.deep.equal({
+              key: 'test',
+              name: 'test',
+              next: 1486439700000,
+              iterationCount: 2,
+              every: 60000,
+              offset: 0,
+            });
+
+            const count = await queue.getJobCountByTypes('delayed');
+            expect(count).to.be.equal(1);
+
+            await worker.close();
           });
         });
 
-        (await worker.getNextJob(token)) as Job;
+        describe('when using pattern', function () {
+          it('emits duplicated event and does not update scheduler', async function () {
+            const date = new Date('2017-02-07T09:24:00.000+05:30');
+            this.clock.setSystemTime(date);
+            const worker = new Worker(queueName, void 0, {
+              connection,
+              prefix,
+            });
+            const token = 'my-token';
 
-        await queue.upsertJobScheduler(jobSchedulerId, {
-          every: ONE_MINUTE * 2,
+            await worker.waitUntilReady();
+
+            const jobSchedulerId = 'test';
+            const job = await queue.upsertJobScheduler(jobSchedulerId, {
+              pattern: '*/2 * * * * *',
+            });
+
+            const duplicating = new Promise<void>(resolve => {
+              queueEvents.once('duplicated', () => {
+                resolve();
+              });
+            });
+            await job!.promote();
+
+            (await worker.getNextJob(token)) as Job;
+
+            await queue.upsertJobScheduler(
+              jobSchedulerId,
+              {
+                pattern: '*/2 * * * * *',
+              },
+              { data: { foo: 'bar' } },
+            );
+
+            await duplicating;
+
+            const repeatableJobs = await queue.getJobSchedulers();
+            expect(repeatableJobs.length).to.be.eql(1);
+
+            expect(repeatableJobs[0]).to.deep.equal({
+              key: 'test',
+              name: 'test',
+              next: 1486439644000,
+              iterationCount: 2,
+              pattern: '*/2 * * * * *',
+            });
+
+            const count = await queue.getJobCountByTypes('delayed');
+            expect(count).to.be.equal(1);
+
+            await worker.close();
+          });
         });
-
-        await duplicating;
-
-        const repeatableJobs = await queue.getJobSchedulers();
-        expect(repeatableJobs.length).to.be.eql(1);
-
-        expect(repeatableJobs[0]).to.deep.equal({
-          key: 'test',
-          name: 'test',
-          next: 1486439700000,
-          iterationCount: 2,
-          every: 60000,
-          offset: 0,
-        });
-
-        const count = await queue.getJobCountByTypes('delayed');
-        expect(count).to.be.equal(1);
-
-        await worker.close();
       });
 
       describe('when job scheduler is being updated', function () {

--- a/tests/test_job_scheduler.ts
+++ b/tests/test_job_scheduler.ts
@@ -314,16 +314,19 @@ describe('Job Scheduler', function () {
             await worker.waitUntilReady();
 
             const jobSchedulerId = 'test';
-            const job = await queue.upsertJobScheduler(jobSchedulerId, {
-              pattern: '*/2 * * * * *',
-            });
+            const schedulerJob = await queue.upsertJobScheduler(
+              jobSchedulerId,
+              {
+                pattern: '*/2 * * * * *',
+              },
+            );
 
             const duplicating = new Promise<void>(resolve => {
               queueEvents.once('duplicated', () => {
                 resolve();
               });
             });
-            await job!.promote();
+            await schedulerJob!.promote();
 
             (await worker.getNextJob(token)) as Job;
 


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 

  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? Cover duplicated event being triggered when using pattern in schedulers

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
