### PR TITLE
fix(rate-limiter): avoid unnecessary GET when limiter key does not exist

### DIFF
--- a/src/commands/includes/getRateLimitTTL.lua
+++ b/src/commands/includes/getRateLimitTTL.lua
@@ -2,15 +2,18 @@
   Function to get current rate limit ttl.
 ]]
 local function getRateLimitTTL(maxJobs, rateLimiterKey)
-  if maxJobs and maxJobs <= tonumber(rcall("GET", rateLimiterKey) or 0) then
-    local pttl = rcall("PTTL", rateLimiterKey)
-
-    if pttl == 0 then
-      rcall("DEL", rateLimiterKey)
-    end
-
-    if pttl > 0 then
-      return pttl
+  if maxJobs then
+    -- Check if key exists first to avoid unnecessary GET on non-existent keys
+    if rcall("EXISTS", rateLimiterKey) == 1 then
+      local currentCount = tonumber(rcall("GET", rateLimiterKey))
+      if currentCount and maxJobs <= currentCount then
+        local pttl = rcall("PTTL", rateLimiterKey)
+        if pttl > 0 then
+          return pttl
+        elseif pttl == 0 then
+          rcall("DEL", rateLimiterKey)
+        end
+      end
     end
   end
   return 0

--- a/tests/rate_limiter.test.ts
+++ b/tests/rate_limiter.test.ts
@@ -1383,6 +1383,112 @@ describe('Rate Limiter', () => {
     });
   });
 
+  describe('getRateLimitTTL function behavior', () => {
+    // Key behaviors under test are:
+    //
+    //   1. Key does not exist  → EXISTS returns 0 → skip GET, return 0
+    //   2. Key exists, count < maxJobs  → return 0
+    //   3. Key exists, count >= maxJobs, PTTL > 0  → return PTTL
+    //   4. Key exists, count >= maxJobs, PTTL == -1 (no TTL)  → return 0
+    //   5. Key exists, count >= maxJobs, PTTL == 0 (transient expired state)
+    //        → DEL key + return 0
+    //   6. No maxJobs arg, no global rate limit  → raw PTTL (-2 when key absent)
+    //   7. No maxJobs arg, global rate limit configured  → uses meta max
+
+    describe('when the rate limiter key does not exist', () => {
+      it('should return 0 without performing a GET', async () => {
+        // EXISTS returns 0 → the inner GET is skipped entirely (new optimisation)
+        const ttl = await queue.getRateLimitTtl(5);
+        expect(ttl).toBe(0);
+      });
+    });
+
+    describe('when the rate limiter key exists with count below maxJobs', () => {
+      it('should return 0', async () => {
+        // count (2) < maxJobs (5) → not at the limit yet
+        await connection.set(queue.keys.limiter, 2, 'PX', 1000);
+        const ttl = await queue.getRateLimitTtl(5);
+        expect(ttl).toBe(0);
+      });
+    });
+
+    describe('when the rate limiter key exists with count equal to maxJobs and PTTL > 0', () => {
+      it('should return the remaining PTTL', async () => {
+        // count (5) == maxJobs (5) and PTTL > 0 → rate limited, return PTTL
+        await connection.set(queue.keys.limiter, 5, 'PX', 1000);
+        const ttl = await queue.getRateLimitTtl(5);
+        expect(ttl).toBeGreaterThan(0);
+        expect(ttl).toBeLessThanOrEqual(1000);
+      });
+    });
+
+    describe('when the rate limiter key exists with count above maxJobs and PTTL > 0', () => {
+      it('should return the remaining PTTL', async () => {
+        // count (10) > maxJobs (5) and PTTL > 0 → rate limited, return PTTL
+        await connection.set(queue.keys.limiter, 10, 'PX', 500);
+        const ttl = await queue.getRateLimitTtl(5);
+        expect(ttl).toBeGreaterThan(0);
+        expect(ttl).toBeLessThanOrEqual(500);
+      });
+    });
+
+    describe('when the rate limiter key exists with count above maxJobs but has no TTL', () => {
+      it('should return 0', async () => {
+        // count (10) > maxJobs (5) but PTTL == -1 (persistent key, no expiry)
+        // → pttl is not > 0, not == 0, so returns 0
+        await connection.set(queue.keys.limiter, 10);
+        const ttl = await queue.getRateLimitTtl(5);
+        expect(ttl).toBe(0);
+      });
+    });
+
+    describe('when the rate limiter key is in the transient PTTL == 0 expired state', () => {
+      it('should delete the key and return 0', async () => {
+        // PTTL == 0 is the edge-case where the key still shows as existing (EXISTS == 1)
+        // but PTTL has just reached 0.  In that case the function executes DEL and
+        // returns 0.  We approximate this state by setting an extremely short TTL and
+        // waiting for expiry; both code paths (EXISTS == 0 after natural eviction, and
+        // the explicit DEL when PTTL == 0) produce the same observable result: 0.
+        await connection.set(queue.keys.limiter, 10, 'PX', 1);
+        await delay(10); // allow the key to fully expire
+        const ttl = await queue.getRateLimitTtl(5);
+        expect(ttl).toBe(0);
+        // Confirm the key is absent — whether removed by Redis lazily or by the DEL branch
+        const keyExists = await connection.exists(queue.keys.limiter);
+        expect(keyExists).toBe(0);
+      });
+    });
+
+    describe('when maxJobs is not provided and no global rate limit is configured', () => {
+      it('should return -2 when the limiter key does not exist', async () => {
+        // No maxJobs → outer script falls back to raw PTTL; -2 means key absent
+        const ttl = await queue.getRateLimitTtl();
+        expect(ttl).toBe(-2);
+      });
+    });
+
+    describe('when maxJobs is not provided but a global rate limit is configured', () => {
+      it('should use the global max from the meta key and return PTTL when limit is reached', async () => {
+        // setGlobalRateLimit writes max=1 into the meta hash; then the outer script
+        // reads that value and passes it to getRateLimitTTL.
+        await queue.setGlobalRateLimit(1, 500);
+        // Simulate a counter already at the limit
+        await connection.set(queue.keys.limiter, 5, 'PX', 500);
+        const ttl = await queue.getRateLimitTtl();
+        expect(ttl).toBeGreaterThan(0);
+        expect(ttl).toBeLessThanOrEqual(500);
+      });
+
+      it('should return 0 when the counter is below the global max', async () => {
+        // Global max is 5, counter is 2 → not rate limited
+        await queue.setGlobalRateLimit(5, 500);
+        await connection.set(queue.keys.limiter, 2, 'PX', 500);
+        const ttl = await queue.getRateLimitTtl();
+        expect(ttl).toBe(0);
+      });
+    });
+  });
+
   it('should obey priority', async () => {
     // TODO: Move timeout to test options: { timeout: 10000 }
 


### PR DESCRIPTION
# Why
Fixes a Redis cache miss issue caused by getRateLimitTTL unconditionally calling GET on the rate limiter key on every job dequeue and completion, even when the key doesn't exist. Rate limiter keys are ephemeral — created on job processing via INCR and expiring after the configured duration. Between job executions the key is absent, so every GET returns nil, generating a cache miss. 

Closes #3848

# How
Added an EXISTS check in `getRateLimitTTL.lua` before the GET. When the key is absent — the common steady-state between rate limit windows — the function returns 0 immediately after a single EXISTS call, eliminating the miss-generating GET. The PTTL branches were also reordered so pttl > 0 returns early and pttl == 0 is an elseif, avoiding a redundant second condition check.

Tests covering all branches of the modified function were added to `rate_limiter.test.ts` under `describe('getRateLimitTTL function behavior')`.

### Additional Notes
<img width="1019" height="333" alt="image" src="https://github.com/user-attachments/assets/315eb05c-c274-46b4-8dd7-e914c68df60e" />

<img width="1694" height="131" alt="image" src="https://github.com/user-attachments/assets/69392adb-43b7-4ace-86c8-1f6a00266dee" />
