### PR TITLE
fix(job): use consistent grammar in error message

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -1559,7 +1559,7 @@ export class Job<
     }
 
     if (this.opts.delay && this.opts.repeat && !this.opts.repeat?.count) {
-      throw new Error(`Delay and repeat options could not be used together`);
+      throw new Error(`Delay and repeat options cannot be used together`);
     }
 
     const enabledExclusiveOptions = exclusiveOptions.filter(

--- a/tests/job.test.ts
+++ b/tests/job.test.ts
@@ -134,7 +134,7 @@ describe('Job', () => {
         const data = { foo: 'bar' };
         const opts = { repeat: { every: 200 }, delay: 1000 };
         await expect(Job.create(queue, 'test', data, opts)).rejects.toThrow(
-          'Delay and repeat options could not be used together',
+          'Delay and repeat options cannot be used together',
         );
       });
     });


### PR DESCRIPTION
## Summary

Fixes a minor grammar inconsistency in an error message in `src/classes/job.ts`.

The error thrown when both `delay` and `repeat` options are provided used the awkward phrasing `could not be used together`, while all other similar validation error messages in the same file (e.g., for deduplication, debounce, and exclusive options) use `cannot be used together`.

## Changes

- `src/classes/job.ts`: Change `Delay and repeat options could not be used together` to `Delay and repeat options cannot be used together`
- `tests/job.test.ts`: Update the corresponding test assertion to match the new error message

## Test plan

- [x] Updated existing test in `tests/job.test.ts` to match the new error message
- [x] Verified no other references to the old string remain in the codebase