### PR TITLE
docs(queue-getters): fix typo excedeed -> exceeded in JSDoc

### DIFF
--- a/src/classes/queue-getters.ts
+++ b/src/classes/queue-getters.ts
@@ -86,7 +86,7 @@ export class QueueGetters<JobBase extends Job = Job> extends QueueBase {
   /**
    * Returns the time to live for a rate limited key in milliseconds.
    * @param maxJobs - max jobs to be considered in rate limit state. If not passed
-   * it will return the remaining ttl without considering if max jobs is excedeed.
+   * it will return the remaining ttl without considering if max jobs is exceeded.
    * @returns -2 if the key does not exist.
    * -1 if the key exists but has no associated expire.
    * @see {@link https://redis.io/commands/pttl/}


### PR DESCRIPTION
## Summary

Fixes a small typo in the JSDoc comment for `getRateLimitTtl` in `src/classes/queue-getters.ts`.

"excedeed" -> "exceeded"

## Details

The JSDoc for the `maxJobs` parameter previously read:

> it will return the remaining ttl without considering if max jobs is excedeed.

Corrected to:

> it will return the remaining ttl without considering if max jobs is exceeded.

Documentation-only change; no runtime behavior is affected.