### PR TITLE
fix(sandbox): support .mts and .cts extensions for sandboxed processors (closes #3474)

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -287,7 +287,15 @@ export class Worker<
           }
           processor = processor.href;
         } else {
-          const supportedFileTypes = ['.js', '.ts', '.flow', '.cjs', '.mjs'];
+          const supportedFileTypes = [
+            '.js',
+            '.ts',
+            '.flow',
+            '.cjs',
+            '.mjs',
+            '.mts',
+            '.cts',
+          ];
           const processorFile =
             processor +
             (supportedFileTypes.includes(path.extname(processor)) ? '' : '.js');


### PR DESCRIPTION
## Summary

Closes #3474.

Adds `.mts` and `.cts` to the list of supported file extensions for sandboxed processors in `src/classes/worker.ts`. Node.js 22+ natively supports TypeScript through `.mts` and `.cts` extensions, so sandboxed processors written in TypeScript ESM/CJS modules should also be recognized without requiring users to rename files or append an extension manually.

## Changes

- `src/classes/worker.ts`: extended `supportedFileTypes` to include `.mts` and `.cts` alongside the existing `.js`, `.ts`, `.flow`, `.cjs`, and `.mjs`.

## Test plan

- [x] Verified the updated array is used by the existing extension check in the sandboxed processor resolution path.