### PR TITLE
Add docs for batches and real-time updates

### DIFF
--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -16,6 +16,7 @@
 - [Queues](guide/queues/README.md)
   - [Auto-removal of jobs](guide/queues/auto-removal-of-jobs.md)
   - [Adding jobs in bulk](guide/queues/adding-bulks.md)
+  - [Working with batches](guide/queues/batches.md)
   - [Global Concurrency](guide/queues/global-concurrency.md)
   - [Global Rate Limit](guide/queues/global-rate-limit.md)
   - [Meta](guide/queues/meta.md)

--- a/docs/gitbook/guide/events/README.md
+++ b/docs/gitbook/guide/events/README.md
@@ -32,6 +32,8 @@ myWorker.on('failed', (job: Job) => {
 });
 ```
 
+## Real-time updates
+
 The events above are local for the workers that actually completed the jobs. However, in many situations you want to listen to all the events emitted by all the workers in one single place. For this you can use the [`QueueEvents`](https://api.docs.bullmq.io/classes/v5.QueueEvents.html) class:
 
 ```typescript

--- a/docs/gitbook/guide/queues/batches.md
+++ b/docs/gitbook/guide/queues/batches.md
@@ -1,0 +1,11 @@
+# Working with batches
+
+If you need to enqueue many jobs at once, BullMQ provides bulk APIs:
+
+- [Adding jobs in bulk](adding-bulks.md) using `Queue.addBulk`
+- [Adding flows in bulk](../../flows/adding-bulks.md) using `FlowProducer.addBulk`
+
+If you want workers to **process jobs in batches**, that capability is provided by
+BullMQ Pro. See:
+
+- [BullMQ Pro: Batches](../../bullmq-pro/batches.md)


### PR DESCRIPTION
## Summary
- Add a short guide page on working with batches, including links to bulk APIs and BullMQ Pro batches
- Add a clearer heading for real-time updates in the Events guide
- Add the new page to the docs summary

## Issue
Fixes #126
