### PR TITLE
fix(python): use discard instead of remove in processJob to prevent KeyError

### DIFF
--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -250,7 +250,7 @@ class Worker(EventEmitter):
             except Exception as err:
                 self.emit("error", err, job)
         finally:
-            self.jobs.remove((job, token))
+            self.jobs.discard((job, token))
 
     async def retryIfFailed(self, fn, opts=None):
         """


### PR DESCRIPTION
## Problem

With `concurrency > 1`, asyncio task interleaving can cause a `(job, token)` tuple to be missing from `self.jobs` when the `finally` block in `processJob` tries to remove it. This raises a `KeyError` that crashes the worker.

**Reproduction:** Run a Python worker with `concurrency >= 2` under sustained load. The `processJob` coroutines interleave, and occasionally two tasks process the same job reference, causing one `remove()` call to find the entry already gone.

## Root cause

`python/bullmq/worker.py` line 253:
```python
self.jobs.remove((job, token))  # raises KeyError if missing
```

The TypeScript worker avoids this entirely by not using a `self.jobs` tracking set — it uses `AsyncFifoQueue` instead.

## Fix

Replace `set.remove()` with `set.discard()` — a drop-in replacement that silently ignores missing entries. The job already completed, so the tracking entry is irrelevant.

```diff
- self.jobs.remove((job, token))
+ self.jobs.discard((job, token))
```

## Impact

Without this fix, workers with `concurrency > 1` experience intermittent `KeyError` crashes in `processJob`, triggering restart loops that compound other issues (e.g., connection leaks from incomplete `close()` calls).