### PR TITLE
ioredis move to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,12 +56,14 @@
   },
   "dependencies": {
     "cron-parser": "4.9.0",
-    "ioredis": "5.9.1",
     "msgpackr": "1.11.5",
     "node-abort-controller": "3.1.1",
     "semver": "7.7.3",
     "tslib": "2.8.1",
     "uuid": "11.1.0"
+  },
+  "peerDependencies": {
+    "ioredis": "^5.9.1"
   },
   "devDependencies": {
     "@commitlint/cli": "20.3.1",
@@ -97,6 +99,7 @@
     "eslint-plugin-tsdoc": "0.5.0",
     "fast-glob": "3.3.3",
     "husky": "8.0.3",
+    "ioredis": "5.9.1",
     "lint-staged": "16.2.7",
     "madge": "8.0.0",
     "minimatch": "9.0.5",


### PR DESCRIPTION
### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
Currently, IORedis is included in the dependencies section of package.json, and its version is pinned.
There are tree cons to this.

- As with the recent issue (#3667), you need to update package.json every time IORedis is updated.
- You cannot freely choose the version of IORedis.
- When users install IORedis and pass the IORedis instance as a connection to BullMQ, version mismatches may occur.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->

- Move the current `“ioredis”: “5.9.1”` setting from `dependencies` to `devDependencies`.
- Add `“ioredis”: “^5.9.1”` to `peerDependencies`

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->

🚨 __Caution__
If you have only installed `bullmq` and not `ioredis`, you will need to install `ioredis`.
I think it should be announced as a breaking change.

__P.S.__
I believe this change will benefit both maintainers and users.
I kindly ask for your consideration.