### PR TITLE
fix(flow-producer): use deduplication id when no jobId is provided

### DIFF
--- a/src/classes/flow-producer.ts
+++ b/src/classes/flow-producer.ts
@@ -320,7 +320,9 @@ export class FlowProducer extends EventEmitter {
     const queueOpts = queuesOpts && queuesOpts[node.queueName];
 
     const jobsOpts = queueOpts?.defaultJobOptions ?? {};
-    const jobId = node.opts?.jobId || v4();
+    const deduplicationId = node.opts?.deduplication?.id;
+
+    const jobId = node.opts?.jobId ?? deduplicationId ?? v4();
 
     return trace<Promise<JobNode>>(
       this.telemetry,

--- a/tests/flow-producer-deduplication.test.ts
+++ b/tests/flow-producer-deduplication.test.ts
@@ -1,0 +1,105 @@
+import IORedis from 'ioredis';
+import { describe, beforeEach, afterEach, it, expect } from 'vitest';
+import { v4 } from 'uuid';
+
+import { FlowProducer } from '../src';
+import { removeAllQueueData } from '../src/utils';
+
+describe('FlowProducer deduplication', () => {
+  const redisHost = process.env.REDIS_HOST || '127.0.0.1';
+
+  let flowProducer: FlowProducer;
+  let queueName: string;
+  let prefix: string;
+
+  beforeEach(async () => {
+    queueName = `test-${v4()}`;
+    prefix = `bull-${v4()}`;
+
+    const connection = new IORedis(redisHost, {
+      maxRetriesPerRequest: null,
+    });
+
+    flowProducer = new FlowProducer({ connection, prefix });
+  });
+
+  afterEach(async () => {
+    const client = await flowProducer.client;
+    await removeAllQueueData(client, queueName);
+    await flowProducer.close();
+  });
+
+  it('should reuse job when deduplication id is the same', async () => {
+    const first = await flowProducer.add({
+      name: 'job',
+      queueName,
+      data: {},
+      opts: {
+        deduplication: { id: 'dedup-1' },
+      },
+    });
+
+    const second = await flowProducer.add({
+      name: 'job',
+      queueName,
+      data: {},
+      opts: {
+        deduplication: { id: 'dedup-1' },
+      },
+    });
+
+    expect(first.job.id).toBe(second.job.id);
+  });
+
+  it('should create different jobs for different deduplication ids', async () => {
+    const first = await flowProducer.add({
+      name: 'job',
+      queueName,
+      data: {},
+      opts: {
+        deduplication: { id: 'dedup-1' },
+      },
+    });
+
+    const second = await flowProducer.add({
+      name: 'job',
+      queueName,
+      data: {},
+      opts: {
+        deduplication: { id: 'dedup-2' },
+      },
+    });
+
+    expect(first.job.id).not.toBe(second.job.id);
+  });
+
+  it('should prioritize jobId over deduplication id', async () => {
+    const result = await flowProducer.add({
+      name: 'job',
+      queueName,
+      data: {},
+      opts: {
+        jobId: 'job-1',
+        deduplication: { id: 'dedup-1' },
+      },
+    });
+
+    expect(result.job.id).toBe('job-1');
+  });
+
+  it('should create different jobs when no deduplication is provided', async () => {
+    const first = await flowProducer.add({
+      name: 'job',
+      queueName,
+      data: {},
+    });
+
+    const second = await flowProducer.add({
+      name: 'job',
+      queueName,
+      data: {},
+    });
+
+    expect(first.job.id).not.toBe(second.job.id);
+  });
+});


### PR DESCRIPTION
Fixes #3878

## Problem
FlowProducer.add does not respect deduplication.id, resulting in duplicate jobs when using flows.

## Solution
This PR attempts to address this by using `deduplication.id` as a fallback `jobId` when no explicit `jobId` is provided.

## Notes
- Keeps existing `jobId` precedence unchanged
- Adds tests to cover the deduplication behavior