### PR TITLE
fix(cancellation): use native AbortController implementation if found

### DIFF
--- a/src/classes/abort-controller.ts
+++ b/src/classes/abort-controller.ts
@@ -1,0 +1,14 @@
+// Note: this Polyfill is only needed for Node versions < 15.4.0
+import { AbortController as AbortControllerPolyfill } from 'node-abort-controller';
+
+let AbortControllerImpl: typeof AbortControllerPolyfill;
+
+// prefer native AbortController implementation if found
+if (globalThis.AbortController) {
+  AbortControllerImpl =
+    globalThis.AbortController as typeof AbortControllerPolyfill;
+} else {
+  AbortControllerImpl = AbortControllerPolyfill;
+}
+
+export class AbortController extends AbortControllerImpl {}

--- a/src/classes/child-processor.ts
+++ b/src/classes/child-processor.ts
@@ -1,4 +1,4 @@
-import { AbortController } from 'node-abort-controller';
+import { AbortController } from './abort-controller';
 import { ParentCommand } from '../enums';
 import {
   MoveToWaitingChildrenOpts,

--- a/src/classes/lock-manager.ts
+++ b/src/classes/lock-manager.ts
@@ -1,4 +1,4 @@
-import { AbortController } from 'node-abort-controller';
+import { AbortController } from './abort-controller';
 import { SpanKind, TelemetryAttributes } from '../enums';
 import { LockManagerWorkerContext, Span } from '../interfaces';
 

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -3,9 +3,7 @@ import { URL } from 'url';
 import type { Cluster, Redis } from 'ioredis';
 import * as path from 'path';
 import { v4 } from 'uuid';
-
-// Note: this Polyfill is only needed for Node versions < 15.4.0
-import { AbortController } from 'node-abort-controller';
+import { AbortController } from './abort-controller';
 
 import {
   GetNextJobOptions,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,5 @@
 import { Cluster, Redis } from 'ioredis';
-
-// Note: this Polyfill is only needed for Node versions < 15.4.0
-import { AbortController } from 'node-abort-controller';
+import { AbortController } from '../classes/abort-controller';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
Node.js versions starting from `v15.4.0` provide native implementations of `AbortController` and `AbortSignal` classes. When combining native abort signals with the polyfilled `AbortSignal` from `node-abort-controller` (using `AbortSignal.any())`, Node will throw an error because it requires all signals to share the same prototype when composing.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
With this change, instead of using the pollyfilled `AbortController` implementation indiscriminately, bullmq will use the native implementation by default and only fall back to the polyfill if the `AbortController` class is not present in the global namespace.

This is done by exporting an `AbortController`-class from `src/classes/abort-controller.ts` that conditionally extends either the native implementation or the polyfill.

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
Fixes #3901 
