### PR TITLE
fix(worker): make resume() work after pause(true) (closes #3971)

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -1185,7 +1185,7 @@ will never work with more accuracy than 1ms. */
    * Resumes processing of this worker (if paused).
    */
   resume(): void {
-    if (!this.running) {
+    if (this.paused) {
       this.trace<void>(SpanKind.INTERNAL, 'resume', this.name, span => {
         span?.setAttributes({
           [TelemetryAttributes.WorkerId]: this.id,
@@ -1194,9 +1194,31 @@ will never work with more accuracy than 1ms. */
 
         this.paused = false;
 
-        if (this.processFn) {
-          this.run();
+        if (!this.running) {
+          if (this.processFn) {
+            this.run();
+          }
+        } else if (this.mainLoopRunning) {
+          // After pause(true), the main loop may still be exiting
+          // asynchronously. Wait for it to settle, then restart the
+          // worker if it is not paused or closing.
+          this.mainLoopRunning.then(
+            () => {
+              if (
+                !this.paused &&
+                !this.closing &&
+                !this.running &&
+                this.processFn
+              ) {
+                this.run();
+              }
+            },
+            () => {
+              // Errors are handled inside run(); ignore here.
+            },
+          );
         }
+
         this.emit('resumed');
       });
     }

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -3013,6 +3013,47 @@ describe('workers', () => {
 
         await worker.close();
       });
+
+      it('should resume after pause(true) while jobs are still active', async () => {
+        const worker = new Worker(
+          queueName,
+          async () => {
+            await delay(500);
+          },
+          { connection, prefix },
+        );
+        await worker.waitUntilReady();
+
+        await queue.add('test', { foo: 'bar' });
+
+        // Wait for the job to become active
+        await new Promise<void>(resolve => {
+          worker.once('active', () => resolve());
+        });
+
+        // Pause without waiting for active jobs. This leaves the worker
+        // in running=true, paused=true state.
+        await worker.pause(true);
+        expect(worker.isPaused()).toBe(true);
+
+        // Resume should succeed even though running is still true
+        worker.resume();
+        expect(worker.isPaused()).toBe(false);
+
+        // Add another job to verify the worker is actually processing again
+        const completed = new Promise<void>(resolve => {
+          worker.on('completed', job => {
+            if (job.data.marker === 'after-resume') {
+              resolve();
+            }
+          });
+        });
+
+        await queue.add('test', { marker: 'after-resume' });
+        await completed;
+
+        await worker.close();
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #3971: `resume()` was a no-op after `pause(true)`, leaving the worker permanently stuck in `running=true`, `paused=true` state.

## Root cause

- `pause(true)` (doNotWaitActive) sets `this.paused = true` but skips `whenCurrentJobsFinished()`, so the main loop has not yet exited and `this.running` is still `true`.
- The old `resume()` checked `if (!this.running)` and bailed out in that case, so nothing happened. The main loop would eventually exit and set `running = false`, but nothing ever called `run()` again to restart processing.

## Fix

`resume()` now gates on `this.paused` instead of `!this.running` and handles both scenarios:

1. **Worker not running** (classic case): clear `paused`, call `run()`.
2. **Worker still running** (after `pause(true)`): clear `paused`. If the main loop is still exiting asynchronously, wait for `mainLoopRunning` to settle and restart via `run()` only if the worker is still not paused/closing/running.

## Test plan

- Added `should resume after pause(true) while jobs are still active` in `tests/worker.test.ts` which:
  - Starts a worker, adds a long-running job
  - Calls `pause(true)` while the job is still active
  - Calls `resume()` and verifies `isPaused()` is false
  - Adds another job and verifies it gets processed