### PR TITLE
docs: fix misleading example in getJobCountByTypes comment

### DIFF
--- a/src/classes/queue-getters.ts
+++ b/src/classes/queue-getters.ts
@@ -158,7 +158,6 @@ export class QueueGetters<JobBase extends Job = Job> extends QueueBase {
    *
    * Queue#getJobCountByTypes('completed') =\> completed count
    * Queue#getJobCountByTypes('completed', 'failed') =\> completed + failed count
-   * Queue#getJobCountByTypes('completed', 'failed') =\> completed + failed count
    * Queue#getJobCountByTypes('completed', 'waiting', 'failed') =\> completed + waiting + failed count
    */
   async getJobCountByTypes(...types: JobType[]): Promise<number> {


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
The comment example implied comma-delimited strings were supported, but the implementation requires separate arguments.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
I deleted the line, as changing it to the correct format would create duplicate lines.

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
No Additional Notes
