### PR TITLE
feat: add generic ProgressType parameter to Job and Worker

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -60,7 +60,8 @@ export class Job<
   DataType = any,
   ReturnType = any,
   NameType extends string = string,
-> implements MinimalJob<DataType, ReturnType, NameType> {
+  ProgressType extends JobProgress = JobProgress,
+> implements MinimalJob<DataType, ReturnType, NameType, ProgressType> {
   /**
    * It includes the prefix, the namespace separator :, and queue name.
    * @see {@link https://www.gnu.org/software/gawk/manual/html_node/Qualified-Names.html}
@@ -71,7 +72,7 @@ export class Job<
    * The progress a job has performed so far.
    * @defaultValue 0
    */
-  progress: JobProgress = 0;
+  progress: ProgressType = 0 as ProgressType;
 
   /**
    * The value returned by the processor when processing this job.
@@ -612,7 +613,7 @@ export class Job<
    *
    * @param progress - number or object to be saved as progress.
    */
-  async updateProgress(progress: JobProgress): Promise<void> {
+  async updateProgress(progress: ProgressType): Promise<void> {
     this.progress = progress;
     await this.scripts.updateProgress(this.id, progress);
     this.queue.emit('progress', this, progress);

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -52,13 +52,17 @@ export interface WorkerListener<
   DataType = any,
   ResultType = any,
   NameType extends string = string,
+  ProgressType extends JobProgress = JobProgress,
 > extends IoredisListener {
   /**
    * Listen to 'active' event.
    *
    * This event is triggered when a job enters the 'active' state.
    */
-  active: (job: Job<DataType, ResultType, NameType>, prev: string) => void;
+  active: (
+    job: Job<DataType, ResultType, NameType, ProgressType>,
+    prev: string,
+  ) => void;
 
   /**
    * Listen to 'closed' event.
@@ -80,7 +84,7 @@ export interface WorkerListener<
    * This event is triggered when a job has successfully completed.
    */
   completed: (
-    job: Job<DataType, ResultType, NameType>,
+    job: Job<DataType, ResultType, NameType, ProgressType>,
     result: ResultType,
     prev: string,
   ) => void;
@@ -109,7 +113,7 @@ export interface WorkerListener<
    * reaches the stalled limit and it is deleted by the removeOnFail option.
    */
   failed: (
-    job: Job<DataType, ResultType, NameType> | undefined,
+    job: Job<DataType, ResultType, NameType, ProgressType> | undefined,
     error: Error,
     prev: string,
   ) => void;
@@ -130,8 +134,8 @@ export interface WorkerListener<
    * world.
    */
   progress: (
-    job: Job<DataType, ResultType, NameType>,
-    progress: JobProgress,
+    job: Job<DataType, ResultType, NameType, ProgressType>,
+    progress: ProgressType,
   ) => void;
 
   /**
@@ -182,6 +186,7 @@ export class Worker<
   DataType = any,
   ResultType = any,
   NameType extends string = string,
+  ProgressType extends JobProgress = JobProgress,
 > extends QueueBase {
   declare readonly opts: WorkerOptions;
   readonly id: string;
@@ -204,7 +209,7 @@ export class Worker<
   protected _jobScheduler: JobScheduler;
 
   protected paused: boolean;
-  protected processFn: Processor<DataType, ResultType, NameType>;
+  protected processFn: Processor<DataType, ResultType, NameType, ProgressType>;
   protected running = false;
   protected mainLoopRunning: Promise<void> | null = null;
 
@@ -214,7 +219,11 @@ export class Worker<
 
   constructor(
     name: string,
-    processor?: string | URL | null | Processor<DataType, ResultType, NameType>,
+    processor?:
+      | string
+      | URL
+      | null
+      | Processor<DataType, ResultType, NameType, ProgressType>,
     opts?: WorkerOptions,
     Connection?: typeof RedisConnection,
   ) {
@@ -377,7 +386,11 @@ export class Worker<
    * @param processor - The processor file path, URL, or function to be sandboxed
    */
   protected createSandbox(
-    processor: string | URL | null | Processor<DataType, ResultType, NameType>,
+    processor:
+      | string
+      | URL
+      | null
+      | Processor<DataType, ResultType, NameType, ProgressType>,
   ) {
     this.processFn = sandbox<DataType, ResultType, NameType>(
       processor,
@@ -397,39 +410,69 @@ export class Worker<
     return this.scripts.extendLocks(jobIds, tokens, duration);
   }
 
-  emit<U extends keyof WorkerListener<DataType, ResultType, NameType>>(
+  emit<
+    U extends keyof WorkerListener<
+      DataType,
+      ResultType,
+      NameType,
+      ProgressType
+    >,
+  >(
     event: U,
-    ...args: Parameters<WorkerListener<DataType, ResultType, NameType>[U]>
+    ...args: Parameters<
+      WorkerListener<DataType, ResultType, NameType, ProgressType>[U]
+    >
   ): boolean {
     return super.emit(event, ...args);
   }
 
-  off<U extends keyof WorkerListener<DataType, ResultType, NameType>>(
+  off<
+    U extends keyof WorkerListener<
+      DataType,
+      ResultType,
+      NameType,
+      ProgressType
+    >,
+  >(
     eventName: U,
-    listener: WorkerListener<DataType, ResultType, NameType>[U],
+    listener: WorkerListener<DataType, ResultType, NameType, ProgressType>[U],
   ): this {
     super.off(eventName, listener);
     return this;
   }
 
-  on<U extends keyof WorkerListener<DataType, ResultType, NameType>>(
+  on<
+    U extends keyof WorkerListener<
+      DataType,
+      ResultType,
+      NameType,
+      ProgressType
+    >,
+  >(
     event: U,
-    listener: WorkerListener<DataType, ResultType, NameType>[U],
+    listener: WorkerListener<DataType, ResultType, NameType, ProgressType>[U],
   ): this {
     super.on(event, listener);
     return this;
   }
 
-  once<U extends keyof WorkerListener<DataType, ResultType, NameType>>(
+  once<
+    U extends keyof WorkerListener<
+      DataType,
+      ResultType,
+      NameType,
+      ProgressType
+    >,
+  >(
     event: U,
-    listener: WorkerListener<DataType, ResultType, NameType>[U],
+    listener: WorkerListener<DataType, ResultType, NameType, ProgressType>[U],
   ): this {
     super.once(event, listener);
     return this;
   }
 
   protected callProcessJob(
-    job: Job<DataType, ResultType, NameType>,
+    job: Job<DataType, ResultType, NameType, ProgressType>,
     token: string,
     signal?: AbortSignal,
   ): Promise<ResultType> {
@@ -439,11 +482,12 @@ export class Worker<
   protected createJob(
     data: JobJsonRaw,
     jobId: string,
-  ): Job<DataType, ResultType, NameType> {
+  ): Job<DataType, ResultType, NameType, ProgressType> {
     return this.Job.fromJSON(this as MinimalQueue, data, jobId) as Job<
       DataType,
       ResultType,
-      NameType
+      NameType,
+      ProgressType
     >;
   }
 
@@ -580,7 +624,8 @@ export class Worker<
     const asyncFifoQueue = new AsyncFifoQueue<void | Job<
       DataType,
       ResultType,
-      NameType
+      NameType,
+      ProgressType
     >>();
 
     let tokenPostfix = 0;
@@ -602,7 +647,8 @@ export class Worker<
         const fetchedJob = this.retryIfFailed<void | Job<
           DataType,
           ResultType,
-          NameType
+          NameType,
+          ProgressType
         >>(() => this._getNextJob(client, bclient, token, { block: true }), {
           delayInMs: this.opts.runRetryDelay,
           onlyEmitError: true,
@@ -632,7 +678,7 @@ export class Worker<
 
       // Since there can be undefined jobs in the queue (when a job fails or queue is empty)
       // we iterate until we find a job.
-      let job: Job<DataType, ResultType, NameType> | void;
+      let job: Job<DataType, ResultType, NameType, ProgressType> | void;
       do {
         job = await asyncFifoQueue.fetch();
       } while (!job && asyncFifoQueue.numQueued() > 0);
@@ -641,7 +687,7 @@ export class Worker<
         const token = job.token;
         asyncFifoQueue.add(
           this.processJob(
-            <Job<DataType, ResultType, NameType>>job,
+            <Job<DataType, ResultType, NameType, ProgressType>>job,
             token,
             () => asyncFifoQueue.numTotal() <= this._concurrency,
           ),
@@ -665,7 +711,9 @@ export class Worker<
       { block },
     );
 
-    return this.trace<Job<DataType, ResultType, NameType> | undefined>(
+    return this.trace<
+      Job<DataType, ResultType, NameType, ProgressType> | undefined
+    >(
       SpanKind.INTERNAL,
       'getNextJob',
       this.name,
@@ -689,7 +737,7 @@ export class Worker<
     bclient: RedisClient,
     token: string,
     { block = true }: GetNextJobOptions = {},
-  ): Promise<Job<DataType, ResultType, NameType> | undefined> {
+  ): Promise<Job<DataType, ResultType, NameType, ProgressType> | undefined> {
     if (this.paused) {
       return;
     }
@@ -698,7 +746,7 @@ export class Worker<
       return;
     }
 
-    let job: Job<DataType, ResultType, NameType> | undefined;
+    let job: Job<DataType, ResultType, NameType, ProgressType> | undefined;
     if (this.drained && block && !this.limitUntil && !this.waiting) {
       this.waiting = this.waitForJob(bclient, this.blockUntil);
       try {
@@ -765,7 +813,7 @@ will never work with more accuracy than 1ms. */
     client: RedisClient,
     token: string,
     name?: string,
-  ): Promise<Job<DataType, ResultType, NameType>> {
+  ): Promise<Job<DataType, ResultType, NameType, ProgressType>> {
     const [jobData, id, rateLimitDelay, delayUntil] =
       await this.scripts.moveToActive(client, token, name);
     this.updateDelays(rateLimitDelay, delayUntil);
@@ -889,7 +937,7 @@ will never work with more accuracy than 1ms. */
     jobData?: JobJsonRaw,
     jobId?: string,
     token?: string,
-  ): Promise<Job<DataType, ResultType, NameType>> {
+  ): Promise<Job<DataType, ResultType, NameType, ProgressType>> {
     if (!jobData) {
       if (!this.drained) {
         this.emit('drained');
@@ -961,13 +1009,13 @@ will never work with more accuracy than 1ms. */
   }
 
   async processJob(
-    job: Job<DataType, ResultType, NameType>,
+    job: Job<DataType, ResultType, NameType, ProgressType>,
     token: string,
     fetchNextCallback = () => true,
-  ): Promise<void | Job<DataType, ResultType, NameType>> {
+  ): Promise<void | Job<DataType, ResultType, NameType, ProgressType>> {
     const srcPropagationMetadata = job.opts?.telemetry?.metadata;
 
-    return this.trace<void | Job<DataType, ResultType, NameType>>(
+    return this.trace<void | Job<DataType, ResultType, NameType, ProgressType>>(
       SpanKind.CONSUMER,
       'process',
       this.name,
@@ -993,7 +1041,8 @@ will never work with more accuracy than 1ms. */
             const failed = await this.retryIfFailed<void | Job<
               DataType,
               ResultType,
-              NameType
+              NameType,
+              ProgressType
             >>(
               () => {
                 this.lockManager.untrackJob(job.id);
@@ -1020,7 +1069,8 @@ will never work with more accuracy than 1ms. */
           return await this.retryIfFailed<void | Job<
             DataType,
             ResultType,
-            NameType
+            NameType,
+            ProgressType
           >>(
             () => {
               this.lockManager.untrackJob(job.id);
@@ -1038,7 +1088,8 @@ will never work with more accuracy than 1ms. */
           const failed = await this.retryIfFailed<void | Job<
             DataType,
             ResultType,
-            NameType
+            NameType,
+            ProgressType
           >>(
             () => {
               this.lockManager.untrackJob(job.id);
@@ -1070,7 +1121,7 @@ will never work with more accuracy than 1ms. */
   }
 
   private getUnrecoverableErrorMessage(
-    job: Job<DataType, ResultType, NameType>,
+    job: Job<DataType, ResultType, NameType, ProgressType>,
   ) {
     if (job.deferredFailure) {
       return job.deferredFailure;
@@ -1085,7 +1136,7 @@ will never work with more accuracy than 1ms. */
 
   protected async handleCompleted(
     result: ResultType,
-    job: Job<DataType, ResultType, NameType>,
+    job: Job<DataType, ResultType, NameType, ProgressType>,
     token: string,
     fetchNextCallback = () => true,
     span?: Span,
@@ -1117,7 +1168,7 @@ will never work with more accuracy than 1ms. */
 
   protected async handleFailed(
     err: Error,
-    job: Job<DataType, ResultType, NameType>,
+    job: Job<DataType, ResultType, NameType, ProgressType>,
     token: string,
     fetchNextCallback = () => true,
     span?: Span,
@@ -1451,7 +1502,7 @@ will never work with more accuracy than 1ms. */
   }
 
   private moveLimitedBackToWait(
-    job: Job<DataType, ResultType, NameType>,
+    job: Job<DataType, ResultType, NameType, ProgressType>,
     token: string,
   ) {
     return job.moveToWait(token);

--- a/src/interfaces/minimal-job.ts
+++ b/src/interfaces/minimal-job.ts
@@ -58,6 +58,7 @@ export interface MinimalJob<
   DataType = any,
   ReturnType = any,
   NameType extends string = string,
+  ProgressType extends JobProgress = JobProgress,
 > {
   /**
    * The name of the Job
@@ -76,7 +77,7 @@ export interface MinimalJob<
    * The progress a job has performed so far.
    * @defaultValue 0
    */
-  progress: JobProgress;
+  progress: ProgressType;
   /**
    * The value returned by the processor when processing this job.
    * @defaultValue null
@@ -146,7 +147,7 @@ export interface MinimalJob<
    *
    * @param progress - number or object to be saved as progress.
    */
-  updateProgress(progress: JobProgress): Promise<void>;
+  updateProgress(progress: ProgressType): Promise<void>;
   /**
    * Logs one row of log data.
    *

--- a/src/types/processor.ts
+++ b/src/types/processor.ts
@@ -1,10 +1,12 @@
 import { Job } from '../classes/job';
+import { JobProgress } from './job-progress';
 
 /**
  * An async function that receives `Job`s and handles them.
  */
-export type Processor<T = any, R = any, N extends string = string> = (
-  job: Job<T, R, N>,
-  token?: string,
-  signal?: AbortSignal,
-) => Promise<R>;
+export type Processor<
+  T = any,
+  R = any,
+  N extends string = string,
+  P extends JobProgress = JobProgress,
+> = (job: Job<T, R, N, P>, token?: string, signal?: AbortSignal) => Promise<R>;

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -317,6 +317,44 @@ describe('workers', () => {
     await worker.close();
   });
 
+  it('process a job that updates progress with a typed progress generic', async () => {
+    type CustomProgress = { percent: number; message: string };
+    const expected: CustomProgress = { percent: 42, message: 'halfway' };
+
+    const job = await queue.add('test', { foo: 'bar' });
+    expect(job.id).toBeTruthy();
+    expect(job.data.foo).toEqual('bar');
+
+    // The 4th generic parameter makes progress type-safe end-to-end: the
+    // processor's `job.updateProgress` only accepts CustomProgress, and the
+    // `progress` event handler receives it typed as CustomProgress.
+    const worker = new Worker<{ foo: string }, void, string, CustomProgress>(
+      queueName,
+      async job => {
+        expect(job.data.foo).toBe('bar');
+        await job.updateProgress(expected);
+      },
+      { connection, prefix },
+    );
+
+    const processing = new Promise<void>((resolve, reject) => {
+      worker.on('progress', (_job, progress) => {
+        try {
+          expect(progress).toEqual(expected);
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+
+    await worker.waitUntilReady();
+
+    await processing;
+
+    await worker.close();
+  });
+
   it('processes jobs that were added before the worker started', async () => {
     const jobs = [
       queue.add('test', { bar: 'baz' }),


### PR DESCRIPTION
## Problem

The `JobProgress` type is hardcoded as `string | boolean | number | object`, so there is no way to get type-safe progress when calling `updateProgress()` or listening to the `progress` event:

```typescript
// Current behavior — progress is always `string | boolean | number | object`
worker.on('progress', (job, progress) => {
  progress.percent; // TS error: Property 'percent' does not exist on type 'JobProgress'
});
```

Requested in #3721 and discussed in #3184.

## Solution

Add an optional 4th generic type parameter `ProgressType` to `Job`, `MinimalJob`, `Worker`, `WorkerListener`, and `Processor`. It is constrained `extends JobProgress` and defaults to `JobProgress`, making this a **fully backwards-compatible** change.

### Usage

```typescript
type MyProgress = { percent: number; message: string };

const worker = new Worker<InputType, OutputType, string, MyProgress>(
  'myQueue',
  async job => {
    await job.updateProgress({ percent: 50, message: 'halfway' }); // type-safe
    return { result: 'done' };
  },
  { connection },
);

worker.on('progress', (job, progress) => {
  console.log(progress.percent); // number
  console.log(progress.message); // string
});
```

### Backwards compatibility

Existing code using up to 3 generics compiles unchanged — `ProgressType` defaults to `JobProgress`:

```typescript
const worker = new Worker<InputType, OutputType, string>('queue', processor, opts);
```

## Changes

| File | Change |
|------|--------|
| `src/interfaces/minimal-job.ts` | `ProgressType extends JobProgress = JobProgress` 4th generic; typed `progress` + `updateProgress()` |
| `src/classes/job.ts` | `ProgressType` generic on `Job`; typed `progress` field and `updateProgress()` |
| `src/classes/worker.ts` | `ProgressType` threaded through `Worker`, `WorkerListener` (incl. `active`/`completed`/`failed`/`progress`), and the processor flow |
| `src/types/processor.ts` | `ProgressType` 4th generic so the processor's `job.updateProgress()` is typed |
| `tests/worker.test.ts` | Runtime integration test for typed progress (in the worker suite, per review) |

## Design / scope notes

- **Constraint instead of internal plumbing.** `ProgressType extends JobProgress` makes `Job<…, P>` covariantly assignable to the internal `MinimalJob<…, JobProgress>` helpers (`Scripts.*`, `Backoffs.calculate`), which never read or write `progress` — so no generic needs to be threaded through them. This keeps the diff small and matches the persistence contract (`updateProgress` ultimately `JSON.stringify`s progress).
- **Sandboxed / threaded processors keep `JobProgress`.** Progress for sandboxed processors crosses an IPC/Redis JSON boundary where the static type is lost, so it stays `JobProgress` by design.
- **Queue-side fetch keeps the default.** `getJob`, `Job.create`/`fromId` etc. still return the default `JobProgress`; threading `ProgressType` through the producer/getter surface can be a focused follow-up.
- **`progress` still defaults to `0`** (bullmq's long-standing default) before the first update.

## Verification

- `tsc --noEmit` clean for both `tsconfig.json` and `tsconfig-cjs.json`
- `eslint` and `prettier --check` clean on all changed files
- Type-safety proven with `@ts-expect-error` assertions (typed processor + `progress`/`completed` handlers compile; `bigint` rejected by the constraint; 3-generic usage still compiles)
- Branch rebased onto current `master`

Closes #3721
