### PR TITLE
fix(worker): do not retry processor when connection errors happen

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -556,15 +556,11 @@ export class Worker<
       if (job) {
         const token = job.token;
         asyncFifoQueue.add(
-          this.retryIfFailed<void | Job<DataType, ResultType, NameType>>(
-            () =>
-              this.processJob(
-                <Job<DataType, ResultType, NameType>>job,
-                token,
-                () => asyncFifoQueue.numTotal() <= this._concurrency,
-                jobsInProgress,
-              ),
-            this.opts.runRetryDelay,
+          this.processJob(
+            <Job<DataType, ResultType, NameType>>job,
+            token,
+            () => asyncFifoQueue.numTotal() <= this._concurrency,
+            jobsInProgress,
           ),
         );
       } else if (asyncFifoQueue.numQueued() === 0) {
@@ -719,12 +715,9 @@ will never work with more accuracy than 1ms. */
           // We cannot trust that the blocking connection stays blocking forever
           // due to issues in Redis and IORedis, so we will reconnect if we
           // don't get a response in the expected time.
-          timeout = setTimeout(
-            async () => {
-              bclient.disconnect(!this.closing);
-            },
-            blockTimeout * 1000 + 1000,
-          );
+          timeout = setTimeout(async () => {
+            bclient.disconnect(!this.closing);
+          }, blockTimeout * 1000 + 1000);
 
           this.updateDelays(); // reset delays to avoid reusing same values in next iteration
 
@@ -922,38 +915,62 @@ will never work with more accuracy than 1ms. */
           const unrecoverableErrorMessage =
             this.getUnrecoverableErrorMessage(job);
           if (unrecoverableErrorMessage) {
-            const failed = await this.handleFailed(
-              new UnrecoverableError(unrecoverableErrorMessage),
-              job,
-              token,
-              fetchNextCallback,
-              jobsInProgress,
-              inProgressItem,
-              span,
+            const failed = await this.retryIfFailed<void | Job<
+              DataType,
+              ResultType,
+              NameType
+            >>(
+              () =>
+                this.handleFailed(
+                  new UnrecoverableError(unrecoverableErrorMessage),
+                  job,
+                  token,
+                  fetchNextCallback,
+                  jobsInProgress,
+                  inProgressItem,
+                  span,
+                ),
+              this.opts.runRetryDelay,
             );
             return failed;
           }
           jobsInProgress.add(inProgressItem);
 
           const result = await this.callProcessJob(job, token);
-          return await this.handleCompleted(
-            result,
-            job,
-            token,
-            fetchNextCallback,
-            jobsInProgress,
-            inProgressItem,
-            span,
+          return await this.retryIfFailed<void | Job<
+            DataType,
+            ResultType,
+            NameType
+          >>(
+            () =>
+              this.handleCompleted(
+                result,
+                job,
+                token,
+                fetchNextCallback,
+                jobsInProgress,
+                inProgressItem,
+                span,
+              ),
+            this.opts.runRetryDelay,
           );
         } catch (err) {
-          const failed = await this.handleFailed(
-            <Error>err,
-            job,
-            token,
-            fetchNextCallback,
-            jobsInProgress,
-            inProgressItem,
-            span,
+          const failed = await this.retryIfFailed<void | Job<
+            DataType,
+            ResultType,
+            NameType
+          >>(
+            () =>
+              this.handleFailed(
+                <Error>err,
+                job,
+                token,
+                fetchNextCallback,
+                jobsInProgress,
+                inProgressItem,
+                span,
+              ),
+            this.opts.runRetryDelay,
           );
           return failed;
         } finally {


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? retryIfFailed method was applied to the whole processJob method, this one includes the call of job processor plus our handler of completed and failed. While we want to retry this operation for our scripts when there is a connection error, we should not re-execute the processor operation, but the ones that we manage

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
