### PR TITLE
fix(types): allow undefined in url with exactOptionalPropertyTypes TS config

### DIFF
--- a/src/interfaces/redis-options.ts
+++ b/src/interfaces/redis-options.ts
@@ -1,7 +1,7 @@
 import type * as IORedis from 'ioredis';
 
 export interface BaseOptions {
-  skipVersionCheck?: boolean;
+  skipVersionCheck?: boolean | undefined;
   url?: string | undefined;
 }
 


### PR DESCRIPTION

### Why

When project uses `exactOptionalPropertyTypes` (https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes), redis `url` config cannot be passed in as `undefined`. This change permits to do that. Implementation already allows to work with both optional or undefined property.

### How

Broaden `BaseOptions` type definition to allow url as both `optional` and `undefined` under stricter  `exactOptionalPropertyTypes` TS config.
