### PR TITLE
fix(worker): handle repeatable job keys with 5+ colon segments

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -904,20 +904,21 @@ will never work with more accuracy than 1ms. */
           async () => {
             if (job.repeatJobKey) {
               const jobScheduler = await this.jobScheduler;
-              const nextJob = await jobScheduler.upsertJobScheduler(
-                // Most of these arguments are not really needed
-                // anymore as we read them from the job scheduler itself
-                job.repeatJobKey,
-                job.opts.repeat,
-                job.name,
-                job.data,
-                job.opts,
-                { override: false, producerId: job.id },
-              );
+              const schedulerExists =
+                await jobScheduler.getScheduler(job.repeatJobKey);
 
-              // If the job scheduler did not find a matching scheduler,
-              // fall back to the legacy repeat system.
-              if (!nextJob && job.opts.repeat) {
+              if (schedulerExists) {
+                await jobScheduler.upsertJobScheduler(
+                  // Most of these arguments are not really needed
+                  // anymore as we read them from the job scheduler itself
+                  job.repeatJobKey,
+                  job.opts.repeat,
+                  job.name,
+                  job.data,
+                  job.opts,
+                  { override: false, producerId: job.id },
+                );
+              } else if (job.opts.repeat) {
                 const repeat = await this.repeat;
                 await repeat.updateRepeatableJob(
                   job.name,

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -902,9 +902,9 @@ will never work with more accuracy than 1ms. */
       try {
         await this.retryIfFailed(
           async () => {
-            if (job.repeatJobKey && job.repeatJobKey.split(':').length < 5) {
+            if (job.repeatJobKey) {
               const jobScheduler = await this.jobScheduler;
-              await jobScheduler.upsertJobScheduler(
+              const nextJob = await jobScheduler.upsertJobScheduler(
                 // Most of these arguments are not really needed
                 // anymore as we read them from the job scheduler itself
                 job.repeatJobKey,
@@ -914,6 +914,20 @@ will never work with more accuracy than 1ms. */
                 job.opts,
                 { override: false, producerId: job.id },
               );
+
+              // If the job scheduler did not find a matching scheduler,
+              // fall back to the legacy repeat system.
+              if (!nextJob && job.opts.repeat) {
+                const repeat = await this.repeat;
+                await repeat.updateRepeatableJob(
+                  job.name,
+                  job.data,
+                  job.opts,
+                  {
+                    override: false,
+                  },
+                );
+              }
             } else if (job.opts.repeat) {
               const repeat = await this.repeat;
               await repeat.updateRepeatableJob(job.name, job.data, job.opts, {


### PR DESCRIPTION
## Summary
- Fixes #3828 - Repeatable jobs with 5+ colon segments in their key create duplicates
- Removes the fragile `job.repeatJobKey.split(':').length < 5` heuristic for distinguishing JobScheduler keys from legacy Repeat keys
- Instead, always tries the JobScheduler path first when `repeatJobKey` is set, and falls back to the legacy Repeat path only if the scheduler was not found (returned `undefined`)

## Root cause
The worker used colon-count (`< 5`) to decide whether a repeatable job key belongs to the new JobScheduler system or the legacy Repeat system. This worked for simple cases but failed when:
- A JobScheduler ID contained 4+ colons (e.g., `namespace:service:scheduler:type:daily`) -- routed incorrectly to the legacy Repeat path, creating duplicate jobs
- A legacy key happened to have fewer than 5 colon segments

## Fix
The `updateJobScheduler` Lua script already validates that the scheduler exists via `ZSCORE` before processing. If the scheduler is not found, it returns `nil` and does nothing. This makes it safe to always attempt the JobScheduler path first:

1. If `job.repeatJobKey` is set, try `upsertJobScheduler` (which calls `updateJobSchedulerNextMillis`)
2. If it returns `undefined` (scheduler not found), fall back to `updateRepeatableJob` (legacy Repeat)
3. If `job.repeatJobKey` is not set but `job.opts.repeat` exists, use the legacy Repeat path directly

This approach is robust regardless of the key format and does not depend on colon-counting heuristics.

## Test plan
- [ ] Existing repeatable job tests pass (both JobScheduler and legacy Repeat paths)
- [ ] Create a JobScheduler with an ID containing 5+ colon segments (e.g., `a:b:c:d:e`) and verify jobs are processed without duplicates
- [ ] Verify legacy Repeat jobs with hash-based keys still work correctly (fall through from JobScheduler to Repeat path)