### PR TITLE
feat(queue): emit 'removed' event when removing jobs via queue.remove()

### DIFF
--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -804,7 +804,14 @@ export class Queue<
           }),
         });
 
-        return await this.scripts.remove(jobId, removeChildren);
+        const job = await this.getJob(jobId);
+        const result = await this.scripts.remove(jobId, removeChildren);
+
+        if (result === 1 && job) {
+          this.emit('removed', job as JobBase<DataType, ResultType, NameType>);
+        }
+
+        return result;
       },
     );
   }

--- a/tests/test_queue.ts
+++ b/tests/test_queue.ts
@@ -451,6 +451,24 @@ describe('queues', function () {
     });
   });
 
+  describe('.remove', () => {
+    it.only('should emit "removed" event when a job is removed via queue.remove()', async () => {
+      await queue.waitUntilReady();
+
+      const job = await queue.add('test-job', { foo: 'bar' });
+
+      const removedPromise = new Promise<Job>(resolve => {
+        queue.on('removed', job => resolve(job));
+      });
+
+      const result = await queue.remove(job.id!);
+      expect(result).to.equal(1);
+
+      const removedJob = await removedPromise;
+      expect(removedJob.id).to.equal(job.id);
+    });
+  });
+
   describe('.removeDeprecatedPriorityKey', () => {
     it('removes old priority key', async () => {
       const client = await queue.client;


### PR DESCRIPTION
### Why
- `queue.remove(jobId)` did not emit the `'removed'` event, unlike `job.remove()`.
- This caused inconsistencies:
  - `QueueEvents` listeners never received a `'removed'` notification.
  - Removed job IDs stayed in cache, making reusing job IDs trigger a `'duplicated'` event instead of `'added'`.
- Fixes [#2668](https://github.com/taskforcesh/bullmq/issues/2668).

### How
- Updated `Queue.remove()` to:
  - Retrieve the job before removal.
  - Call `this.emit('removed', job)` when removal succeeds (`result === 1`).
- Added a new test in `test_queue.ts` to verify:
  - Calling `queue.remove(jobId)` emits the `'removed'` event.
  - The emitted job matches the removed job.
- This mirrors the behavior of `Job.remove()`, keeping API consistency.

### Additional Notes
- Scoped the change to only emit the event when removal actually succeeds.
- No breaking changes: existing functionality remains intact.
- New test ensures regression protection going forward.