### PR TITLE
fix: use connection from opts in FlowProducer [python]

### DIFF
--- a/python/bullmq/flow_producer.py
+++ b/python/bullmq/flow_producer.py
@@ -36,7 +36,8 @@ class FlowProducer:
         """
         Initialize a connection
         """
-        self.redisConnection = RedisConnection(redisOpts)
+        connection = redisOpts if redisOpts else opts.get("connection", {})
+        self.redisConnection = RedisConnection(connection)
         self.client = self.redisConnection.conn
         self.opts: dict = opts
         self.prefix = opts.get("prefix", "bull")

--- a/python/tests/flow_test.py
+++ b/python/tests/flow_test.py
@@ -284,5 +284,50 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         await child_queue.obliterate()
         await child_queue.close()
 
+    async def test_should_use_connection_from_opts_when_redis_opts_empty(self):
+        """Test that FlowProducer uses opts connection when redisOpts is empty"""
+        parent_queue_name = f"__test_parent_queue__{uuid4().hex}"
+
+        flow = FlowProducer({}, {"prefix": prefix, "connection": {"host": "localhost", "port": 6379}})
+        tree = await flow.add(
+            {
+                "name": 'test-job',
+                "queueName": parent_queue_name,
+                "data": {"foo": "bar"},
+            }
+        )
+
+        self.assertIsNotNone(tree)
+        await flow.close()
+
+        parent_queue = Queue(parent_queue_name, {"prefix": prefix})
+        await parent_queue.pause()
+        await parent_queue.obliterate()
+        await parent_queue.close()
+
+    async def test_should_prefer_redis_opts_over_opts_connection(self):
+        """Test that FlowProducer prefers redisOpts over opts connection"""
+        parent_queue_name = f"__test_parent_queue__{uuid4().hex}"
+
+        flow = FlowProducer(
+            {"host": "localhost", "port": 6379},
+            {"prefix": prefix, "connection": {"host": "invalid-host", "port": 9999}}
+        )
+        tree = await flow.add(
+            {
+                "name": 'test-job',
+                "queueName": parent_queue_name,
+                "data": {"foo": "bar"},
+            }
+        )
+
+        self.assertIsNotNone(tree)
+        await flow.close()
+
+        parent_queue = Queue(parent_queue_name, {"prefix": prefix})
+        await parent_queue.pause()
+        await parent_queue.obliterate()
+        await parent_queue.close()
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

- Fixes #3619: Python `FlowProducer` now falls back to `opts["connection"]` when `redisOpts` is not provided, matching the behavior of `Queue` and `Worker` classes
- Previously, passing `connection` inside the `opts` dict was silently ignored, requiring users to pass connection config as the first positional argument

## Details

In `python/bullmq/flow_producer.py`, the constructor was hardcoded to use only the `redisOpts` parameter for `RedisConnection`, ignoring `opts.get("connection")`. The `Queue` class already reads the connection from `opts`:

```python
# Queue (existing correct behavior)
redisOpts = opts.get("connection", {})
self.redisConnection = RedisConnection(redisOpts)
```

This PR applies the same pattern to `FlowProducer`:

```python
# FlowProducer (fixed)
connection = redisOpts if redisOpts else opts.get("connection", {})
self.redisConnection = RedisConnection(connection)
```

This allows users to instantiate `FlowProducer` the same way as `Queue`:

```python
flow = FlowProducer(opts={"connection": "redis://localhost:6379"})
```

## Test plan

- [ ] Verify `FlowProducer(redisOpts="redis://...")` still works (direct connection string)
- [ ] Verify `FlowProducer(opts={"connection": "redis://..."})` now works (opts-based connection)
- [ ] Verify `FlowProducer(redisOpts="redis://...", opts={"connection": "redis://other"})` uses `redisOpts` (first arg takes priority)
- [ ] Verify `FlowProducer()` defaults to empty dict connection (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)