### PR TITLE
fix(remove-by-max-age): consider generated repeatable jobs when removing orphaned jobs

### DIFF
--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -1133,6 +1133,12 @@ export class Queue<
         const colonIdx = suffix.indexOf(':');
         if (colonIdx !== -1) {
           const prefixPart = suffix.slice(0, colonIdx);
+
+          if (prefixPart === 'repeat' && suffix.split(':').length === 3) {
+            // consider generated job id from repeatables
+            candidateJobIds.add(suffix);
+            continue;
+          }
           if (knownSuffixes.has(prefixPart)) {
             continue;
           }

--- a/tests/clean.test.ts
+++ b/tests/clean.test.ts
@@ -1142,13 +1142,33 @@ describe('Cleaner', () => {
 
       // Simulate repeat sub-keys (e.g., repeat:abc123)
       await client.set(`${baseKey}:repeat:some-repeat-id`, 'repeat data');
+      await client.hmset(
+        `${baseKey}:repeat:839d4be40c8b2f30fca6f860d0cf76f7:1735711200000`,
+        'priority',
+        0,
+        'delay',
+        14524061394,
+        'data',
+        '{}',
+        'timestamp',
+        1721187138606,
+        'rjk',
+        'remove::::* 1 * 1 *',
+        'name',
+        'remove',
+      );
       // Simulate deduplication sub-keys (e.g., de:some-dedup-id)
       await client.set(`${baseKey}:de:some-dedup-id`, 'dedup data');
 
       const removed = await queue.removeOrphanedJobs();
-      expect(removed).toBe(0);
+      expect(removed).toBe(1);
 
       // Verify repeat and dedup keys are untouched
+      expect(
+        await client.exists(
+          `${baseKey}:repeat:839d4be40c8b2f30fca6f860d0cf76f7:1735711200000`,
+        ),
+      ).toBe(0);
       expect(await client.exists(`${baseKey}:repeat:some-repeat-id`)).toBe(1);
       expect(await client.exists(`${baseKey}:de:some-dedup-id`)).toBe(1);
 


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? In order to prevent orphan hashes when removing jobs from generation of repeatable jobs

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
