### PR TITLE
docs(guide): fix small typos

### DIFF
--- a/docs/gitbook/guide/flows/remove-child-dependency.md
+++ b/docs/gitbook/guide/flows/remove-child-dependency.md
@@ -28,4 +28,4 @@ await originalTree.children[0].job.removeChildDependency();
 As soon as a **child** calls this method, it will verify if it has an existing parent, if not, it'll throw an error.
 {% endhint %}
 
-Failed or completed children using this option won't generate any removal as they won't be part of unprocessed list:
+Failed or completed children using this option won't generate any removal as they won't be part of unprocessed list.

--- a/docs/gitbook/guide/troubleshooting.md
+++ b/docs/gitbook/guide/troubleshooting.md
@@ -8,20 +8,20 @@ An error that can be thrown by the workers has the following structure: “Missi
 
 When a worker processes a job, it requires a special lock key to ensure that the job is currently “owned” by that worker, preventing other workers from picking up the same job. However, this lock can be deleted, and such a deletion may not be detected until the worker tries to move the job to a completed or failed status.
 
-A lock can be deleted for several reasons, the most common being::
+A lock can be deleted for several reasons, the most common being:
 
-* The worker is consuming too much CPU and has no time to renew the lock every 30 seconds (which is the default expiration time for locks)
-* The worker has lost communication with Redis and cannot renew the lock in time.
-* The job has been forcefully removed using one of BullMQ's APIs to remove jobs (or by removing the entire queue).
-* The Redis instance has a wrong [maxmemory](https://docs.bullmq.io/guide/going-to-production#max-memory-policy) policy; it should be no-eviction to avoid Redis removing keys with the expiration date before hand.
+- The worker is consuming too much CPU and has no time to renew the lock every 30 seconds (which is the default expiration time for locks)
+- The worker has lost communication with Redis and cannot renew the lock in time.
+- The job has been forcefully removed using one of BullMQ's APIs to remove jobs (or by removing the entire queue).
+- The Redis instance has a wrong [maxmemory](https://docs.bullmq.io/guide/going-to-production#max-memory-policy) policy; it should be no-eviction to avoid Redis removing keys with the expiration date before hand.
 
 ### Invalid or Undefined Environment Variables
 
 If you rely on environment variables (e.g., for queue names or job data), a common pitfall is passing them directly to BullMQ methods when those environment variables are:
 
-* Undefined (not set at all)
-* Empty strings (i.e., "")
-* Non-string values (e.g., inadvertently passing objects or arrays)
+- Undefined (not set at all)
+- Empty strings (i.e., "")
+- Non-string values (e.g., inadvertently passing objects or arrays)
 
 This can cause BullMQ’s internal Lua scripts to throw ERR Error running script ... Lua redis() command arguments must be strings or integers. It typically happens when a parameter passed into the Redis command ends up being something other than a valid string or number.
 


### PR DESCRIPTION
### Why

Hi team, I read the [documentation](https://docs.bullmq.io) today and found a few typos. The only one I can't solve has been issued in #3548.

### How

Nothing special, just remove redundant denotations.

### Additional Notes (Optional)
Nope
