### PR TITLE
docs: update bullmq-pro changelog for version v7.39.0

### DIFF
--- a/docs/gitbook/bullmq-pro/changelog.md
+++ b/docs/gitbook/bullmq-pro/changelog.md
@@ -1,3 +1,13 @@
+# [7.39.0](https://github.com/taskforcesh/bullmq-pro/compare/v7.38.5...v7.39.0) (2025-09-18)
+
+
+### Features
+
+* **deps:** upgrade bullmq to v5.58.5 ([#372](https://github.com/taskforcesh/bullmq-pro/issues/372)) ([c9645c5](https://github.com/taskforcesh/bullmq-pro/commit/c9645c53ec7ad49a7e9456e4fc6204c209acff2c))
+
+
+
+
 ## [7.38.5](https://github.com/taskforcesh/bullmq-pro/compare/v7.38.4...v7.38.5) (2025-09-05)
 
 


### PR DESCRIPTION
Automated update of BullMQ Pro changelog for version v7.39.0

  This PR updates the BullMQ Pro changelog with the latest release notes.