### PR TITLE
docs(lua): fix typo in moveToFinished comment

### DIFF
--- a/src/commands/moveToFinished-14.lua
+++ b/src/commands/moveToFinished-14.lua
@@ -1,5 +1,5 @@
 --[[
-  Move job from active to a finished status (completed o failed)
+  Move job from active to a finished status (completed or failed)
   A job can only be moved to completed if it was active.
   The job must be locked before it can be moved to a finished status,
   and the lock must be released in this script.


### PR DESCRIPTION
## Summary

Fixes a small typo in the header comment of `src/commands/moveToFinished-14.lua`.

The comment read:

```
Move job from active to a finished status (completed o failed)
```

It now reads:

```
Move job from active to a finished status (completed or failed)
```

Comment-only change; no behavioral or runtime impact.