### PR TITLE
ci: add a create release step for PHP

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,6 @@ jobs:
             echo "No changes detected after semantic-release"
           fi
       - run: yarn copy:lua:python
-
       # Python Release
       - name: Setup Python
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4
@@ -296,6 +295,28 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: php
         run: npx semantic-release
+      - name: Create PHP release asset
+        if: ${{ success() && steps.semantic_release_php.outcome == 'success' }}
+        working-directory: php
+        run: |
+          VERSION=$(node -p "require('./composer.json').version")
+          # Create a clean directory with only the necessary files
+          mkdir -p ../bullmq-php-${VERSION}
+          cp -r src ../bullmq-php-${VERSION}/
+          cp composer.json ../bullmq-php-${VERSION}/
+          cp README.md ../bullmq-php-${VERSION}/ || true
+          cp LICENSE ../bullmq-php-${VERSION}/ || true
+          # Create zip file
+          cd ..
+          zip -r bullmq-php-${VERSION}.zip bullmq-php-${VERSION}
+          echo "PHP_VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "PHP_ASSET_PATH=$(pwd)/bullmq-php-${VERSION}.zip" >> $GITHUB_ENV
+      - name: Upload PHP release asset
+        if: ${{ success() && steps.semantic_release_php.outcome == 'success' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "vphp${PHP_VERSION}" "${PHP_ASSET_PATH}" --clobber
       - name: Create PR with PHP release changes
         if: ${{ success() && steps.semantic_release_php.outcome == 'success' }}
         env:

--- a/docs/gitbook/php/introduction.md
+++ b/docs/gitbook/php/introduction.md
@@ -12,7 +12,33 @@ The PHP package only implements the Queue class (producer side). Workers are not
 
 ### Installation
 
-This package is distributed directly from the BullMQ monorepo. Add the repository to your `composer.json`:
+#### Option 1: Download Release (Recommended)
+
+Download the latest release from the [releases page](https://github.com/taskforcesh/bullmq/releases) (look for `bullmq-php-X.X.X.zip`), extract it to your project, and configure Composer:
+
+```json
+{
+  "repositories": [
+    {
+      "type": "path",
+      "url": "./bullmq-php-X.X.X"
+    }
+  ],
+  "require": {
+    "taskforcesh/bullmq-php": "*"
+  }
+}
+```
+
+Then run:
+
+```bash
+composer install
+```
+
+#### Option 2: Install from GitHub (Development)
+
+For development or the latest changes, install directly from the repository:
 
 ```json
 {
@@ -30,18 +56,14 @@ This package is distributed directly from the BullMQ monorepo. Add the repositor
 }
 ```
 
-Then run:
+{% hint style="warning" %}
+Installing from VCS requires building the Lua scripts. After `composer install`, run from the monorepo root:
 
 ```bash
-composer install
+yarn install && yarn build && yarn copy:lua:php
 ```
 
-Or add it to an existing project via command line:
-
-```bash
-composer config repositories.bullmq vcs https://github.com/taskforcesh/bullmq
-composer require taskforcesh/bullmq-php:dev-master
-```
+{% endhint %}
 
 ### Requirements
 

--- a/php/README.md
+++ b/php/README.md
@@ -12,7 +12,33 @@ This library allows you to add jobs to a BullMQ queue from your PHP application.
 
 ## Installation
 
-This package is distributed directly from the BullMQ monorepo. Add the repository to your `composer.json` and require the package:
+### Option 1: Download Release (Recommended)
+
+Download the latest release from the [releases page](https://github.com/taskforcesh/bullmq/releases) (look for `bullmq-php-X.X.X.zip`), extract it to your project, and configure Composer:
+
+```json
+{
+  "repositories": [
+    {
+      "type": "path",
+      "url": "./bullmq-php-X.X.X"
+    }
+  ],
+  "require": {
+    "taskforcesh/bullmq-php": "*"
+  }
+}
+```
+
+Then run:
+
+```bash
+composer install
+```
+
+### Option 2: Install from GitHub (Development)
+
+For development or if you want the latest changes, you can install directly from the repository. Note that this requires Node.js to build the Lua scripts first.
 
 ```json
 {
@@ -30,17 +56,14 @@ This package is distributed directly from the BullMQ monorepo. Add the repositor
 }
 ```
 
-Then run:
+After installing, you need to build the Lua scripts:
 
 ```bash
-composer install
-```
-
-Or add it to an existing project:
-
-```bash
-composer config repositories.bullmq vcs https://github.com/taskforcesh/bullmq
-composer require taskforcesh/bullmq-php:dev-master
+cd vendor/taskforcesh/bullmq-php
+# From the monorepo root:
+yarn install
+yarn build
+yarn copy:lua:php
 ```
 
 > **Note:** Stable releases are tagged with the format `vphp{version}` (e.g., `vphp1.0.0`). Check the [releases page](https://github.com/taskforcesh/bullmq/releases) for available versions.


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
The compiled lua scripts are missing in the PHP release, this PR creates a php release that includes everything necessary. Fixes this issue: https://github.com/taskforcesh/bullmq/issues/3615

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
By creating a .zip file in the release GitHub action that will pack all the necessary files.

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
