### PR TITLE
feat(sandbox): add missing method declarations to SandboxedJob interface

### DIFF
--- a/src/classes/child-processor.ts
+++ b/src/classes/child-processor.ts
@@ -228,7 +228,9 @@ export class ChildProcessor {
       /**
        * Proxy `getChildrenValues` function.
        */
-      getChildrenValues: async () => {
+      getChildrenValues: async <CT = any>(): Promise<{
+        [jobKey: string]: CT;
+      }> => {
         const requestId = Math.random().toString(36).substring(2, 15);
         await send({
           requestId,
@@ -240,7 +242,7 @@ export class ChildProcessor {
           this.receiver,
           RESPONSE_TIMEOUT,
           'getChildrenValues',
-        );
+        ) as Promise<{ [jobKey: string]: CT }>;
       },
 
       /**
@@ -252,7 +254,9 @@ export class ChildProcessor {
        * @returns - A promise that resolves with the ignored children failures.
        * The exact structure of the returned data depends on the parent process implementation.
        */
-      getIgnoredChildrenFailures: async () => {
+      getIgnoredChildrenFailures: async (): Promise<{
+        [jobKey: string]: string;
+      }> => {
         const requestId = Math.random().toString(36).substring(2, 15);
         await send({
           requestId,
@@ -264,7 +268,7 @@ export class ChildProcessor {
           this.receiver,
           RESPONSE_TIMEOUT,
           'getIgnoredChildrenFailures',
-        );
+        ) as Promise<{ [jobKey: string]: string }>;
       },
 
       /**
@@ -275,7 +279,12 @@ export class ChildProcessor {
         ignored?: boolean;
         processed?: boolean;
         unprocessed?: boolean;
-      }) => {
+      }): Promise<{
+        failed?: number;
+        ignored?: number;
+        processed?: number;
+        unprocessed?: number;
+      }> => {
         const requestId = Math.random().toString(36).substring(2, 15);
         await send({
           requestId,
@@ -288,7 +297,12 @@ export class ChildProcessor {
           this.receiver,
           RESPONSE_TIMEOUT,
           'getDependenciesCount',
-        );
+        ) as Promise<{
+          failed?: number;
+          ignored?: number;
+          processed?: number;
+          unprocessed?: number;
+        }>;
       },
     };
 

--- a/src/interfaces/sandboxed-job.ts
+++ b/src/interfaces/sandboxed-job.ts
@@ -4,19 +4,34 @@ import { MoveToWaitingChildrenOpts } from './minimal-job';
 /**
  * @see {@link https://docs.bullmq.io/guide/workers/sandboxed-processors}
  */
-export interface SandboxedJob<T = any, R = any>
-  extends Omit<JobJsonSandbox, 'data' | 'opts' | 'returnValue'> {
+export interface SandboxedJob<T = any, R = any> extends Omit<
+  JobJsonSandbox,
+  'data' | 'opts' | 'returnValue'
+> {
   data: T;
   opts: JobsOptions;
   queueQualifiedName: string;
+  returnValue: R;
+  getChildrenValues: <CT = any>() => Promise<{ [jobKey: string]: CT }>;
+  getDependenciesCount: (opts?: {
+    failed?: boolean;
+    ignored?: boolean;
+    processed?: boolean;
+    unprocessed?: boolean;
+  }) => Promise<{
+    failed?: number;
+    ignored?: number;
+    processed?: number;
+    unprocessed?: number;
+  }>;
+  getIgnoredChildrenFailures: () => Promise<{ [jobKey: string]: string }>;
+  log: (row: any) => void;
   moveToDelayed: (timestamp: number, token?: string) => Promise<void>;
   moveToWait: (token?: string) => Promise<void>;
   moveToWaitingChildren: (
     token?: string,
     opts?: MoveToWaitingChildrenOpts,
   ) => Promise<boolean>;
-  log: (row: any) => void;
   updateData: (data: any) => Promise<void>;
   updateProgress: (value: JobProgress) => Promise<void>;
-  returnValue: R;
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature / Type alignment

## What is the current behavior?

The `SandboxedJob` interface is missing type declarations for `getChildrenValues`, `getIgnoredChildrenFailures`, and `getDependenciesCount`. These methods are fully implemented at runtime in `wrapJob()` (in `child-processor.ts`) and handled on the parent side (in `sandbox.ts`), but TypeScript users cannot access them without using type assertions like `(job as any).getChildrenValues()`.

Closes #3925

## What is the new behavior?

The `SandboxedJob` interface now declares all three methods with proper type signatures matching the `Job` class:

- `getChildrenValues<CT = any>(): Promise<{ [jobKey: string]: CT }>`
- `getIgnoredChildrenFailures(): Promise<{ [jobKey: string]: string }>`
- `getDependenciesCount(opts?): Promise<{ failed?: number; ignored?: number; processed?: number; unprocessed?: number }>`

The implementations in `child-processor.ts` are also updated with explicit return type annotations and proper type casts for the `waitResponse` calls, ensuring type safety between the interface and implementation.

## Additional context

- No runtime behavior changes — this is a types-only alignment
- `getDependenciesCount` was also missing from the interface (same pattern as the two methods mentioned in the issue), so it is included for completeness
- The return type signatures match those on the `Job` class (`src/classes/job.ts`)
- Follows the same pattern used by `moveToWaitingChildren` which already had a proper type cast