### PR TITLE
fix(worker): resume processing after pause with doNotWaitActive

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -1185,7 +1185,7 @@ will never work with more accuracy than 1ms. */
    * Resumes processing of this worker (if paused).
    */
   resume(): void {
-    if (!this.running) {
+    if (!this.running || this.paused) {
       this.trace<void>(SpanKind.INTERNAL, 'resume', this.name, span => {
         span?.setAttributes({
           [TelemetryAttributes.WorkerId]: this.id,
@@ -1194,8 +1194,14 @@ will never work with more accuracy than 1ms. */
 
         this.paused = false;
 
-        if (this.processFn) {
-          this.run();
+        if (!this.running) {
+          if (this.processFn) {
+            this.run();
+          }
+        } else {
+          // Main loop is still running (pause was called with doNotWaitActive=true).
+          // Restart the stalled checker since pause() stopped it.
+          this.startStalledCheckTimer();
         }
         this.emit('resumed');
       });

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -196,6 +196,7 @@ export class Worker<
   protected lockManager: LockManager;
   private processorAcceptsSignal = false;
 
+  private stalledCheckerRunning = false;
   private stalledCheckStopper?: () => void;
   private waiting: Promise<number> | null = null;
   private _repeat: Repeat; // To be deprecated in v6 in favor of Job Scheduler
@@ -1184,27 +1185,32 @@ will never work with more accuracy than 1ms. */
    *
    * Resumes processing of this worker (if paused).
    */
-  resume(): void {
+  async resume(): Promise<void> {
     if (!this.running || this.paused) {
-      this.trace<void>(SpanKind.INTERNAL, 'resume', this.name, span => {
-        span?.setAttributes({
-          [TelemetryAttributes.WorkerId]: this.id,
-          [TelemetryAttributes.WorkerName]: this.opts.name,
-        });
+      await this.trace<void>(
+        SpanKind.INTERNAL,
+        'resume',
+        this.name,
+        async span => {
+          span?.setAttributes({
+            [TelemetryAttributes.WorkerId]: this.id,
+            [TelemetryAttributes.WorkerName]: this.opts.name,
+          });
 
-        this.paused = false;
+          this.paused = false;
 
-        if (!this.running) {
-          if (this.processFn) {
-            this.run();
+          if (!this.running) {
+            if (this.processFn) {
+              this.run();
+            }
+          } else {
+            // Main loop is still running (pause was called with doNotWaitActive=true).
+            // Restart the stalled checker since pause() stopped it.
+            await this.startStalledCheckTimer();
           }
-        } else {
-          // Main loop is still running (pause was called with doNotWaitActive=true).
-          // Restart the stalled checker since pause() stopped it.
-          this.startStalledCheckTimer();
-        }
-        this.emit('resumed');
-      });
+          this.emit('resumed');
+        },
+      );
     }
   }
 
@@ -1304,7 +1310,7 @@ will never work with more accuracy than 1ms. */
    */
   async startStalledCheckTimer(): Promise<void> {
     if (!this.opts.skipStalledCheck) {
-      if (!this.closing) {
+      if (!this.closing && !this.stalledCheckerRunning) {
         await this.trace<void>(
           SpanKind.INTERNAL,
           'startStalledCheckTimer',
@@ -1315,9 +1321,14 @@ will never work with more accuracy than 1ms. */
               [TelemetryAttributes.WorkerName]: this.opts.name,
             });
 
-            this.stalledChecker().catch(err => {
-              this.emit('error', <Error>err);
-            });
+            this.stalledCheckerRunning = true;
+            this.stalledChecker()
+              .catch(err => {
+                this.emit('error', <Error>err);
+              })
+              .finally(() => {
+                this.stalledCheckerRunning = false;
+              });
           },
         );
       }

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -1200,6 +1200,7 @@ will never work with more accuracy than 1ms. */
             this.run();
           }
         } else {
+          // TODO: await for startStalledCheckTimer in next breaking change, that will convert resume method to async
           // Main loop is still running (pause was called with doNotWaitActive=true).
           // Restart the stalled checker since pause() stopped it.
           void this.startStalledCheckTimer().catch(err => {

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -1185,32 +1185,31 @@ will never work with more accuracy than 1ms. */
    *
    * Resumes processing of this worker (if paused).
    */
-  async resume(): Promise<void> {
+  resume(): void {
     if (!this.running || this.paused) {
-      await this.trace<void>(
-        SpanKind.INTERNAL,
-        'resume',
-        this.name,
-        async span => {
-          span?.setAttributes({
-            [TelemetryAttributes.WorkerId]: this.id,
-            [TelemetryAttributes.WorkerName]: this.opts.name,
-          });
+      this.trace<void>(SpanKind.INTERNAL, 'resume', this.name, span => {
+        span?.setAttributes({
+          [TelemetryAttributes.WorkerId]: this.id,
+          [TelemetryAttributes.WorkerName]: this.opts.name,
+        });
 
-          this.paused = false;
+        this.paused = false;
 
-          if (!this.running) {
-            if (this.processFn) {
-              this.run();
-            }
-          } else {
-            // Main loop is still running (pause was called with doNotWaitActive=true).
-            // Restart the stalled checker since pause() stopped it.
-            await this.startStalledCheckTimer();
+        if (!this.running) {
+          if (this.processFn) {
+            this.run();
           }
-          this.emit('resumed');
-        },
-      );
+        } else {
+          // Main loop is still running (pause was called with doNotWaitActive=true).
+          // Restart the stalled checker since pause() stopped it.
+          void this.startStalledCheckTimer().catch(err => {
+            this.emit('error', err);
+          });
+        }
+        this.emit('resumed');
+      }).catch(err => {
+        this.emit('error', err);
+      });
     }
   }
 

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -3013,6 +3013,56 @@ describe('workers', () => {
 
         await worker.close();
       });
+
+      it('should resume processing after pause with doNotWaitActive', async () => {
+        const worker = new Worker(
+          queueName,
+          async () => {
+            await delay(50);
+          },
+          {
+            connection,
+            prefix,
+          },
+        );
+        await worker.waitUntilReady();
+
+        // Process first job to ensure the worker is running
+        await queue.add('test', { seq: 'first' });
+
+        const firstCompleted = new Promise<void>(resolve => {
+          worker.once('completed', () => resolve());
+        });
+
+        await firstCompleted;
+
+        expect(worker.isRunning()).toBe(true);
+        expect(worker.isPaused()).toBe(false);
+
+        // Pause with doNotWaitActive=true (main loop keeps running)
+        await worker.pause(true);
+        expect(worker.isPaused()).toBe(true);
+        expect(worker.isRunning()).toBe(true);
+
+        // Resume should work even though isRunning() is true
+        worker.resume();
+        expect(worker.isPaused()).toBe(false);
+        expect(worker.isRunning()).toBe(true);
+
+        // Verify the worker actually processes new jobs after resume
+        await queue.add('test', { seq: 'after-resume' });
+
+        const secondCompleted = new Promise<void>(resolve => {
+          worker.once('completed', job => {
+            expect(job.data.seq).toBe('after-resume');
+            resolve();
+          });
+        });
+
+        await secondCompleted;
+
+        await worker.close();
+      });
     });
   });
 

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -3027,12 +3027,12 @@ describe('workers', () => {
         );
         await worker.waitUntilReady();
 
-        // Process first job to ensure the worker is running
-        await queue.add('test', { seq: 'first' });
-
         const firstCompleted = new Promise<void>(resolve => {
           worker.once('completed', () => resolve());
         });
+
+        // Process first job to ensure the worker is running
+        await queue.add('test', { seq: 'first' });
 
         await firstCompleted;
 
@@ -3049,15 +3049,15 @@ describe('workers', () => {
         expect(worker.isPaused()).toBe(false);
         expect(worker.isRunning()).toBe(true);
 
-        // Verify the worker actually processes new jobs after resume
-        await queue.add('test', { seq: 'after-resume' });
-
         const secondCompleted = new Promise<void>(resolve => {
           worker.once('completed', job => {
             expect(job.data.seq).toBe('after-resume');
             resolve();
           });
         });
+
+        // Verify the worker actually processes new jobs after resume
+        await queue.add('test', { seq: 'after-resume' });
 
         await secondCompleted;
 


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? Workers are stuck after applying pause(true) if we try to resume later

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
fixes https://github.com/taskforcesh/bullmq/issues/3971