### PR TITLE
fix: coerce jobId to string before validation to prevent runtime crash

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -1580,16 +1580,14 @@ export class Job<
     }
 
     if (this.opts?.jobId) {
-      if (`${parseInt(this.opts.jobId, 10)}` === this.opts?.jobId) {
+      const jobId = String(this.opts.jobId);
+      if (`${parseInt(jobId, 10)}` === jobId) {
         throw new Error('Custom Id cannot be integers');
       }
 
       // TODO: replace this check in next breaking check with include(':')
       // By using split we are still keeping compatibility with old repeatable jobs
-      if (
-        this.opts?.jobId.includes(':') &&
-        this.opts?.jobId?.split(':').length !== 3
-      ) {
+      if (jobId.includes(':') && jobId.split(':').length !== 3) {
         throw new Error('Custom Id cannot contain :');
       }
     }

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -163,6 +163,20 @@ describe('queues', () => {
       });
     });
 
+    describe('when jobId is provided as a numeric type', () => {
+      it('coerces to string and throws if numeric', async () => {
+        await expect(
+          queue.add('test', { foo: 1 }, { jobId: 123 as any }),
+        ).rejects.toThrow('Custom Id cannot be integers');
+      });
+
+      it('does not crash with a non-numeric number type', async () => {
+        await expect(
+          queue.add('test', { foo: 1 }, { jobId: 'valid-id' }),
+        ).resolves.toBeDefined();
+      });
+    });
+
     describe('when custom job id contains :', () => {
       it('throws an error', async () => {
         await expect(


### PR DESCRIPTION
## Problem

When a JavaScript user passes a non-string value as `jobId` (e.g., `{ jobId: 123 }`), the validation block in `Job` crashes with:

```
TypeError: _d.jobId.includes is not a function
```

This happens because `Number` does not have an `.includes()` method, which is called at [src/classes/job.ts:1590](https://github.com/taskforcesh/bullmq/blob/master/src/classes/job.ts#L1590).

While the TypeScript type correctly defines `jobId` as `string`, JavaScript users (or those using `as any`) can pass any type at runtime without compile-time safety.

## Root Cause

The validation block at `job.ts:1582-1595` calls `.includes(':')` and `.split(':')` directly on `this.opts.jobId` without first ensuring it is a string. The `parseInt` check on line 1583 only catches numeric *strings* (e.g., `"123"`), not actual `Number` values.

## Solution

Coerce `jobId` to a string with `String(this.opts.jobId)` before running any validation. This:

- **Prevents the crash** on non-string types
- **Preserves existing behavior** for string inputs (no breaking change)
- **Still correctly rejects numeric IDs** (e.g., `123` → `"123"` → rejected by the integer check)
- **Reduces repetition** by extracting `jobId` into a local variable instead of accessing `this.opts?.jobId` four times

## Changes

- `src/classes/job.ts`: Coerce `this.opts.jobId` to string before validation
- `tests/queue.test.ts`: Add test case for numeric `jobId` type to prevent regression

## Test Plan

- `{ jobId: 123 }` (number) → coerces to `"123"`, rejected as integer ✅
- `{ jobId: '2' }` (numeric string) → rejected as integer (existing behavior) ✅
- `{ jobId: 'valid-id' }` (valid string) → passes validation (existing behavior) ✅
- `{ jobId: '1:0' }` (colon) → rejected (existing behavior) ✅

Closes #3852