### PR TITLE
fix(worker): remove default execArgv flags for sandboxed workers

### DIFF
--- a/src/classes/child.ts
+++ b/src/classes/child.ts
@@ -1,5 +1,5 @@
-import { ChildProcess, fork } from 'child_process';
 import { AddressInfo, createServer } from 'net';
+import { ChildProcess, fork } from 'child_process';
 import { Worker } from 'worker_threads';
 import { ChildCommand, ParentCommand } from '../enums';
 import { SandboxedOptions } from '../interfaces';
@@ -76,13 +76,10 @@ export class Child extends EventEmitter {
   }
 
   async init(): Promise<void> {
-    const execArgv = await convertExecArgv(process.execArgv);
-
     let parent: ChildProcess | Worker;
 
     if (this.opts.useWorkerThreads) {
       this.worker = parent = new Worker(this.mainFile, {
-        execArgv,
         stdin: true,
         stdout: true,
         stderr: true,
@@ -91,6 +88,7 @@ export class Child extends EventEmitter {
           : {}),
       });
     } else {
+      const execArgv = await convertExecArgv(process.execArgv);
       this.childProcess = parent = fork(this.mainFile, [], {
         execArgv,
         stdio: 'pipe',
@@ -239,14 +237,13 @@ const convertExecArgv = async (execArgv: string[]): Promise<string[]> => {
   const standard: string[] = [];
   const convertedArgs: string[] = [];
 
-  for (let i = 0; i < execArgv.length; i++) {
-    const arg = execArgv[i];
-    if (arg.indexOf('--inspect') === -1) {
-      standard.push(arg);
-    } else {
-      const argName = arg.split('=')[0];
+  for (const arg of execArgv) {
+    const argName = arg.split('=')[0];
+    if (argName === '--inspect' || argName === '--inspect-brk') {
       const port = await getFreePort();
       convertedArgs.push(`${argName}=${port}`);
+    } else {
+      standard.push(arg);
     }
   }
 

--- a/tests/child-pool.test.ts
+++ b/tests/child-pool.test.ts
@@ -2,7 +2,6 @@ import { ChildPool } from '../src/classes';
 import { join } from 'path';
 import { describe, beforeEach, afterEach, it, expect } from 'vitest';
 
-const NoopProc = () => {};
 describe('Child pool for Child Processes', () => {
   sandboxProcessTests();
 });
@@ -25,78 +24,84 @@ function sandboxProcessTests(
   describe('Child pool', () => {
     let pool: ChildPool;
 
+    const originalExecArgv = process.execArgv;
+
     beforeEach(() => {
       pool = new ChildPool({ mainFile, useWorkerThreads });
+      process.execArgv = [...originalExecArgv];
     });
 
-    afterEach(() => pool.clean());
+    afterEach(() => {
+      pool.clean();
+      process.execArgv = originalExecArgv;
+    });
 
     it('should return same child if free', async () => {
       const processor = __dirname + '/fixtures/fixture_processor_bar.js';
-      const child = await pool.retain(processor, NoopProc);
+      const child = await pool.retain(processor);
       expect(child).toBeTruthy();
       pool.release(child);
       expect(Object.keys(pool.retained)).toHaveLength(0);
-      const newChild = await pool.retain(processor, NoopProc);
+      const newChild = await pool.retain(processor);
       expect(child).toEqual(newChild);
     });
 
     it('should return a new child if reused the last free one', async () => {
       const processor = __dirname + '/fixtures/fixture_processor_bar.js';
-      let child = await pool.retain(processor, NoopProc);
+      let child = await pool.retain(processor);
       expect(child).toBeTruthy();
       pool.release(child);
       expect(Object.keys(pool.retained)).toHaveLength(0);
-      let newChild = await pool.retain(processor, NoopProc);
+      let newChild = await pool.retain(processor);
       expect(child).toEqual(newChild);
       child = newChild;
-      newChild = await pool.retain(processor, NoopProc);
+      newChild = await pool.retain(processor);
       expect(child).not.toEqual(newChild);
     });
 
     it('should return a new child if none free', async () => {
       const processor = __dirname + '/fixtures/fixture_processor_bar.js';
-      const child = await pool.retain(processor, NoopProc);
+      const child = await pool.retain(processor);
       expect(child).toBeTruthy();
       expect(Object.keys(pool.retained).length).toBeGreaterThan(0);
-      const newChild = await pool.retain(processor, NoopProc);
+      const newChild = await pool.retain(processor);
       expect(child).not.toEqual(newChild);
     });
 
     it('should return a new child if killed', async () => {
       const processor = __dirname + '/fixtures/fixture_processor_bar.js';
-      const child = await pool.retain(processor, NoopProc);
+      const child = await pool.retain(processor);
       expect(child).toBeTruthy();
       await pool.kill(child);
       expect(Object.keys(pool.retained)).toHaveLength(0);
-      const newChild = await pool.retain(processor, NoopProc);
+      const newChild = await pool.retain(processor);
       expect(child).not.toEqual(newChild);
     });
 
     it('should return a new child if many retained and none free', async () => {
       const processor = __dirname + '/fixtures/fixture_processor_bar.js';
       const children = await Promise.all([
-        pool.retain(processor, NoopProc),
-        pool.retain(processor, NoopProc),
-        pool.retain(processor, NoopProc),
-        pool.retain(processor, NoopProc),
-        pool.retain(processor, NoopProc),
-        pool.retain(processor, NoopProc),
+        pool.retain(processor),
+        pool.retain(processor),
+        pool.retain(processor),
+        pool.retain(processor),
+        pool.retain(processor),
+        pool.retain(processor),
       ]);
       expect(children).toHaveLength(6);
-      const child = await pool.retain(processor, NoopProc);
+      const child = await pool.retain(processor);
       expect(children).not.toContain(child);
     });
 
     it('should return an old child if many retained and one free', async () => {
       const processor = __dirname + '/fixtures/fixture_processor_bar.js';
       const children = await Promise.all([
-        pool.retain(processor, NoopProc),
-        pool.retain(processor, NoopProc),
-        pool.retain(processor, NoopProc),
-        pool.retain(processor, NoopProc),
-        pool.retain(processor, NoopProc),
-        pool.retain(processor, NoopProc),
+        pool.retain(processor),
+        pool.retain(processor),
+        pool.retain(processor),
+        pool.retain(processor),
+        pool.retain(processor),
+        pool.retain(processor),
       ]);
 
       expect(children).toHaveLength(6);
@@ -109,7 +114,7 @@ function sandboxProcessTests(
       const processor = __dirname + '/fixtures/fixture_processor_bar.js';
       process.execArgv.push('--no-warnings');
 
-      const child = await pool.retain(processor, NoopProc);
+      const child = await pool.retain(processor);
       expect(child).toBeTruthy();
       if (!useWorkerThreads) {
         expect(child.childProcess.spawnargs).toContain('--no-warnings');


### PR DESCRIPTION
### Why

Fixes #3699 - this addresses a bug where BullMQ's sandboxed workers fail with an ERR_WORKER_INVALID_EXEC_ARGV error when the parent process is run with `node --watch` on v24+

(This PR builds off #3735 - I just ran into the same issue and wanted to try addressing the feedback. Hopefully I'm not stepping on anyone's toes!)

`convertExecArgv` currently processes all flags from `process.execArgv`, and assigns new ports to any `--inspect*` arguments, before passing them into either the child process or worker thread constructor. However, the docs for [new Worker(filename[, options])](https://nodejs.org/download/release/v22.14.0/docs/api/worker_threads.html#new-workerfilename-options) state:

> V8 options (such as --max-old-space-size) and options that affect the process (such as --title) are not supported. [...] By default, options are inherited from the parent thread.

Filtering out V8 options from `process.execArgv` seems like a tedious solution. The default behavior would be ideal if it weren't for the `--inspect` workaround...

However, at least in my testing, passing `--inspect` into a worker thread doesn't seem to have any effect (no debugger is spawned - tested on 18.20.1 and 24.13.0). I couldn't find this behavior documented anywhere, though.

Additionally:
- VS Code will pick up any worker threads for debugging automatically once it's attached to the parent
- WebStorm appears to do the same
- Recent node versions have an [--experimental-worker-inspection](https://nodejs.org/api/cli.html#--experimental-worker-inspection) flag that enables Chrome's DevTools to do the same
- The `node:inspector` API can still be used within a worker thread with no issue

As such, I'm hoping that `convertExecArgv` isn't actually needed for worker threads at all. Please let me know if I'm mistaken!

### How

- Removed `execArgv` from the default worker args
- Refactored `convertExecArgv` to more strictly look for `--inspect` and `--inspect-brk` (this avoids modifying `--inspect-publish-uid` by mistake)
- Updated tests/child-pool.test.ts to remove unnecessary arguments & clean up modifications to `process.execArgv`