### PR TITLE
fixed typo in queue obliterate jsdoc comment

### DIFF
--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -937,7 +937,7 @@ export class Queue<
 
   /**
    * Completely destroys the queue and all of its contents irreversibly.
-   * This method will the *pause* the queue and requires that there are no
+   * This method will *pause* the queue and requires that there are no
    * active jobs. It is possible to bypass this requirement, i.e. not
    * having active jobs using the "force" option.
    *


### PR DESCRIPTION
### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
The typo could have caused confusion, at least at first glance (I had to do a double take while reading it because it tripped me up). The description of `obliterate` is now a bit clearer on first read.

### How
<!--
  1. How did you implement this?
  4. Outline the approach or steps taken.
  5. List any resources or documentation that helped you.
-->
It's a very, very simple change - just a typo fix.
