### PR TITLE
fix(scheduler): add generated delayed job before processing current job [elixir]

### DIFF
--- a/elixir/lib/bullmq/job.ex
+++ b/elixir/lib/bullmq/job.ex
@@ -377,7 +377,7 @@ defmodule BullMQ.Job do
   def should_retry?(%__MODULE__{opts: opts, attempts_made: attempts_made}) do
     # Handle both atom and string keys (string keys come from JSON decode)
     max_attempts = get_opt(opts, :attempts, "attempts", 1)
-    attempts_made < max_attempts
+    attempts_made + 1 < max_attempts
   end
 
   @doc """


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? Delayed jobs from schedulers must be added before processing current jobs so they are not being affected by job failures

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
