### PR TITLE
docs: update bullmq-pro changelog for version v7.40.1

### DIFF
--- a/docs/gitbook/bullmq-pro/changelog.md
+++ b/docs/gitbook/bullmq-pro/changelog.md
@@ -1,3 +1,13 @@
+## [7.40.1](https://github.com/taskforcesh/bullmq-pro/compare/v7.40.0...v7.40.1) (2025-11-15)
+
+
+### Bug Fixes
+
+* **deps:** upgrade bullmq to v5.63.1 ([#386](https://github.com/taskforcesh/bullmq-pro/issues/386)) ([a9a0fcb](https://github.com/taskforcesh/bullmq-pro/commit/a9a0fcbff5fff1aec8381825534f882204012a5f))
+
+
+
+
 # [7.40.0](https://github.com/taskforcesh/bullmq-pro/compare/v7.39.3...v7.40.0) (2025-11-04)
 
 


### PR DESCRIPTION
Automated update of BullMQ Pro changelog for version v7.40.1

  This PR updates the BullMQ Pro changelog with the latest release notes.