### PR TITLE
docs: update bullmq-pro changelog for version v7.39.1

### DIFF
--- a/docs/gitbook/bullmq-pro/changelog.md
+++ b/docs/gitbook/bullmq-pro/changelog.md
@@ -1,3 +1,13 @@
+## [7.39.1](https://github.com/taskforcesh/bullmq-pro/compare/v7.39.0...v7.39.1) (2025-09-20)
+
+
+### Bug Fixes
+
+* **scripts:** detect missing transformed scripts ([#371](https://github.com/taskforcesh/bullmq-pro/issues/371)) ([006b394](https://github.com/taskforcesh/bullmq-pro/commit/006b3948928eab365c17bd6adac57c2f17fd1f75))
+
+
+
+
 # [7.39.0](https://github.com/taskforcesh/bullmq-pro/compare/v7.38.5...v7.39.0) (2025-09-18)
 
 


### PR DESCRIPTION
Automated update of BullMQ Pro changelog for version v7.39.1

  This PR updates the BullMQ Pro changelog with the latest release notes.