### PR TITLE
fix(worker): emit error once when failure happens in moveToFinished

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -1039,7 +1039,7 @@ will never work with more accuracy than 1ms. */
 
     if (!this.connection.closing) {
       // Check if the job was manually rate-limited
-      if (err.message == RATE_LIMIT_ERROR) {
+      if (err.message === RATE_LIMIT_ERROR) {
         const rateLimitTtl = await this.moveLimitedBackToWait(job, token);
         this.limitUntil = rateLimitTtl > 0 ? Date.now() + rateLimitTtl : 0;
         return;


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? retryIfFailed emits errors in worker, we also emit it in handleFailed method. As we are wrapping handleFailed with retryIfFailed, no need to emit error again but only in one place

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
