### PR TITLE
Fixed calling .includes() on job id of type Number - issue #3852

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -1579,7 +1579,7 @@ export class Job<
       );
     }
 
-    if (this.opts?.jobId) {
+    if (typeof this.opts?.jobId === 'string') {
       if (`${parseInt(this.opts.jobId, 10)}` === this.opts?.jobId) {
         throw new Error('Custom Id cannot be integers');
       }

--- a/tests/job.test.ts
+++ b/tests/job.test.ts
@@ -74,6 +74,13 @@ describe('Job', () => {
       expect(createdJob.id).toBe(customJobId);
     });
 
+    it('should use custom jobId when it is type Number', async () => {
+      const job = await Job.create(queue, 'test', data, {
+        jobId: 54321,
+      });
+      expect(job.id).toBe(54321);
+    });
+
     describe('when custom jobId is provided as empty string', () => {
       it('should ignore the empty custom id and generates a numeric id', async () => {
         const job = await Job.create(queue, 'test', data, {


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
Prevents a TypeError: jobId.includes is not a function when a custom jobId is passed as a Number. The current logic assumes jobId is always a String before calling .includes(). This was reported in https://github.com/taskforcesh/bullmq/issues/3852 after investigating a production issue.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
Added a type check to skip the string-based validation (numeric string and colon checks) if the jobId is already a Number.

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
If Number types are intentionally disallowed for jobId, we should implement an explicit validation or type-guard earlier in the lifecycle.
