### PR TITLE
docs: update bullmq-pro changelog for version v7.40.0

### DIFF
--- a/docs/gitbook/bullmq-pro/changelog.md
+++ b/docs/gitbook/bullmq-pro/changelog.md
@@ -1,3 +1,13 @@
+# [7.40.0](https://github.com/taskforcesh/bullmq-pro/compare/v7.39.3...v7.40.0) (2025-11-04)
+
+
+### Features
+
+* **deps:** upgrade bullmq to v5.63.0 ([#382](https://github.com/taskforcesh/bullmq-pro/issues/382)) ([4e5fc31](https://github.com/taskforcesh/bullmq-pro/commit/4e5fc31b1ec69808f8c3be9a2bb7cfa665b1e94f))
+
+
+
+
 ## [7.39.3](https://github.com/taskforcesh/bullmq-pro/compare/v7.39.2...v7.39.3) (2025-10-08)
 
 


### PR DESCRIPTION
Automated update of BullMQ Pro changelog for version v7.40.0

  This PR updates the BullMQ Pro changelog with the latest release notes.