### PR TITLE
fix(sandbox): remove race condition when starting sandboxed processor…

### DIFF
--- a/src/classes/child-processor.ts
+++ b/src/classes/child-processor.ts
@@ -10,6 +10,7 @@ import { errorToJSON } from '../utils';
 
 enum ChildStatus {
   Idle,
+  Starting,
   Started,
   Terminating,
   Errored,
@@ -29,6 +30,7 @@ export class ChildProcessor {
   public processor: any;
   public currentJobPromise: Promise<unknown> | undefined;
   private abortController?: AbortController;
+  private pending?: { job: JobJsonSandbox; token?: string };
 
   constructor(
     private send: (msg: any) => Promise<void>,
@@ -77,15 +79,48 @@ export class ChildProcessor {
     });
   }
 
-  public async start(jobJson: JobJsonSandbox, token?: string): Promise<void> {
+  public async start(
+    jobJson: JobJsonSandbox,
+    token?: string,
+    waitForReady = false,
+  ): Promise<void> {
     if (this.status !== ChildStatus.Idle) {
       return this.send({
         cmd: ParentCommand.Error,
         err: errorToJSON(new Error('cannot start a not idling child process')),
       });
     }
-    this.status = ChildStatus.Started;
+    this.status = ChildStatus.Starting;
     this.abortController = new AbortController();
+
+    if (waitForReady) {
+      this.pending = { job: jobJson, token };
+
+      return await this.send({
+        cmd: ParentCommand.StartReady,
+      });
+    }
+
+    await this.runJob(jobJson, token);
+  }
+
+  public async run(): Promise<void> {
+    if (this.status !== ChildStatus.Starting || !this.pending) {
+      return this.send({
+        cmd: ParentCommand.Error,
+        err: errorToJSON(new Error('cannot run a job that is not starting')),
+      });
+    }
+
+    const { job, token } = this.pending;
+    this.pending = undefined;
+
+    await this.runJob(job, token);
+  }
+
+  private async runJob(jobJson: JobJsonSandbox, token?: string): Promise<void> {
+    this.status = ChildStatus.Started;
+
     this.currentJobPromise = (async () => {
       try {
         const job = this.wrapJob(jobJson, this.send);
@@ -104,9 +139,7 @@ export class ChildProcessor {
           value: errorToJSON(!(<Error>err).message ? new Error(<any>err) : err),
         });
       } finally {
-        this.status = ChildStatus.Idle;
-        this.currentJobPromise = undefined;
-        this.abortController = undefined;
+        this.resetCurrentJobState();
       }
     })();
   }
@@ -118,7 +151,26 @@ export class ChildProcessor {
   public cancel(reason?: string): void {
     if (this.abortController) {
       this.abortController.abort(reason);
+
+      if (this.status === ChildStatus.Starting) {
+        this.status = ChildStatus.Idle;
+        this.abortController = undefined;
+        this.pending = undefined;
+        this.currentJobPromise = this.send({
+          cmd: ParentCommand.Failed,
+          value: errorToJSON(new Error(reason || 'Job was cancelled')),
+        }).finally(() => {
+          this.currentJobPromise = undefined;
+        });
+      }
     }
+  }
+
+  private resetCurrentJobState(): void {
+    this.status = ChildStatus.Idle;
+    this.currentJobPromise = undefined;
+    this.abortController = undefined;
+    this.pending = undefined;
   }
 
   public async stop(): Promise<void> {}

--- a/src/classes/child.ts
+++ b/src/classes/child.ts
@@ -180,15 +180,17 @@ export class Child extends EventEmitter {
         }
 
         if (msg.cmd === ParentCommand.InitCompleted) {
+          this.off('message', onMessageHandler);
+          this.off('close', onCloseHandler);
           resolve();
         } else if (msg.cmd === ParentCommand.InitFailed) {
           const err = new Error();
           err.stack = msg.err.stack;
           err.message = msg.err.message;
+          this.off('message', onMessageHandler);
+          this.off('close', onCloseHandler);
           reject(err);
         }
-        this.off('message', onMessageHandler);
-        this.off('close', onCloseHandler);
       };
 
       const onCloseHandler = (code: number, signal: number) => {

--- a/src/classes/main-base.ts
+++ b/src/classes/main-base.ts
@@ -17,7 +17,10 @@ export default (send: (msg: any) => Promise<void>, receiver: Receiver) => {
           await childProcessor.init(msg.value);
           break;
         case ChildCommand.Start:
-          await childProcessor.start(msg.job, msg?.token);
+          await childProcessor.start(msg.job, msg?.token, msg?.waitForReady);
+          break;
+        case ChildCommand.Run:
+          await childProcessor.run();
           break;
         case ChildCommand.Stop:
           break;

--- a/src/classes/sandbox.ts
+++ b/src/classes/sandbox.ts
@@ -17,6 +17,7 @@ const sandbox = <T, R, N extends string>(
     let msgHandler: any;
     let exitHandler: any;
     let abortHandler: (() => void) | undefined;
+    let readyForRun = false;
     try {
       const done: Promise<R> = new Promise((resolve, reject) => {
         const initChild = async () => {
@@ -35,6 +36,20 @@ const sandbox = <T, R, N extends string>(
             msgHandler = async (msg: ChildMessage) => {
               try {
                 switch (msg.cmd) {
+                  case ParentCommand.StartReady:
+                    readyForRun = true;
+
+                    if (signal?.aborted) {
+                      await child.send({
+                        cmd: ChildCommand.Cancel,
+                        value: signal?.reason,
+                      });
+                    } else {
+                      await child.send({
+                        cmd: ChildCommand.Run,
+                      });
+                    }
+                    break;
                   case ParentCommand.Completed:
                     resolve(msg.value);
                     break;
@@ -104,14 +119,12 @@ const sandbox = <T, R, N extends string>(
 
             child.on('message', msgHandler);
 
-            child.send({
-              cmd: ChildCommand.Start,
-              job: job.asJSONSandbox(),
-              token,
-            });
-
             if (signal) {
               abortHandler = () => {
+                if (!readyForRun) {
+                  return;
+                }
+
                 try {
                   child.send({
                     cmd: ChildCommand.Cancel,
@@ -122,12 +135,17 @@ const sandbox = <T, R, N extends string>(
                 }
               };
 
-              if (signal.aborted) {
-                abortHandler();
-              } else {
+              if (!signal.aborted) {
                 signal.addEventListener('abort', abortHandler, { once: true });
               }
             }
+
+            await child.send({
+              cmd: ChildCommand.Start,
+              job: job.asJSONSandbox(),
+              token,
+              waitForReady: true,
+            });
           } catch (error) {
             reject(error);
           }

--- a/src/enums/child-command.ts
+++ b/src/enums/child-command.ts
@@ -6,4 +6,5 @@ export enum ChildCommand {
   GetIgnoredChildrenFailuresResponse,
   MoveToWaitingChildrenResponse,
   Cancel,
+  Run,
 }

--- a/src/enums/parent-command.ts
+++ b/src/enums/parent-command.ts
@@ -12,4 +12,5 @@ export enum ParentCommand {
   GetChildrenValues,
   GetIgnoredChildrenFailures,
   MoveToWaitingChildren,
+  StartReady,
 }

--- a/tests/fixtures/fixture_main_non_bullmq_messages.js
+++ b/tests/fixtures/fixture_main_non_bullmq_messages.js
@@ -38,9 +38,15 @@ process.on('message', async msg => {
         await childProcessor.init(msg.value);
         break;
       case ChildCommand.Start:
-        await childProcessor.start(msg.job, msg?.token);
+        await childProcessor.start(msg.job, msg?.token, msg?.waitForReady);
+        break;
+      case ChildCommand.Run:
+        await childProcessor.run();
         break;
       case ChildCommand.Stop:
+        break;
+      case ChildCommand.Cancel:
+        childProcessor.cancel(msg.value);
         break;
     }
   } catch (err) {

--- a/tests/sandboxed_process.test.ts
+++ b/tests/sandboxed_process.test.ts
@@ -1,4 +1,5 @@
 import { pathToFileURL } from 'url';
+import { EventEmitter } from 'events';
 import { default as IORedis } from 'ioredis';
 import { after } from 'lodash';
 import {
@@ -20,6 +21,9 @@ import {
   UNRECOVERABLE_ERROR,
   Worker,
 } from '../src/classes';
+import { ChildProcessor } from '../src/classes/child-processor';
+import sandbox from '../src/classes/sandbox';
+import { ChildCommand, ParentCommand } from '../src/enums';
 
 import { v4 } from 'uuid';
 import { delay, removeAllQueueData } from '../src/utils';
@@ -58,7 +62,8 @@ describe('Sandboxed process using child processes', () => {
     });
 
     it('should handle non-BullMQ messages during child initialization', async function () {
-      const mainFile = __dirname + '/fixtures/fixture_main_non_bullmq_messages.js';
+      const mainFile =
+        __dirname + '/fixtures/fixture_main_non_bullmq_messages.js';
       const processFile = __dirname + '/fixtures/fixture_processor_simple.js';
 
       const child = new Child(mainFile, processFile, {
@@ -73,6 +78,242 @@ describe('Sandboxed process using child processes', () => {
       expect(child.killed).to.be.false;
 
       await child.kill();
+    });
+
+    it('should emit StartReady before completion', async function () {
+      const processFile = __dirname + '/fixtures/fixture_processor_simple.js';
+
+      const sentMessages: any[] = [];
+      const receiver = new EventEmitter();
+      const childProcessor = new ChildProcessor(async msg => {
+        sentMessages.push(msg);
+      }, receiver as any);
+
+      await childProcessor.init(processFile);
+      await childProcessor.start(
+        {
+          id: 'job-1',
+          name: 'test',
+          data: JSON.stringify({ foo: 'bar' }),
+          opts: {},
+          progress: 0,
+          attemptsMade: 0,
+          attemptsStarted: 0,
+          timestamp: Date.now(),
+          failedReason: JSON.stringify(''),
+          stacktrace: JSON.stringify([]),
+          returnvalue: JSON.stringify(null),
+          stalledCounter: 0,
+          queueName: 'test-queue',
+          queueQualifiedName: 'bull:test-queue',
+          prefix: 'bull',
+        },
+        'token-1',
+        true,
+      );
+
+      await childProcessor.run();
+
+      await childProcessor.currentJobPromise;
+
+      const startReadyIndex = sentMessages.findIndex(
+        msg => msg.cmd === ParentCommand.StartReady,
+      );
+      const completedIndex = sentMessages.findIndex(
+        msg => msg.cmd === ParentCommand.Completed,
+      );
+
+      expect(startReadyIndex).toBeGreaterThan(-1);
+      expect(completedIndex).toBeGreaterThan(-1);
+      expect(startReadyIndex).toBeLessThan(completedIndex);
+    });
+
+    it('should fail before running user code when cancelled before Run', async function () {
+      const processFile = __dirname + '/fixtures/fixture_processor_simple.js';
+
+      const sentMessages: any[] = [];
+      const receiver = new EventEmitter();
+      const childProcessor = new ChildProcessor(async msg => {
+        sentMessages.push(msg);
+      }, receiver as any);
+
+      await childProcessor.init(processFile);
+      await childProcessor.start(
+        {
+          id: 'job-1',
+          name: 'test',
+          data: JSON.stringify({ foo: 'bar' }),
+          opts: {},
+          progress: 0,
+          attemptsMade: 0,
+          attemptsStarted: 0,
+          timestamp: Date.now(),
+          failedReason: JSON.stringify(''),
+          stacktrace: JSON.stringify([]),
+          returnvalue: JSON.stringify(null),
+          stalledCounter: 0,
+          queueName: 'test-queue',
+          queueQualifiedName: 'bull:test-queue',
+          prefix: 'bull',
+        },
+        'token-1',
+        true,
+      );
+
+      childProcessor.cancel('cancelled-before-run');
+      await childProcessor.currentJobPromise;
+
+      const startReadyIndex = sentMessages.findIndex(
+        msg => msg.cmd === ParentCommand.StartReady,
+      );
+      const failedIndex = sentMessages.findIndex(
+        msg => msg.cmd === ParentCommand.Failed,
+      );
+      const completedIndex = sentMessages.findIndex(
+        msg => msg.cmd === ParentCommand.Completed,
+      );
+
+      expect(startReadyIndex).toBeGreaterThan(-1);
+      expect(failedIndex).toBeGreaterThan(-1);
+      expect(completedIndex).toBe(-1);
+      expect(sentMessages[failedIndex].value.message).toBe(
+        'cancelled-before-run',
+      );
+    });
+
+    it('should error if Run is received before Start', async function () {
+      const processFile = __dirname + '/fixtures/fixture_processor_simple.js';
+
+      const sentMessages: any[] = [];
+      const receiver = new EventEmitter();
+      const childProcessor = new ChildProcessor(async msg => {
+        sentMessages.push(msg);
+      }, receiver as any);
+
+      await childProcessor.init(processFile);
+      await childProcessor.run();
+
+      expect(sentMessages.at(-1)).toMatchObject({
+        cmd: ParentCommand.Error,
+      });
+      expect(sentMessages.at(-1).err.message).toBe(
+        'cannot run a job that is not starting',
+      );
+    });
+
+    it('should error if Start is received twice before Run', async function () {
+      const processFile = __dirname + '/fixtures/fixture_processor_simple.js';
+
+      const sentMessages: any[] = [];
+      const receiver = new EventEmitter();
+      const childProcessor = new ChildProcessor(async msg => {
+        sentMessages.push(msg);
+      }, receiver as any);
+
+      const job = {
+        id: 'job-1',
+        name: 'test',
+        data: JSON.stringify({ foo: 'bar' }),
+        opts: {},
+        progress: 0,
+        attemptsMade: 0,
+        attemptsStarted: 0,
+        timestamp: Date.now(),
+        failedReason: JSON.stringify(''),
+        stacktrace: JSON.stringify([]),
+        returnvalue: JSON.stringify(null),
+        stalledCounter: 0,
+        queueName: 'test-queue',
+        queueQualifiedName: 'bull:test-queue',
+        prefix: 'bull',
+      };
+
+      await childProcessor.init(processFile);
+      await childProcessor.start(job, 'token-1', true);
+      await childProcessor.start(job, 'token-1', true);
+
+      expect(sentMessages.at(-1)).toMatchObject({
+        cmd: ParentCommand.Error,
+      });
+      expect(sentMessages.at(-1).err.message).toBe(
+        'cannot start a not idling child process',
+      );
+    });
+
+    it('should send Cancel instead of Run when already aborted before StartReady', async function () {
+      const sentCommands: number[] = [];
+      const child = new EventEmitter() as Child & {
+        send: (msg: any) => Promise<void>;
+        exitCode: number | null;
+        signalCode: number | null;
+      };
+      child.exitCode = null;
+      child.signalCode = null;
+      child.send = async msg => {
+        sentCommands.push(msg.cmd);
+
+        if (msg.cmd === ChildCommand.Start) {
+          queueMicrotask(() => {
+            child.emit('message', { cmd: ParentCommand.StartReady });
+          });
+        }
+
+        if (msg.cmd === ChildCommand.Cancel) {
+          queueMicrotask(() => {
+            child.emit('message', {
+              cmd: ParentCommand.Failed,
+              value: { message: msg.value },
+            });
+          });
+        }
+      };
+
+      const childPool = {
+        retain: async () => child,
+        release: () => undefined,
+      };
+
+      const process = sandbox('processor.js', childPool as any);
+      const job = {
+        asJSONSandbox: () => ({
+          id: 'job-1',
+          name: 'test',
+          data: JSON.stringify({ foo: 'bar' }),
+          opts: {},
+          progress: 0,
+          attemptsMade: 0,
+          attemptsStarted: 0,
+          timestamp: Date.now(),
+          failedReason: JSON.stringify(''),
+          stacktrace: JSON.stringify([]),
+          returnvalue: JSON.stringify(null),
+          stalledCounter: 0,
+          queueName: 'test-queue',
+          queueQualifiedName: 'bull:test-queue',
+          prefix: 'bull',
+        }),
+        updateProgress: async () => undefined,
+        log: async () => undefined,
+        moveToDelayed: async () => undefined,
+        moveToWait: async () => undefined,
+        moveToWaitingChildren: async () => false,
+        updateData: async () => undefined,
+        getChildrenValues: async () => ({}),
+        getIgnoredChildrenFailures: async () => ({}),
+      } as unknown as Job<any, any, string>;
+
+      const controller = new AbortController();
+      controller.abort('already-aborted');
+
+      await expect(
+        process(job, 'token-1', controller.signal),
+      ).rejects.toMatchObject({
+        message: 'already-aborted',
+      });
+
+      expect(sentCommands).toContain(ChildCommand.Start);
+      expect(sentCommands).toContain(ChildCommand.Cancel);
+      expect(sentCommands).not.toContain(ChildCommand.Run);
     });
 
     it('should allow to pass workerForkOptions', async () => {


### PR DESCRIPTION
… with abort signal

<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
To avoid a race condition that appears when using the abort signal functionality with sandboxed processors.


### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
Introduces a two-phase start protocol for sandboxed child processes to
eliminate a race condition where an abort signal could arrive before the
child was ready to handle it, or user code could start executing before
the abort was delivered.

- Add intermediate `Starting` state and `pending` job storage in
  ChildProcessor
- Add `StartReady` parent command and `Run` child command to implement
  a handshake before executing user code
- When `waitForReady=true`, the child signals readiness via `StartReady`
  and waits for an explicit `Run` (or `Cancel`) from the parent
- Handle cancellation during `Starting` state by failing immediately
  without running user code
- Fix event listener cleanup order in Child init to remove handlers
  before resolving/rejecting
- Add unit tests for the new protocol edge cases
- 
### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
