### PR TITLE
chore(child): added an error log when a child process exits

### DIFF
--- a/src/classes/child.ts
+++ b/src/classes/child.ts
@@ -99,6 +99,10 @@ export class Child extends EventEmitter {
     }
 
     parent.on('exit', (exitCode: number, signalCode?: number) => {
+      if (exitCode > 0) {
+        console.error(`child process exited with code ${exitCode} and signal ${signalCode}`);
+      }
+
       this._exitCode = exitCode;
 
       // Coerce to null if undefined for backwards compatibility


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->

Today I was implemented sandboxed processes on our existing BullMQ setup and ran into issues I was struggling to debug. I setup a demo project following the documentation and it worked as expected, however I could not get it to work as intended in our existing project.

Eventually I found the issue after adding logs to the BullMQ dist code in `node_modules` to track it down to incompatible Node.js flags (I've yet to determine what flags are causing the issue). The way I found this was by logging the exit code of the child process which in my case was `9` indicating that the process was being killed immediately unexpectedly.

Without this log the child process exits silently, and in bull board the only message present is:

```
UnrecoverableError: job stalled more than allowable limit
```

I've conditionally added the log based on the exit code as an exit code of 0 might be expected behaviour in the lifecycle of the process.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->

The log was helpful for me to debug the issue I had with incompatible Node.js runtime flags. I was able to identify where the issue was happening and add a log to confirm this was the problem.

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->

I couldn't see any logger and wasn't sure if there was a way to control the log level either hence the reference to console.error.
