### PR TITLE
fix(python): make Worker.close() fault-tolerant to match TypeScript

### DIFF
--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -341,8 +341,12 @@ class Worker(EventEmitter):
         if not force and len(self.processing) > 0:
             await asyncio.wait(self.processing, return_when=asyncio.ALL_COMPLETED)
 
-        await self.blockingRedisConnection.close()
-        await self.redisConnection.close()
+        for conn in (self.blockingRedisConnection, self.redisConnection):
+            try:
+                await conn.close()
+            except Exception as err:
+                self.emit('error', err)
+
         self.closed = True
         self.emit('closed')
 


### PR DESCRIPTION
## Problem

`Worker.close()` calls `blockingRedisConnection.close()` then `redisConnection.close()` sequentially with no error handling. If the first throws (e.g., the blocking connection is stuck in `BZPOPMIN`), the second never runs and its TCP connection leaks permanently.

Over time, leaked connections accumulate until the Redis `maxclients` limit is hit and new connections are rejected.

**Observed in production:** A single zone accumulated 158 zombie Redis connections (83 lifecycle + 42 collection workers) against a 256 `maxclients` limit, with 4,809 rejected connections.

## Root cause

`python/bullmq/worker.py` lines 344-345:
```python
await self.blockingRedisConnection.close()  # if this throws...
await self.redisConnection.close()          # ...this never runs
```

## TypeScript reference

The TypeScript worker already handles this correctly (`src/classes/worker.ts` lines 1264-1271):

```typescript
// Run cleanup functions sequentially and make sure all are run despite any errors
for (const cleanup of asyncCleanups) {
    try {
        await cleanup();
    } catch (err) {
        this.emit('error', err);
    }
}
```

## Fix

Apply the same pattern — iterate both connections with independent try/catch:

```python
for conn in (self.blockingRedisConnection, self.redisConnection):
    try:
        await conn.close()
    except Exception as err:
        self.emit('error', err)
```

One connection failure can no longer prevent the other from closing.