### PR TITLE
fix(tsconfig): use inline sourcemaps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "declaration": true,
     "outDir": "dist/esm",
     "sourceMap": true,
+    "inlineSources": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "strict": true,


### PR DESCRIPTION
### Why

`bullmq` publishes files to npm with sourcemap URLs in the. For instance, `dist/esm/index.js` contains the following:

```js
//# sourceMappingURL=index.js.map
```

That file (`dist/esm/index.js.map`), in turn, contains this:

```json
{"version":3,"file":"index.js","sourceRoot":"","sources":["../../src/index.ts"],"names":[],"mappings":"AAAA,cAAc,WAAW,CAAC;AAC1B,cAAc,SAAS,CAAC;AACxB,cAAc,cAAc,CAAC;AAC7B,cAAc,SAAS,CAAC;AACxB,cAAc,SAAS,CAAC;AAExB,iCAAiC;AACjC,cAAc,mBAAmB,CAAC;AAClC,cAAc,wBAAwB,CAAC"}
```

That contains a relative path to `src/`, which isn't published to `npm`:

https://github.com/taskforcesh/bullmq/blob/f3e89237c00dc967648111800d7c3db675b17360/package.json#L19-L21

So, when tools try to load and process sourcemaps, they fail, because the referenced file doesn't exist.

### How

This fix adds `"inlineSources": true` to force TypeScript to include the sources in the `.map` files in a `sourcesCourse` property. However, there are two alternatives worth considering:

- Stop publishing sourcemaps entirely. Given that the `dist/` files aren't mangled or minified, this could be a simpler option, and would keep the published size of the package smaller.
- Publish the entire `src/` directory. This wouldn't make the published package any larger, because with the change that's currently in this PR, all those files end up being published _anyways_, they're just inlined in the `.map` files.