### PR TITLE
docs: complete missing JSDoc param and return descriptions

### DIFF
--- a/src/classes/flow-producer.ts
+++ b/src/classes/flow-producer.ts
@@ -548,9 +548,9 @@ export class FlowProducer extends EventEmitter {
    * Helper factory method that creates a queue-like object
    * required to create jobs in any queue.
    *
-   * @param node -
-   * @param queueKeys -
-   * @returns
+   * @param node - The flow node containing the queue name and other job options.
+   * @param queueKeys - The queue keys helper used to resolve key names.
+   * @returns A queue-like object with the client, keys, and options needed to create jobs.
    */
   private queueFromNode(
     node: Omit<NodeOpts, 'id' | 'depth' | 'maxChildren'>,

--- a/src/classes/flow-producer.ts
+++ b/src/classes/flow-producer.ts
@@ -550,6 +550,7 @@ export class FlowProducer extends EventEmitter {
    *
    * @param node - The flow node containing the queue name and other job options.
    * @param queueKeys - The queue keys helper used to resolve key names.
+   * @param prefix - The Redis key prefix used for the queue.
    * @returns A queue-like object with the client, keys, and options needed to create jobs.
    */
   private queueFromNode(

--- a/src/classes/queue-base.ts
+++ b/src/classes/queue-base.ts
@@ -123,8 +123,8 @@ export class QueueBase extends EventEmitter implements MinimalQueue {
    * Emits an event. Normally used by subclasses to emit events.
    *
    * @param event - The emitted event.
-   * @param args -
-   * @returns
+   * @param args - The arguments to pass to the event listeners.
+   * @returns True if the event had listeners, false otherwise.
    */
   emit(event: string | symbol, ...args: any[]): boolean {
     try {
@@ -199,8 +199,8 @@ export class QueueBase extends EventEmitter implements MinimalQueue {
    * @param operation - operation name (such as add, process, etc)
    * @param destination - destination name (normally the queue name)
    * @param callback - code to wrap with telemetry
-   * @param srcPropagationMetadata -
-   * @returns
+   * @param srcPropagationMetadata - The source propagation metadata for telemetry context.
+   * @returns The result of the callback function.
    */
   trace<T>(
     spanKind: SpanKind,

--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -1036,7 +1036,7 @@ export class Queue<
   /**
    * Trim the event stream to an approximately maxLength.
    *
-   * @param maxLength -
+   * @param maxLength - The maximum length of the events stream.
    */
   async trimEvents(maxLength: number): Promise<number> {
     return this.trace<number>(

--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -1036,7 +1036,7 @@ export class Queue<
   /**
    * Trim the event stream to an approximately maxLength.
    *
-   * @param maxLength - The maximum length of the events stream.
+   * @param maxLength - The maximum length of the event stream.
    */
   async trimEvents(maxLength: number): Promise<number> {
     return this.trace<number>(

--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -1036,7 +1036,7 @@ export class Queue<
   /**
    * Trim the event stream to an approximately maxLength.
    *
-   * @param maxLength - The maximum length of the event stream.
+   * @param maxLength - The approximate maximum length, or target length, of the event stream.
    */
   async trimEvents(maxLength: number): Promise<number> {
     return this.trace<number>(


### PR DESCRIPTION
## Summary
- Add missing `@param` and `@returns` descriptions in `QueueBase.emit()` and `QueueBase.trace()` methods
- Add missing `@param` and `@returns` descriptions in `FlowProducer.queueFromNode()` method
- Add missing `@param` description in `Queue.trimEvents()` method

## Test plan
- [ ] Verify JSDoc descriptions render correctly in IDE tooltips
- [ ] No functional code changes; documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)