### PR TITLE
fix: blog (fail-fast) job data syntax

### DIFF
--- a/docs/gitbook/patterns/failing-fast-when-redis-is-down.md
+++ b/docs/gitbook/patterns/failing-fast-when-redis-is-down.md
@@ -13,7 +13,7 @@ const myQueue = new Queue("transcoding", {
 
 app.post("/jobs", async (req, res) => {
   try {
-    const job = await myQueue.add("myjob", { req.body });
+    const job = await myQueue.add("myjob", req.body);
     res.status(201).json(job.id);
   }catch(err){
     res.status(503).send(err);


### PR DESCRIPTION
### Why
This change fixes a syntax issue in the job submission example on https://docs.bullmq.io/patterns/failing-fast-when-redis-is-down.

The previous implementation used { req.body }, which wrapped the payload in an extra body property and could prevent the job from being added correctly.

### How
Corrected the second argument of the myQueue.add() method to pass req.body directly as the data object.

### Additional Notes (Optional)
None.
