### PR TITLE
docs(job): clarify createBulk is not atomic (closes #3451)

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -293,7 +293,11 @@ export class Job<
   }
 
   /**
-   * Creates a bulk of jobs and adds them atomically to the given queue.
+   * Creates a bulk of jobs and adds them to the given queue.
+   *
+   * Jobs are added via a Redis pipeline for efficiency, but each command
+   * is executed independently. If one job fails to add, previously
+   * pipelined jobs in the same batch may already have been created.
    *
    * @param queue - the queue where to add the jobs.
    * @param jobs - an array of jobs to be added to the queue.


### PR DESCRIPTION
## Summary

Fixes misinformation in the JSDoc for `Job.createBulk` in `src/classes/job.ts`.

The previous documentation stated that jobs were added "atomically" to the queue, but the implementation uses `client.pipeline()` rather than `client.multi()`. A Redis pipeline only batches commands together for efficiency; each command is executed independently on the server. If one job fails to be added, previously pipelined jobs in the same batch may already have been created in Redis.

## Changes

- Removed the incorrect claim of atomicity from the JSDoc.
- Added a clarifying note explaining that jobs are added via a Redis pipeline and that partial creation is possible if a command fails.

Closes #3451

## Test plan

- [x] Documentation-only change, no functional impact
- [x] Verified the JSDoc accurately reflects the behavior of the `pipeline().exec()` implementation at the same location