### PR TITLE
test(pause): add regression test for resume after pause(true)

### DIFF
--- a/tests/pause.test.ts
+++ b/tests/pause.test.ts
@@ -411,4 +411,47 @@ describe('Pause', () => {
       await worker!.close();
     });
   });
+
+  it('should resume processing after pause(true) without waiting for active jobs', async () => {
+    let jobProcessedAfterResume = false;
+
+    const worker = new Worker(
+      queueName,
+      async () => {
+        await delay(100);
+      },
+      { connection, prefix },
+    );
+
+    await worker.waitUntilReady();
+
+    // Add a job so the worker is processing
+    await queue.add('test', { foo: 'bar' });
+    await delay(50);
+
+    // Pause without waiting for active jobs to finish
+    await worker.pause(true);
+
+    expect(worker.isPaused()).toBe(true);
+
+    // Resume the worker
+    worker.resume();
+
+    expect(worker.isPaused()).toBe(false);
+
+    // Add another job and verify it gets processed
+    const processingAfterResume = new Promise<void>(resolve => {
+      worker.on('completed', () => {
+        jobProcessedAfterResume = true;
+        resolve();
+      });
+    });
+
+    await queue.add('test2', { foo: 'baz' });
+    await processingAfterResume;
+
+    expect(jobProcessedAfterResume).toBe(true);
+
+    await worker.close();
+  });
 });


### PR DESCRIPTION
### Why
The fix for `resume()` being a no-op after `pause(true)` has already landed on master via #3974. This PR is now test-only: it adds a regression test in `tests/pause.test.ts` covering the specific `pause(true)` → `resume()` → process new job scenario, which is not currently exercised in that file.

Refs #3971 (the original bug this defends against regressing).

### How
Adds a single test to the existing Pause describe block that:
1. Starts a worker processing a job
2. Calls `worker.pause(true)` (doNotWaitActive)
3. Asserts `isPaused()` is true
4. Calls `worker.resume()`
5. Asserts `isPaused()` is false
6. Enqueues another job and verifies it completes

### Additional Notes
- The worker.ts changes from the original PR are now subsumed by #3974 (which landed first with a superset of the fix), so only the test file remains in this PR's diff.
- Close if the coverage is considered redundant with the tests added in #3974 to `tests/worker.test.ts`.