### PR TITLE
refactor(script-loader): sync with pro version

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,6 +1,8 @@
 import { ScriptLoader } from './script-loader';
 export { ScriptMetadata, Command, ScriptLoaderError } from './script-loader';
 
-const scriptLoader = new ScriptLoader();
+const scriptLoader = new ScriptLoader({
+  base: __dirname,
+});
 
 export { ScriptLoader, scriptLoader };

--- a/src/commands/script-loader.ts
+++ b/src/commands/script-loader.ts
@@ -15,6 +15,7 @@ export interface Command {
   name: string;
   options: {
     numberOfKeys: number;
+    includes?: ScriptMetadata[];
     lua: string;
   };
 }
@@ -23,6 +24,8 @@ export interface Command {
  * Script metadata
  */
 export interface ScriptMetadata {
+  dir: string;
+
   /**
    * Name of the script
    */
@@ -46,6 +49,10 @@ export interface ScriptMetadata {
    * Metadata on the scripts that this script includes
    */
   includes: ScriptMetadata[];
+  /**
+   * Identify if this script is an alias to another script (used when loading includes from different directories)
+   */
+  isAlias?: boolean;
 }
 
 export class ScriptLoaderError extends Error {
@@ -91,11 +98,17 @@ export class ScriptLoader {
   private commandCache = new Map<string, Command[]>();
   private rootPath: string;
 
-  constructor() {
+  constructor(extraMappings?: { [key: string]: string }) {
     this.rootPath = getPkgJsonDir();
     this.pathMapper.set('~', this.rootPath);
     this.pathMapper.set('rootDir', this.rootPath);
     this.pathMapper.set('base', __dirname);
+
+    if (extraMappings) {
+      for (const [key, value] of Object.entries(extraMappings)) {
+        this.pathMapper.set(key, value);
+      }
+    }
   }
 
   /**
@@ -156,17 +169,16 @@ export class ScriptLoader {
    * Recursively collect all scripts included in a file
    * @param file - the parent file
    * @param cache - a cache for file metadata to increase efficiency. Since a file can be included
-   * multiple times, we make sure to load it only once.
+   *   multiple times, we make sure to load it only once.
+   * @param isInclude - determine if this is an include (true) or a top-level script (false)
    * @param stack - internal stack to prevent circular references
    */
   private async resolveDependencies(
     file: ScriptMetadata,
-    cache?: Map<string, ScriptMetadata>,
+    cache: Map<string, ScriptMetadata> = new Map<string, ScriptMetadata>(),
     isInclude = false,
     stack: string[] = [],
   ): Promise<void> {
-    cache = cache ?? new Map<string, ScriptMetadata>();
-
     if (stack.includes(file.path)) {
       throw new ScriptLoaderError(
         `circular reference: "${file.path}"`,
@@ -237,8 +249,7 @@ export class ScriptLoader {
         ? // mapped paths imply absolute reference
           this.resolvePath(ensureExt(reference), stack)
         : // include path is relative to the file being processed
-          path.resolve(path.dirname(file.path), ensureExt(reference));
-
+          path.resolve(file.dir, ensureExt(reference));
       let includePaths: string[];
 
       if (hasFilenamePattern(includeFilename)) {
@@ -297,6 +308,7 @@ export class ScriptLoader {
           // this represents a normalized version of the path to make replacement easy
           token = getPathHash(includePath);
           includeMetadata = {
+            dir: path.dirname(includePath),
             name,
             numberOfKeys,
             path: includePath,
@@ -340,23 +352,27 @@ export class ScriptLoader {
   async parseScript(
     filename: string,
     content: string,
+    dir: string,
     cache?: Map<string, ScriptMetadata>,
+    isLoadingIncludes = false,
   ): Promise<ScriptMetadata> {
     const { name, numberOfKeys } = splitFilename(filename);
-    const meta = cache?.get(name);
+    const filePath = isLoadingIncludes ? filename : name;
+    const meta = cache?.get(filePath);
     if (meta?.content === content) {
       return meta;
     }
     const fileInfo: ScriptMetadata = {
-      path: filename,
-      token: getPathHash(filename),
+      dir,
+      path: filePath,
+      token: getPathHash(filePath),
       content,
       name,
       numberOfKeys,
       includes: [],
     };
 
-    await this.resolveDependencies(fileInfo, cache);
+    await this.resolveDependencies(fileInfo, cache, isLoadingIncludes);
     return fileInfo;
   }
 
@@ -365,11 +381,13 @@ export class ScriptLoader {
    * @param file - the file whose content we want to construct
    * @param processed - a cache to keep track of which includes have already been processed
    */
-  interpolate(file: ScriptMetadata, processed?: Set<string>): string {
-    processed = processed || new Set<string>();
+  interpolate(
+    file: ScriptMetadata,
+    processed: Set<string> = new Set<string>(),
+  ): string {
     let content = file.content;
     file.includes.forEach((child: ScriptMetadata) => {
-      const emitted = processed!.has(child.path);
+      const emitted = processed.has(child.path);
       const fragment = this.interpolate(child, processed);
       const replacement = emitted ? '' : fragment;
 
@@ -390,23 +408,44 @@ export class ScriptLoader {
 
   async loadCommand(
     filename: string,
+    dir: string,
     cache?: Map<string, ScriptMetadata>,
+    isLoadingIncludes = false,
+    fileAlias = '',
   ): Promise<Command> {
     filename = path.resolve(filename);
 
     const { name: scriptName } = splitFilename(filename);
-    let script = cache?.get(scriptName);
+
+    let script = cache?.get(isLoadingIncludes ? filename : scriptName);
     if (!script) {
       const content = (await readFile(filename)).toString();
-      script = await this.parseScript(filename, content, cache);
+      script = await this.parseScript(
+        filename,
+        content,
+        dir,
+        cache,
+        isLoadingIncludes,
+      );
+    }
+
+    if (isLoadingIncludes && fileAlias) {
+      const scriptWithAlias = cache?.get(fileAlias);
+      if (!scriptWithAlias) {
+        cache?.set(fileAlias, script);
+      } else {
+        scriptWithAlias.content = script.content;
+        scriptWithAlias.includes = script.includes;
+        scriptWithAlias.isAlias = true;
+      }
     }
 
     const lua = removeEmptyLines(this.interpolate(script));
-    const { name, numberOfKeys } = script;
+    const { name, numberOfKeys, includes } = script;
 
     return {
       name,
-      options: { numberOfKeys: numberOfKeys!, lua },
+      options: { numberOfKeys: numberOfKeys!, lua, includes },
     };
   }
 
@@ -425,6 +464,8 @@ export class ScriptLoader {
   async loadScripts(
     dir?: string,
     cache?: Map<string, ScriptMetadata>,
+    isLoadingIncludes = false,
+    directoryAlias = '',
   ): Promise<Command[]> {
     dir = path.normalize(dir || __dirname);
 
@@ -452,9 +493,46 @@ export class ScriptLoader {
 
     for (let i = 0; i < luaFiles.length; i++) {
       const file = path.join(dir, luaFiles[i]);
+      const fileAlias = path.join(directoryAlias, luaFiles[i]);
 
-      const command = await this.loadCommand(file, cache);
-      commands.push(command);
+      const command = await this.loadCommand(
+        file,
+        dir,
+        cache,
+        isLoadingIncludes,
+        fileAlias,
+      );
+      if (!isLoadingIncludes) {
+        commands.push(command);
+      }
+    }
+
+    const includeScripts = new Map<string, string[]>();
+    for (const luaScript of cache.values()) {
+      if (luaScript.numberOfKeys === undefined && !luaScript.isAlias) {
+        const paths = new Set<string>([
+          ...(includeScripts.get(luaScript.name) || []),
+          luaScript.path,
+        ]);
+        includeScripts.set(luaScript.name, [...paths]);
+      }
+    }
+
+    for (const [key, paths] of includeScripts) {
+      if (paths?.length > 1 && !isLoadingIncludes) {
+        console.warn(
+          `Warning: Include script name conflict for "${key}". Included from:`,
+          paths,
+        );
+        paths.forEach(currentPath => {
+          console.log('-- parents of ', currentPath);
+          for (const meta of cache!.values()) {
+            if (meta.includes.find(include => include.path === currentPath)) {
+              console.log('   ', meta.path);
+            }
+          }
+        });
+      }
     }
 
     this.commandCache.set(dir, commands);

--- a/src/commands/script-loader.ts
+++ b/src/commands/script-loader.ts
@@ -102,7 +102,6 @@ export class ScriptLoader {
     this.rootPath = getPkgJsonDir();
     this.pathMapper.set('~', this.rootPath);
     this.pathMapper.set('rootDir', this.rootPath);
-    this.pathMapper.set('base', __dirname);
 
     if (extraMappings) {
       for (const [key, value] of Object.entries(extraMappings)) {

--- a/tests/test_script_loader.ts
+++ b/tests/test_script_loader.ts
@@ -116,21 +116,31 @@ describe('scriptLoader', () => {
       filename: string,
       cache?: Map<string, ScriptMetadata>,
     ): Promise<string> {
-      const command = await loader.loadCommand(filename, cache);
+      const command = await loader.loadCommand(
+        filename,
+        __dirname + '/fixtures/scripts/',
+        cache,
+      );
       return command.options.lua;
     }
 
     it('handles basic includes', async () => {
       const fixture =
         __dirname + '/fixtures/scripts/fixture_simple_include.lua';
-      const command = await loader.loadCommand(fixture);
+      const command = await loader.loadCommand(
+        fixture,
+        __dirname + '/fixtures/scripts/',
+      );
       expect(command).to.not.eql(undefined);
     });
 
     it('normalizes path before loading', async () => {
       const path =
         __dirname + '/fixtures/scripts/includes/../fixture_simple_include.lua';
-      const command = await loader.loadCommand(path);
+      const command = await loader.loadCommand(
+        path,
+        __dirname + '/fixtures/scripts/',
+      );
       expect(command).to.not.eql(undefined);
     });
 
@@ -189,7 +199,11 @@ describe('scriptLoader', () => {
       loader.addPathMapping('includes', './fixtures/scripts/includes');
       const fixture = __dirname + '/fixtures/scripts/fixture_path_mapped.lua';
       const cache = new Map<string, ScriptMetadata>();
-      await loader.loadCommand(fixture, cache);
+      await loader.loadCommand(
+        fixture,
+        __dirname + '/fixtures/scripts/',
+        cache,
+      );
       const info = cache.get(path.basename(path.resolve(fixture), '.lua'));
 
       expect(info).to.not.eql(undefined);
@@ -206,7 +220,11 @@ describe('scriptLoader', () => {
         __dirname + '/fixtures/scripts/fixture_path_mapped_glob.lua';
       const cache = new Map<string, ScriptMetadata>();
 
-      await loader.loadCommand(fixture, cache);
+      await loader.loadCommand(
+        fixture,
+        __dirname + '/fixtures/scripts/',
+        cache,
+      );
       const info = cache.get(path.basename(path.resolve(fixture), '.lua'));
 
       expect(info).to.not.eql(undefined);
@@ -226,7 +244,7 @@ describe('scriptLoader', () => {
       let didThrow = false;
       let error: ScriptLoaderError;
       try {
-        await loader.loadCommand(fixture);
+        await loader.loadCommand(fixture, __dirname + '/fixtures/scripts/');
       } catch (err) {
         error = <ScriptLoaderError>err;
         didThrow = true;
@@ -245,7 +263,7 @@ describe('scriptLoader', () => {
       let didThrow = false;
       let error: ScriptLoaderError;
       try {
-        await loader.loadCommand(fixture);
+        await loader.loadCommand(fixture, __dirname + '/fixtures/scripts/');
       } catch (err) {
         error = <ScriptLoaderError>err;
         didThrow = true;
@@ -262,7 +280,7 @@ describe('scriptLoader', () => {
       let didThrow = false;
       let error: ScriptLoaderError;
       try {
-        await loader.loadCommand(fixture);
+        await loader.loadCommand(fixture, __dirname + '/fixtures/scripts/');
       } catch (err) {
         error = <ScriptLoaderError>err;
         didThrow = true;

--- a/tests/test_script_loader.ts
+++ b/tests/test_script_loader.ts
@@ -11,6 +11,7 @@ import { RedisClient } from '../src/interfaces';
 
 describe('scriptLoader', () => {
   let loader: ScriptLoader;
+  const basePath = __dirname + '/../src/commands';
 
   function getRootPath() {
     return path.resolve(path.join(__dirname, '../'));
@@ -34,7 +35,9 @@ describe('scriptLoader', () => {
   }
 
   beforeEach(() => {
-    loader = new ScriptLoader();
+    loader = new ScriptLoader({
+      base: basePath,
+    });
   });
 
   describe('when using path mappings', () => {
@@ -299,7 +302,9 @@ describe('scriptLoader', () => {
     });
 
     it('caches loadScripts calls per directory', async () => {
-      const loader = new ScriptLoader();
+      const loader = new ScriptLoader({
+        base: basePath,
+      });
       const loadScriptSpy = sinon.spy(loader, 'loadScripts');
 
       const dirname = __dirname + '/fixtures/scripts/dir-test';
@@ -377,7 +382,9 @@ describe('scriptLoader', () => {
 
   describe('.clearCache', () => {
     it('can clear the command cache', async () => {
-      const loader = new ScriptLoader();
+      const loader = new ScriptLoader({
+        base: basePath,
+      });
       const loadScriptSpy = sinon.spy(loader, 'loadScripts');
 
       const dirname = __dirname + '/fixtures/scripts/dir-test';


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? To have same version of scrip loader and also change how base reference is being built, this way pro version do not need to remove script loader tests every time that we updated base package

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
