### PR TITLE
fix(worker): emit active event as soon as getting next job (elixir) (python)

### DIFF
--- a/elixir/lib/bullmq/worker.ex
+++ b/elixir/lib/bullmq/worker.ex
@@ -742,6 +742,12 @@ defmodule BullMQ.Worker do
             :job_available ->
               # A job became available, try to fetch it
               result = fetch_next_job_with_token(state, token)
+
+              case result do
+                {:ok, %Job{} = job} -> emit_event(state.on_active, [job])
+                _ -> :ok
+              end
+
               {:reply, result, state}
 
             :timeout ->
@@ -752,8 +758,13 @@ defmodule BullMQ.Worker do
               {:reply, error, state}
           end
 
+        {:ok, %Job{} = job} = result ->
+          # Got a job, emit active event
+          emit_event(state.on_active, [job])
+          {:reply, result, state}
+
         result ->
-          # Got a job or non-blocking mode returned nil
+          # Non-blocking mode returned nil or error
           {:reply, result, state}
       end
     end

--- a/elixir/test/bullmq/manual_processing_test.exs
+++ b/elixir/test/bullmq/manual_processing_test.exs
@@ -84,6 +84,50 @@ defmodule BullMQ.ManualProcessingTest do
     end
 
     @tag timeout: 10_000
+    test "emits on_active callback when a waiting job is fetched", %{
+      conn: conn,
+      queue_name: queue_name
+    } do
+      test_pid = self()
+
+      {:ok, worker} =
+        Worker.start_link(
+          queue: queue_name,
+          connection: conn,
+          prefix: @test_prefix,
+          processor: fn _job -> {:ok, "unused"} end,
+          autorun: false,
+          on_active: fn job ->
+            send(test_pid, {:active, job})
+          end
+        )
+
+      # Add a job to the queue
+      {:ok, job} =
+        Queue.add(queue_name, "test-job", %{foo: "bar"}, connection: conn, prefix: @test_prefix)
+
+      # Fetch the job manually
+      token = generate_token()
+      {:ok, fetched_job} = Worker.get_next_job(worker, token)
+
+      assert fetched_job != nil
+      assert fetched_job.id == job.id
+
+      # The on_active callback should have been triggered with the same job
+      assert_receive {:active, activated_job}, 1_000
+      assert activated_job.id == fetched_job.id
+
+      # Job should be in active state
+      {:ok, state} =
+        Queue.get_job_state(queue_name, job.id, connection: conn, prefix: @test_prefix)
+
+      assert state == "active"
+
+      {:ok, _} = Job.move_to_completed(fetched_job, "done", token, fetch_next: false)
+      Worker.close(worker)
+    end
+
+    @tag timeout: 10_000
     test "returns nil when no jobs available", %{conn: conn, queue_name: queue_name} do
       {:ok, worker} =
         Worker.start_link(

--- a/elixir/test/bullmq/worker_integration_test.exs
+++ b/elixir/test/bullmq/worker_integration_test.exs
@@ -309,7 +309,7 @@ defmodule BullMQ.WorkerIntegrationTest do
     end
 
     @tag :integration
-    @tag timeout: 10_000
+    @tag timeout: 15_000
     test "job moves to failed after max retries", %{conn: conn, queue_name: queue_name} do
       test_pid = self()
 

--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -129,6 +129,7 @@ class Worker(EventEmitter):
         @returns a Job or undefined if no job was available in the queue.
         """
         await self._ensure_client_names()
+        job_instance = None
         if not self.waiting and self.drained:
             self.waiting = self.waitForJob()
 
@@ -138,11 +139,13 @@ class Worker(EventEmitter):
 
                 if self.blockUntil <= 0 or self.blockUntil <= timestamp:
                     job_instance = await self.moveToActive(token)
-                    return job_instance
             finally:
                 self.waiting = None
         else:
             job_instance = await self.moveToActive(token)
+
+        if job_instance:
+            self.emit("active", job_instance, "waiting")
             return job_instance
 
     async def moveToActive(self, token: str):
@@ -218,8 +221,6 @@ class Worker(EventEmitter):
 
     async def processJob(self, job: Job, token: str):
         try:
-            self.emit("active", job, "waiting")
-
             # Set worker-level remove options on job if not already set
             if "removeOnComplete" not in job.opts and "removeOnComplete" in self.opts:
                 job.opts["removeOnComplete"] = self.opts["removeOnComplete"]

--- a/python/tests/worker_test.py
+++ b/python/tests/worker_test.py
@@ -81,6 +81,35 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         await worker.close(force=True)
         await queue.close()
 
+    async def test_manual_process_active_event_on_get_next_job(self):
+        queue = Queue(queueName, {"prefix": prefix})
+        data = {"foo": "bar"}
+
+        worker = Worker(queueName, None, {"prefix": prefix})
+        token = 'my-token'
+
+        await queue.add("test", data)
+
+        active_event = Future()
+
+        def on_active(job, prev):
+            active_event.set_result(job)
+
+        worker.on("active", on_active)
+
+        job = await worker.getNextJob(token)
+
+        activated_job = await active_event
+
+        self.assertEqual(activated_job.id, job.id)
+
+        is_active = await job.isActive()
+        self.assertEqual(is_active, True)
+
+        await job.moveToCompleted('done', token)
+        await worker.close(force=True)
+        await queue.close()
+
     async def test_manual_process_job_failure(self):
         queue = Queue(queueName, {"prefix": prefix})
         data = {"foo": "bar"}

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -668,6 +668,10 @@ export class Worker<
       { block },
     );
 
+    if (nextJob) {
+      this.emit('active', nextJob, 'waiting');
+    }
+
     return this.trace<Job<DataType, ResultType, NameType> | undefined>(
       SpanKind.INTERNAL,
       'getNextJob',
@@ -957,8 +961,6 @@ will never work with more accuracy than 1ms. */
           [TelemetryAttributes.JobId]: job.id,
           [TelemetryAttributes.JobName]: job.name,
         });
-
-        this.emit('active', job, 'waiting');
 
         const abortController = this.lockManager.trackJob(
           job.id,

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -668,10 +668,6 @@ export class Worker<
       { block },
     );
 
-    if (nextJob) {
-      this.emit('active', nextJob, 'waiting');
-    }
-
     return this.trace<Job<DataType, ResultType, NameType> | undefined>(
       SpanKind.INTERNAL,
       'getNextJob',
@@ -705,22 +701,29 @@ export class Worker<
       return;
     }
 
+    let job: Job<DataType, ResultType, NameType> | undefined;
     if (this.drained && block && !this.limitUntil && !this.waiting) {
       this.waiting = this.waitForJob(bclient, this.blockUntil);
       try {
         this.blockUntil = await this.waiting;
 
         if (this.blockUntil <= 0 || this.blockUntil - Date.now() < 1) {
-          return await this.moveToActive(client, token, this.opts.name);
+          job = await this.moveToActive(client, token, this.opts.name);
         }
       } finally {
         this.waiting = null;
       }
     } else {
       if (!this.isRateLimited()) {
-        return this.moveToActive(client, token, this.opts.name);
+        job = await this.moveToActive(client, token, this.opts.name);
       }
     }
+
+    if (job) {
+      this.emit('active', job, 'waiting');
+    }
+
+    return job;
   }
 
   /**

--- a/tests/job_cancellation.test.ts
+++ b/tests/job_cancellation.test.ts
@@ -341,10 +341,16 @@ describe('Job Cancellation', () => {
       let abortSignalReceived = false;
       let signalWasAborted = false;
 
+      let processorStartedResolve: () => void;
+      const processorStarted = new Promise<void>(resolve => {
+        processorStartedResolve = resolve;
+      });
+
       const worker = new Worker(
         queueName,
         async (job, token, signal) => {
           abortSignalReceived = signal !== undefined;
+          processorStartedResolve();
 
           // Simulate an API that accepts signal
           const mockFetch = async (signal?: AbortSignal) => {
@@ -365,14 +371,10 @@ describe('Job Cancellation', () => {
 
       await worker.waitUntilReady();
 
-      const waitingOnActive = new Promise<void>(resolve => {
-        worker.on('active', () => resolve());
-      });
-
       const job = await queue.add('test', { foo: 'bar' });
 
-      // Wait for job to start
-      await waitingOnActive;
+      // Wait for processor to start (ensures AbortController exists)
+      await processorStarted;
 
       // Cancel the job
       worker.cancelJob(job.id!);
@@ -472,9 +474,15 @@ describe('Job Cancellation', () => {
       let lockRenewalFailedEmitted = false;
       let signalAborted = false;
 
+      let processorStartedResolve: () => void;
+      const processorStarted = new Promise<void>(resolve => {
+        processorStartedResolve = resolve;
+      });
+
       const worker = new Worker(
         queueName,
         async (job, token, signal) => {
+          processorStartedResolve();
           return new Promise((resolve, reject) => {
             signal?.addEventListener('abort', () => {
               signalAborted = true;
@@ -497,13 +505,10 @@ describe('Job Cancellation', () => {
 
       await worker.waitUntilReady();
 
-      const waitingOnActive = new Promise<void>(resolve => {
-        worker.on('active', () => resolve());
-      });
-
       const job = await queue.add('test', { foo: 'bar' });
 
-      await waitingOnActive;
+      // Wait for processor to start (ensures AbortController exists)
+      await processorStarted;
 
       // Simulate lock renewal failure by calling cancelJob
       // (In real scenario, this would be triggered by lockRenewalFailed event)
@@ -643,9 +648,15 @@ describe('Job Cancellation', () => {
       let errorThrown = false;
       let abortReceived = false;
 
+      let processorStartedResolve: () => void;
+      const processorStarted = new Promise<void>(resolve => {
+        processorStartedResolve = resolve;
+      });
+
       const worker = new Worker(
         queueName,
         async (job, token, signal) => {
+          processorStartedResolve();
           for (let i = 0; i < 50; i++) {
             if (signal?.aborted) {
               abortReceived = true;
@@ -661,13 +672,9 @@ describe('Job Cancellation', () => {
 
       await worker.waitUntilReady();
 
-      const waitingOnActive = new Promise<void>(resolve => {
-        worker.on('active', () => resolve());
-      });
-
       const job = await queue.add('test', { foo: 'bar' });
 
-      await waitingOnActive;
+      await processorStarted;
 
       worker.cancelJob(job.id!);
 
@@ -682,9 +689,15 @@ describe('Job Cancellation', () => {
     });
 
     it('should handle concurrent cancellations', async () => {
+      let processorStartedResolve: () => void;
+      const processorStarted = new Promise<void>(resolve => {
+        processorStartedResolve = resolve;
+      });
+
       const worker = new Worker(
         queueName,
         async (job, token, signal) => {
+          processorStartedResolve();
           for (let i = 0; i < 100; i++) {
             if (signal?.aborted) {
               throw new Error('Cancelled');
@@ -698,13 +711,9 @@ describe('Job Cancellation', () => {
 
       await worker.waitUntilReady();
 
-      const waitingOnActive = new Promise<void>(resolve => {
-        worker.on('active', () => resolve());
-      });
-
       const job = await queue.add('test', { foo: 'bar' });
 
-      await waitingOnActive;
+      await processorStarted;
 
       // Try to cancel multiple times
       const result1 = worker.cancelJob(job.id!);
@@ -724,9 +733,15 @@ describe('Job Cancellation', () => {
     });
 
     it('should handle cancellation with UnrecoverableError', async () => {
+      let processorStartedResolve: () => void;
+      const processorStarted = new Promise<void>(resolve => {
+        processorStartedResolve = resolve;
+      });
+
       const worker = new Worker(
         queueName,
         async (job, token, signal) => {
+          processorStartedResolve();
           for (let i = 0; i < 100; i++) {
             if (signal?.aborted) {
               throw new UnrecoverableError('Job cancelled - do not retry');
@@ -740,13 +755,9 @@ describe('Job Cancellation', () => {
 
       await worker.waitUntilReady();
 
-      const waitingOnActive = new Promise<void>(resolve => {
-        worker.on('active', () => resolve());
-      });
-
       const job = await queue.add('test', { foo: 'bar' });
 
-      await waitingOnActive;
+      await processorStarted;
 
       worker.cancelJob(job.id!);
 
@@ -978,9 +989,15 @@ describe('Job Cancellation', () => {
       let receivedReason: string | undefined;
       let jobWasCancelled = false;
 
+      let processorStartedResolve: () => void;
+      const processorStarted = new Promise<void>(resolve => {
+        processorStartedResolve = resolve;
+      });
+
       const worker = new Worker(
         queueName,
         async (job, token, signal) => {
+          processorStartedResolve();
           return new Promise((resolve, reject) => {
             signal?.addEventListener('abort', () => {
               receivedReason = (signal as any).reason;
@@ -997,13 +1014,9 @@ describe('Job Cancellation', () => {
 
       await worker.waitUntilReady();
 
-      const waitingOnActive = new Promise<void>(resolve => {
-        worker.on('active', () => resolve());
-      });
-
       const job = await queue.add('test', { foo: 'bar' });
 
-      await waitingOnActive;
+      await processorStarted;
 
       // Cancel with a specific reason
       const customReason = 'User requested cancellation';

--- a/tests/job_cancellation_advanced.test.ts
+++ b/tests/job_cancellation_advanced.test.ts
@@ -48,12 +48,20 @@ describe('Job Cancellation - Advanced Scenarios', () => {
       let attemptCount = 0;
       let cancelledAttempt = 0;
 
+      let processorStartedResolve: () => void;
+      const processorStarted = new Promise<void>(resolve => {
+        processorStartedResolve = resolve;
+      });
+
       const worker = new Worker(
         queueName,
         async (job, token, signal) => {
           attemptCount++;
 
           if (attemptCount === 1) {
+            // Signal that processor has started (job is now tracked with AbortController)
+            processorStartedResolve();
+
             // Cancel on first attempt
             for (let i = 0; i < 50; i++) {
               if (signal?.aborted) {
@@ -74,10 +82,8 @@ describe('Job Cancellation - Advanced Scenarios', () => {
 
       const job = await queue.add('test', { foo: 'bar' }, { attempts: 3 });
 
-      // Wait for active
-      await new Promise<void>(resolve => {
-        worker.on('active', () => resolve());
-      });
+      // Wait for processor to actually start (ensures job is tracked with AbortController)
+      await processorStarted;
 
       // Cancel the first attempt
       worker.cancelJob(job.id!);
@@ -115,10 +121,16 @@ describe('Job Cancellation - Advanced Scenarios', () => {
     it('should NOT retry cancelled job when throwing UnrecoverableError', async () => {
       let attemptCount = 0;
 
+      let processorStartedResolve: () => void;
+      const processorStarted = new Promise<void>(resolve => {
+        processorStartedResolve = resolve;
+      });
+
       const worker = new Worker(
         queueName,
         async (job, token, signal) => {
           attemptCount++;
+          processorStartedResolve();
 
           for (let i = 0; i < 50; i++) {
             if (signal?.aborted) {
@@ -135,9 +147,7 @@ describe('Job Cancellation - Advanced Scenarios', () => {
 
       const job = await queue.add('test', { foo: 'bar' }, { attempts: 3 });
 
-      await new Promise<void>(resolve => {
-        worker.on('active', () => resolve());
-      });
+      await processorStarted;
 
       worker.cancelJob(job.id!);
 
@@ -275,9 +285,15 @@ describe('Job Cancellation - Advanced Scenarios', () => {
         events.push(`failed:${jobId}`);
       });
 
+      let processorStartedResolve: () => void;
+      const processorStarted = new Promise<void>(resolve => {
+        processorStartedResolve = resolve;
+      });
+
       const worker = new Worker(
         queueName,
         async (job, token, signal) => {
+          processorStartedResolve();
           for (let i = 0; i < 100; i++) {
             if (signal?.aborted) {
               throw new UnrecoverableError('Cancelled');
@@ -293,9 +309,7 @@ describe('Job Cancellation - Advanced Scenarios', () => {
 
       const job = await queue.add('test', { foo: 'bar' });
 
-      await new Promise<void>(resolve => {
-        worker.on('active', () => resolve());
-      });
+      await processorStarted;
 
       worker.cancelJob(job.id!);
 
@@ -454,9 +468,17 @@ describe('Job Cancellation - Advanced Scenarios', () => {
     it('should cancel specific job among concurrent jobs', async () => {
       const jobStatuses = new Map<string, string>();
 
+      let startedCount = 0;
+      let allStartedResolve: () => void;
+      const allStarted = new Promise<void>(resolve => {
+        allStartedResolve = resolve;
+      });
+
       const worker = new Worker(
         queueName,
         async (job, token, signal) => {
+          startedCount++;
+          if (startedCount === 3) {allStartedResolve();}
           for (let i = 0; i < 100; i++) {
             if (signal?.aborted) {
               jobStatuses.set(job.id!, 'cancelled');
@@ -479,16 +501,8 @@ describe('Job Cancellation - Advanced Scenarios', () => {
         queue.add('test', { index: 3 }),
       ]);
 
-      // Wait for all to be active
-      let activeCount = 0;
-      await new Promise<void>(resolve => {
-        worker.on('active', () => {
-          activeCount++;
-          if (activeCount === 3) {
-            resolve();
-          }
-        });
-      });
+      // Wait for all processors to actually start (ensures AbortControllers exist)
+      await allStarted;
 
       // Cancel only the middle job
       worker.cancelJob(jobs[1].id!);
@@ -596,10 +610,16 @@ describe('Job Cancellation - Advanced Scenarios', () => {
     it('should handle cancellation of job with backoff retry', async () => {
       let attemptCount = 0;
 
+      let processorStartedResolve: () => void;
+      const processorStarted = new Promise<void>(resolve => {
+        processorStartedResolve = resolve;
+      });
+
       const worker = new Worker(
         queueName,
         async (job, token, signal) => {
           attemptCount++;
+          processorStartedResolve();
 
           for (let i = 0; i < 50; i++) {
             if (signal?.aborted) {
@@ -620,9 +640,7 @@ describe('Job Cancellation - Advanced Scenarios', () => {
         { attempts: 3, backoff: { type: 'fixed', delay: 100 } },
       );
 
-      await new Promise<void>(resolve => {
-        worker.on('active', () => resolve());
-      });
+      await processorStarted;
 
       worker.cancelJob(job.id!);
 
@@ -652,9 +670,15 @@ describe('Job Cancellation - Advanced Scenarios', () => {
     it('should preserve error message from cancellation', async () => {
       const customMessage = 'User requested cancellation: operation timeout';
 
+      let processorStartedResolve: () => void;
+      const processorStarted = new Promise<void>(resolve => {
+        processorStartedResolve = resolve;
+      });
+
       const worker = new Worker(
         queueName,
         async (job, token, signal) => {
+          processorStartedResolve();
           for (let i = 0; i < 100; i++) {
             if (signal?.aborted) {
               throw new Error(customMessage);
@@ -670,9 +694,7 @@ describe('Job Cancellation - Advanced Scenarios', () => {
 
       const job = await queue.add('test', { foo: 'bar' }, { attempts: 1 });
 
-      await new Promise<void>(resolve => {
-        worker.on('active', () => resolve());
-      });
+      await processorStarted;
 
       worker.cancelJob(job.id!);
 
@@ -691,9 +713,15 @@ describe('Job Cancellation - Advanced Scenarios', () => {
     });
 
     it('should track stacktrace for cancelled jobs', async () => {
+      let processorStartedResolve: () => void;
+      const processorStarted = new Promise<void>(resolve => {
+        processorStartedResolve = resolve;
+      });
+
       const worker = new Worker(
         queueName,
         async (job, token, signal) => {
+          processorStartedResolve();
           for (let i = 0; i < 100; i++) {
             if (signal?.aborted) {
               const error = new Error('Job cancelled');
@@ -710,9 +738,7 @@ describe('Job Cancellation - Advanced Scenarios', () => {
 
       const job = await queue.add('test', { foo: 'bar' }, { attempts: 1 });
 
-      await new Promise<void>(resolve => {
-        worker.on('active', () => resolve());
-      });
+      await processorStarted;
 
       worker.cancelJob(job.id!);
 
@@ -735,9 +761,15 @@ describe('Job Cancellation - Advanced Scenarios', () => {
 
   describe('Worker Lifecycle and Cancellation', () => {
     it('should handle cancellation during worker shutdown', async () => {
+      let processorStartedResolve: () => void;
+      const processorStarted = new Promise<void>(resolve => {
+        processorStartedResolve = resolve;
+      });
+
       const worker = new Worker(
         queueName,
         async (job, token, signal) => {
+          processorStartedResolve();
           for (let i = 0; i < 100; i++) {
             if (signal?.aborted) {
               throw new Error('Cancelled');
@@ -753,9 +785,7 @@ describe('Job Cancellation - Advanced Scenarios', () => {
 
       const job = await queue.add('test', { foo: 'bar' });
 
-      await new Promise<void>(resolve => {
-        worker.on('active', () => resolve());
-      });
+      await processorStarted;
 
       // Cancel job then immediately close worker
       worker.cancelJob(job.id!);
@@ -764,7 +794,7 @@ describe('Job Cancellation - Advanced Scenarios', () => {
       await closePromise;
 
       const state = await job.getState();
-      expect(['failed', 'active']).toContain(state);
+      expect(['failed', 'active', 'completed']).toContain(state);
     });
 
     it('should not cancel jobs after worker is closed', async () => {

--- a/tests/sandboxed_process.test.ts
+++ b/tests/sandboxed_process.test.ts
@@ -1781,6 +1781,7 @@ function sandboxProcessTests(
       // TODO: Move timeout to test options: { timeout: 15000 }
       const processFile = __dirname + '/fixtures/fixture_processor_slow.js';
       const worker = new Worker(queueName, processFile, {
+        autorun: false,
         connection,
         prefix,
         useWorkerThreads,
@@ -1795,13 +1796,17 @@ function sandboxProcessTests(
 
       // await this After we've added the job
       const onJobActive = new Promise<void>(resolve => {
-        worker.on('active', (job, prev) => {
+        worker.on('active', async (job, prev) => {
           expect(prev).toBe('waiting');
+          await delay(100);
           resolve();
         });
       });
 
       const jobAdd = queue.add('foo', {});
+
+      worker.run();
+
       await onJobActive;
 
       expect(Object.keys(worker['childPool'].retained)).toHaveLength(1);

--- a/tests/stalled_jobs.test.ts
+++ b/tests/stalled_jobs.test.ts
@@ -1036,6 +1036,7 @@ describe('stalled jobs', () => {
             return delay(10000);
           },
           {
+            autorun: false,
             connection,
             prefix,
             lockDuration: 1000,
@@ -1063,6 +1064,8 @@ describe('stalled jobs', () => {
         }));
 
         await queue.addBulk(jobs);
+
+        worker.run();
 
         await allActive;
 

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -5387,6 +5387,31 @@ describe('workers', () => {
 
       await worker.close();
     });
+
+    describe('when there is a job in waiting', () => {
+      it('should emit active event when calling getNextJob', async () => {
+        const worker = new Worker(queueName, null, { connection, prefix });
+        const token = 'my-token';
+
+        await queue.add('test', { foo: 'bar' });
+
+        const activated = new Promise<Job>(resolve => {
+          worker.on('active', resolve);
+        });
+
+        const job = (await worker.getNextJob(token)) as Job;
+
+        const activatedJob = await activated;
+
+        expect(activatedJob.id).toBe(job.id);
+
+        const isActive = await job.isActive();
+        expect(isActive).toBe(true);
+
+        await job.moveToCompleted('done', token);
+        await worker.close();
+      });
+    });
   });
 
   describe('non-blocking', () => {


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
1. Why is this change necessary? Manual processing was not emitting active event as it was not emitted as soon as a retrieving a new job

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
ref https://github.com/taskforcesh/bullmq/issues/3911