### PR TITLE
fix(queue): filter undefined jobs from getJobs results

### DIFF
--- a/src/classes/queue-getters.ts
+++ b/src/classes/queue-getters.ts
@@ -490,9 +490,10 @@ export class QueueGetters<JobBase extends Job = Job> extends QueueBase {
 
     const jobIds = await this.getRanges(currentTypes, start, end, asc);
 
-    return Promise.all(
-      jobIds.map(jobId => this.Job.fromId(this, jobId) as Promise<JobBase>),
+    const jobs = await Promise.all(
+      jobIds.map(jobId => this.Job.fromId(this, jobId)),
     );
+    return jobs.filter(job => job !== undefined) as JobBase[];
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fixes #3767 where `queue.getActive()` (and other `getJobs` based methods) could return arrays containing `undefined` values
- `Job.fromId()` returns `undefined` when a job hash is missing from Redis (e.g., due to race conditions where a job completes between listing IDs and fetching data). The `Promise.all()` preserves these `undefined` entries in the result array
- Added a `.filter(job => job !== undefined)` after the `Promise.all()` call in `getJobs()` to strip out missing jobs before returning

## Test plan
- [ ] Verify that `queue.getActive()`, `queue.getCompleted()`, and other status-based getters no longer include `undefined` in results
- [ ] Verify existing tests still pass