### PR TITLE
docs: update bullmq-pro changelog for version v7.39.3

### DIFF
--- a/docs/gitbook/bullmq-pro/changelog.md
+++ b/docs/gitbook/bullmq-pro/changelog.md
@@ -1,3 +1,13 @@
+## [7.39.3](https://github.com/taskforcesh/bullmq-pro/compare/v7.39.2...v7.39.3) (2025-10-08)
+
+
+### Bug Fixes
+
+* **classes:** expose WaitingError ([#379](https://github.com/taskforcesh/bullmq-pro/issues/379)) ([1cd999e](https://github.com/taskforcesh/bullmq-pro/commit/1cd999e7b52a531d14f5a94f90ef3b3cee167517))
+
+
+
+
 ## [7.39.2](https://github.com/taskforcesh/bullmq-pro/compare/v7.39.1...v7.39.2) (2025-10-04)
 
 


### PR DESCRIPTION
Automated update of BullMQ Pro changelog for version v7.39.3

  This PR updates the BullMQ Pro changelog with the latest release notes.