### PR TITLE
feat(sandbox): add getDependencies proxy for sandboxed processors

### DIFF
--- a/src/classes/child-processor.ts
+++ b/src/classes/child-processor.ts
@@ -1,6 +1,7 @@
 import { AbortController } from './abort-controller';
 import { ParentCommand } from '../enums';
 import {
+  DependenciesOpts,
   MoveToWaitingChildrenOpts,
   Receiver,
   SandboxedJob,
@@ -303,6 +304,25 @@ export class ChildProcessor {
           processed?: number;
           unprocessed?: number;
         }>;
+      },
+
+      /**
+       * Proxy `getDependencies` function.
+       */
+      getDependencies: async (opts?: DependenciesOpts) => {
+        const requestId = Math.random().toString(36).substring(2, 15);
+        await send({
+          requestId,
+          cmd: ParentCommand.GetDependencies,
+          value: opts,
+        });
+
+        return waitResponse(
+          requestId,
+          this.receiver,
+          RESPONSE_TIMEOUT,
+          'getDependencies',
+        );
       },
     };
 

--- a/src/classes/sandbox.ts
+++ b/src/classes/sandbox.ts
@@ -106,6 +106,16 @@ const sandbox = <T, R, N extends string>(
                       });
                     }
                     break;
+                  case ParentCommand.GetDependencies:
+                    {
+                      const value = await job.getDependencies(msg.value);
+                      child.send({
+                        requestId: msg.requestId,
+                        cmd: ChildCommand.GetDependenciesResponse,
+                        value,
+                      });
+                    }
+                    break;
                 }
               } catch (err) {
                 reject(err);

--- a/src/enums/child-command.ts
+++ b/src/enums/child-command.ts
@@ -7,4 +7,5 @@ export enum ChildCommand {
   GetDependenciesCountResponse,
   MoveToWaitingChildrenResponse,
   Cancel,
+  GetDependenciesResponse,
 }

--- a/src/enums/parent-command.ts
+++ b/src/enums/parent-command.ts
@@ -13,4 +13,5 @@ export enum ParentCommand {
   GetIgnoredChildrenFailures,
   GetDependenciesCount,
   MoveToWaitingChildren,
+  GetDependencies,
 }

--- a/tests/fixtures/fixture_processor_get_dependencies.js
+++ b/tests/fixtures/fixture_processor_get_dependencies.js
@@ -1,0 +1,10 @@
+/**
+ * A processor file to be used in tests.
+ *
+ */
+'use strict';
+
+module.exports = async function (job) {
+  const deps = await job.getDependencies();
+  return deps;
+};

--- a/tests/fixtures/fixture_processor_get_dependencies_child.js
+++ b/tests/fixtures/fixture_processor_get_dependencies_child.js
@@ -1,0 +1,9 @@
+/**
+ * A processor file to be used in tests.
+ *
+ */
+'use strict';
+
+module.exports = function (job) {
+  return { childResult: 'bar' };
+};

--- a/tests/sandboxed_process.test.ts
+++ b/tests/sandboxed_process.test.ts
@@ -1091,7 +1091,9 @@ function sandboxProcessTests(
           parentWorker.on('completed', async () => {
             await parentWorker.close();
             reject(
-              new Error('Expected parent job to fail with timeout, but it completed'),
+              new Error(
+                'Expected parent job to fail with timeout, but it completed',
+              ),
             );
           });
         });
@@ -1110,10 +1112,10 @@ function sandboxProcessTests(
         await parentWorker.close();
         await childWorker.close();
         await flow.close();
+        await removeAllQueueData(new IORedis(redisHost), parentQueueName);
       } finally {
         Job.prototype.getDependenciesCount = originalGetDependenciesCount;
       }
-      await removeAllQueueData(new IORedis(redisHost), parentQueueName);
     });
 
     it('can get dependencies by calling getDependencies', async () => {
@@ -1217,7 +1219,9 @@ function sandboxProcessTests(
           parentWorker.on('completed', async () => {
             await parentWorker.close();
             reject(
-              new Error('Expected parent job to fail with timeout, but it completed'),
+              new Error(
+                'Expected parent job to fail with timeout, but it completed',
+              ),
             );
           });
         });

--- a/tests/sandboxed_process.test.ts
+++ b/tests/sandboxed_process.test.ts
@@ -1046,18 +1046,82 @@ function sandboxProcessTests(
     });
 
     it('will fail job if calling getDependenciesCount is too slow', async () => {
-      const getDependenciesCount = Job.prototype.getDependenciesCount;
-      Job.prototype.getDependenciesCount = async function () {
-        await delay(50000);
-        return getDependenciesCount.call(this);
-      };
+      const originalGetDependenciesCount = Job.prototype.getDependenciesCount;
+      try {
+        Job.prototype.getDependenciesCount = async function () {
+          await delay(50000);
+          return originalGetDependenciesCount.call(this);
+        };
 
+        const childJobId = 'child-job-id';
+        const childProcessFile =
+          __dirname +
+          '/fixtures/fixture_processor_get_dependencies_count_child.js';
+        const parentProcessFile =
+          __dirname + '/fixtures/fixture_processor_get_dependencies_count.js';
+        const parentQueueName = `parent-queue-${v4()}`;
+
+        const parentWorker = new Worker(parentQueueName, parentProcessFile, {
+          connection,
+          prefix,
+          drainDelay: 1,
+          useWorkerThreads,
+        });
+
+        const childWorker = new Worker(queueName, childProcessFile, {
+          connection,
+          prefix,
+          drainDelay: 1,
+          useWorkerThreads,
+        });
+
+        const parentFailing = new Promise<void>((resolve, reject) => {
+          parentWorker.on('failed', async (_, error: Error) => {
+            try {
+              expect(error.message).toEqual(
+                'TimeoutError: getDependenciesCount timed out in (500ms)',
+              );
+              resolve();
+            } catch (err) {
+              await parentWorker.close();
+              reject(err);
+            }
+          });
+
+          parentWorker.on('completed', async () => {
+            await parentWorker.close();
+            reject(
+              new Error('Expected parent job to fail with timeout, but it completed'),
+            );
+          });
+        });
+
+        const flow = new FlowProducer({ connection, prefix });
+        await flow.add({
+          name: 'parent-job',
+          queueName: parentQueueName,
+          opts: { jobId: 'job-id' },
+          children: [
+            { name: 'child-job', queueName, opts: { jobId: childJobId } },
+          ],
+        });
+
+        await parentFailing;
+        await parentWorker.close();
+        await childWorker.close();
+        await flow.close();
+      } finally {
+        Job.prototype.getDependenciesCount = originalGetDependenciesCount;
+      }
+      await removeAllQueueData(new IORedis(redisHost), parentQueueName);
+    });
+
+    it('can get dependencies by calling getDependencies', async () => {
       const childJobId = 'child-job-id';
       const childProcessFile =
-        __dirname +
-        '/fixtures/fixture_processor_get_dependencies_count_child.js';
+        __dirname + '/fixtures/fixture_processor_get_dependencies_child.js';
       const parentProcessFile =
-        __dirname + '/fixtures/fixture_processor_get_dependencies_count.js';
+        __dirname + '/fixtures/fixture_processor_get_dependencies.js';
       const parentQueueName = `parent-queue-${v4()}`;
 
       const parentWorker = new Worker(parentQueueName, parentProcessFile, {
@@ -1074,17 +1138,20 @@ function sandboxProcessTests(
         useWorkerThreads,
       });
 
-      const parentFailing = new Promise<void>((resolve, reject) => {
-        parentWorker.on('failed', async (_, error: Error) => {
+      const parentCompleting = new Promise<void>((resolve, reject) => {
+        parentWorker.on('completed', async (job: Job, value: any) => {
           try {
-            expect(error.message).toEqual(
-              'TimeoutError: getDependenciesCount timed out in (500ms)',
-            );
+            expect(value).toHaveProperty('processed');
             resolve();
           } catch (err) {
             await parentWorker.close();
             reject(err);
           }
+        });
+
+        parentWorker.on('failed', async (_, error: Error) => {
+          await parentWorker.close();
+          reject(error);
         });
       });
 
@@ -1098,13 +1165,81 @@ function sandboxProcessTests(
         ],
       });
 
-      await parentFailing;
+      await parentCompleting;
       await parentWorker.close();
       await childWorker.close();
       await flow.close();
-
-      Job.prototype.getDependenciesCount = getDependenciesCount;
       await removeAllQueueData(new IORedis(redisHost), parentQueueName);
+    });
+
+    it('will fail job if calling getDependencies is too slow', async () => {
+      const originalGetDependencies = Job.prototype.getDependencies;
+      try {
+        Job.prototype.getDependencies = async function () {
+          await delay(50000);
+          return originalGetDependencies.call(this);
+        };
+
+        const childJobId = 'child-job-id';
+        const childProcessFile =
+          __dirname + '/fixtures/fixture_processor_get_dependencies_child.js';
+        const parentProcessFile =
+          __dirname + '/fixtures/fixture_processor_get_dependencies.js';
+        const parentQueueName = `parent-queue-${v4()}`;
+
+        const parentWorker = new Worker(parentQueueName, parentProcessFile, {
+          connection,
+          prefix,
+          drainDelay: 1,
+          useWorkerThreads,
+        });
+
+        const childWorker = new Worker(queueName, childProcessFile, {
+          connection,
+          prefix,
+          drainDelay: 1,
+          useWorkerThreads,
+        });
+
+        const parentFailing = new Promise<void>((resolve, reject) => {
+          parentWorker.on('failed', async (_, error: Error) => {
+            try {
+              expect(error.message).toEqual(
+                'TimeoutError: getDependencies timed out in (500ms)',
+              );
+              resolve();
+            } catch (err) {
+              await parentWorker.close();
+              reject(err);
+            }
+          });
+
+          parentWorker.on('completed', async () => {
+            await parentWorker.close();
+            reject(
+              new Error('Expected parent job to fail with timeout, but it completed'),
+            );
+          });
+        });
+
+        const flow = new FlowProducer({ connection, prefix });
+        await flow.add({
+          name: 'parent-job',
+          queueName: parentQueueName,
+          opts: { jobId: 'job-id' },
+          children: [
+            { name: 'child-job', queueName, opts: { jobId: childJobId } },
+          ],
+        });
+
+        await parentFailing;
+        await parentWorker.close();
+        await childWorker.close();
+        await flow.close();
+        await removeAllQueueData(new IORedis(redisHost), parentQueueName);
+      } finally {
+        Job.prototype.getDependencies = originalGetDependencies;
+      }
     });
 
     it('should process and move to delayed', async () => {


### PR DESCRIPTION
### Why
Sandboxed processors cannot call `job.getDependencies()` because the IPC proxy
is missing. Refs #3533

### How
Following the existing `getChildrenValues` proxy pattern:
1. Added `GetDependencies` to `ParentCommand` enum
2. Added `GetDependenciesResponse` to `ChildCommand` enum
3. Added proxy method in `child-processor.ts` `wrapJob()` (forwards opts via message value)
4. Added message handler in `sandbox.ts`
5. Added fixture-based tests (success + timeout) in `sandboxed_process.test.ts`

### Additional Notes
- This is the first of two PRs for #3533. The second PR will add `getDependenciesCount` proxy.
- `SandboxedJob` interface is intentionally unchanged, matching the existing pattern where
  `getChildrenValues` and `getIgnoredChildrenFailures` are also not declared on the interface.
  Happy to add the type declaration if you'd prefer — let me know.