### PR TITLE
fix(sandbox): remove returnvalue from JobJsonSandbox interface

### DIFF
--- a/src/interfaces/sandboxed-job.ts
+++ b/src/interfaces/sandboxed-job.ts
@@ -6,7 +6,7 @@ import { MoveToWaitingChildrenOpts } from './minimal-job';
  */
 export interface SandboxedJob<T = any, R = any> extends Omit<
   JobJsonSandbox,
-  'data' | 'opts' | 'returnValue'
+  'data' | 'opts' | 'returnvalue'
 > {
   data: T;
   opts: JobsOptions;


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? returnValue does not exists in JobJsonSandbox but return value

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
