### PR TITLE
fix(job-scheduler): preserve offset from repeatOpts

### DIFF
--- a/src/classes/job-scheduler.ts
+++ b/src/classes/job-scheduler.ts
@@ -88,7 +88,7 @@ export class JobScheduler extends QueueBase {
     const { immediately, ...filteredRepeatOpts } = repeatOpts;
 
     let nextMillis: number;
-    const newOffset: number | null = null;
+    let newOffset: number | null = offset || null;
 
     if (pattern) {
       nextMillis = await this.repeatStrategy(now, repeatOpts, jobName);


### PR DESCRIPTION
## Summary
- Fixes #3705 - Upsert Job Scheduler no longer respects offset
- In `upsertJobScheduler`, `newOffset` was initialized as `const newOffset: number | null = null` and never updated, causing the offset from `repeatOpts` to be lost for pattern-based (cron) scheduling
- Changed to `let newOffset: number | null = offset || null` so the offset destructured from `repeatOpts` is preserved and passed through to `getNextJobOpts` and `addJobScheduler`

## Test plan
- [ ] Verify that creating a job scheduler with a cron pattern and an offset correctly applies the offset
- [ ] Verify that job schedulers without an offset still work as before (offset defaults to null)
- [ ] Run existing test suite to confirm no regressions