### PR TITLE
fix(events): correct delayed event type and docs for delay field

### DIFF
--- a/src/classes/queue-events.ts
+++ b/src/classes/queue-events.ts
@@ -103,7 +103,8 @@ export interface QueueEventsListener extends IoredisListener {
   /**
    * Listen to 'delayed' event.
    *
-   * This event is triggered when a job is scheduled with a delay before it becomes active.
+   * This event is triggered when a job is scheduled with a delay. When the delay
+   * expires, the job will be moved to waiting, prioritized or paused state.
    *
    * @param args - An object containing details about the delayed job.
    *  - `jobId` - The unique identifier of the job that was delayed.

--- a/src/classes/queue-events.ts
+++ b/src/classes/queue-events.ts
@@ -107,10 +107,11 @@ export interface QueueEventsListener extends IoredisListener {
    *
    * @param args - An object containing details about the delayed job.
    *  - `jobId` - The unique identifier of the job that was delayed.
-   *  - `delay` - The delay duration in milliseconds before the job becomes active.
+   *  - `delay` - The timestamp (UNIX time in milliseconds) at which the job will become
+   *    active, represented as a string due to Redis serialization.
    * @param id - The identifier of the event.
    */
-  delayed: (args: { jobId: string; delay: number }, id: string) => void;
+  delayed: (args: { jobId: string; delay: string }, id: string) => void;
 
   /**
    * Listen to 'drained' event.

--- a/src/classes/queue-events.ts
+++ b/src/classes/queue-events.ts
@@ -107,8 +107,8 @@ export interface QueueEventsListener extends IoredisListener {
    *
    * @param args - An object containing details about the delayed job.
    *  - `jobId` - The unique identifier of the job that was delayed.
-   *  - `delay` - The timestamp (UNIX time in milliseconds) at which the job will become
-   *    active, represented as a string due to Redis serialization.
+   *  - `delay` - The timestamp (UNIX time in milliseconds) at which the job will be
+   *    promoted, represented as a string due to Redis serialization.
    * @param id - The identifier of the event.
    */
   delayed: (args: { jobId: string; delay: string }, id: string) => void;

--- a/tests/flow.test.ts
+++ b/tests/flow.test.ts
@@ -4727,7 +4727,7 @@ describe('flows', () => {
       const delayed = new Promise<void>((resolve, reject) => {
         queueEvents.on('delayed', async ({ jobId, delay }) => {
           try {
-            const milliseconds = delay - Date.now();
+            const milliseconds = Number(delay) - Date.now();
             expect(milliseconds).to.be.lessThanOrEqual(3000);
             expect(milliseconds).toBeGreaterThan(2000);
             resolve();

--- a/tests/job_scheduler.test.ts
+++ b/tests/job_scheduler.test.ts
@@ -3100,7 +3100,7 @@ describe('Job Scheduler', () => {
       const completedJobs: Job[] = [];
       const workerErrors: Error[] = [];
       const processedJobIds: string[] = [];
-      const delayedEvents: { jobId: string; delay: number }[] = [];
+      const delayedEvents: { jobId: string; delay: string }[] = [];
       let schedulerUpdateAttempts = 0;
 
       // Create a worker that will process jobs
@@ -3307,7 +3307,7 @@ describe('Job Scheduler', () => {
       // TODO: Move timeout to test options: { timeout: 8000 } // Reduced timeout since delay will be mocked
 
       const workerErrors: Error[] = [];
-      const delayedEvents: { jobId: string; delay: number }[] = [];
+      const delayedEvents: { jobId: string; delay: string }[] = [];
       let schedulerUpdateFailures = 0;
 
       // Create a worker that will process jobs


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (type correction + documentation fix)

## What is the current behavior?

The `delayed` event in `QueueEventsListener` has two issues:

1. **Incorrect JSDoc**: The `delay` field is documented as *"The delay duration in milliseconds before the job becomes active"*, but it is actually a **UNIX timestamp** (milliseconds since epoch) representing *when* the job will become active. This can be verified in the Lua scripts (`addDelayedJob.lua`, `moveToDelayed-8.lua`, `moveParentToWait.lua`) which all emit `delayedTimestamp` (computed as `timestamp + delay`), not the delay duration.

2. **Incorrect TypeScript type**: The `delay` field is typed as `number`, but Redis streams return all values as strings. The `array2obj` utility (which parses stream entries) returns `Record<string, string>`, so `delay` is actually a `string` at runtime. This is consistent with other event fields like `count: string` in the `cleaned` event.

   Evidence from existing tests:
   - `sandboxed_process.test.ts:1124` already uses `Number(delay)`, indicating the author knew it's a string
   - `flow.test.ts:4730` used `delay - Date.now()` which only worked due to JavaScript's implicit coercion

Closes #3267

## What is the new behavior?

- **JSDoc**: Updated to correctly describe `delay` as *"The timestamp (UNIX time in milliseconds) at which the job will become active, represented as a string due to Redis serialization"*
- **Type**: Changed from `delay: number` to `delay: string` to match the actual runtime value
- **Tests**: Updated `flow.test.ts` and `job_scheduler.test.ts` to use `Number(delay)` for arithmetic and `string` for type annotations

## Additional context

The Lua code in `addDelayedJob.lua` that emits this event:
```lua
local delayedTimestamp = (delay > 0 and (tonumber(timestamp) + delay)) or tonumber(timestamp)
rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event", "delayed",
    "jobId", jobId, "delay", delayedTimestamp)
```

This clearly shows `delay` in the event payload is `delayedTimestamp`, not the delay duration.