### PR TITLE
feat(job): allow resetting attemptsMade and attemptsStarted attributes

### DIFF
--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -25,6 +25,7 @@ import {
   MoveToDelayedOpts,
   RepeatableOptions,
   RetryJobOpts,
+  RetryOptions,
   ScriptQueueContext,
 } from '../interfaces';
 import {
@@ -1420,6 +1421,7 @@ export class Scripts {
   async reprocessJob<T = any, R = any, N extends string = string>(
     job: MinimalJob<T, R, N>,
     state: 'failed' | 'completed',
+    opts: RetryOptions = {},
   ): Promise<void> {
     const client = await this.queue.client;
 
@@ -1439,6 +1441,8 @@ export class Scripts {
       (job.opts.lifo ? 'R' : 'L') + 'PUSH',
       state === 'failed' ? 'failedReason' : 'returnvalue',
       state,
+      opts.resetAttemptsMade ? '1' : '0',
+      opts.resetAttemptsStarted ? '1' : '0',
     ];
 
     const result = await this.execCommand(

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -23,6 +23,7 @@ export * from './redis-streams';
 export * from './repeatable-job';
 export * from './repeatable-options';
 export * from './repeat-options';
+export * from './retry-options';
 export * from './script-queue-context';
 export * from './sandboxed-job-processor';
 export * from './sandboxed-job';

--- a/src/interfaces/retry-options.ts
+++ b/src/interfaces/retry-options.ts
@@ -1,0 +1,14 @@
+/**
+ * Retry method options
+ */
+export interface RetryOptions {
+  /**
+   * Attempts made counter is reset to zero when retrying the job.
+   */
+  resetAttemptsMade?: boolean;
+
+  /**
+   * Attempts started counter is reset to zero when retrying the job.
+   */
+  resetAttemptsStarted?: boolean;
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? Sometimes it's useful to retry a job from the very beginning of its retries

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
ref https://github.com/taskforcesh/bullmq/issues/2152