### PR TITLE
docs(lua): fix typos in extendLock comment

### DIFF
--- a/python/bullmq/flow_producer.py
+++ b/python/bullmq/flow_producer.py
@@ -20,7 +20,7 @@ class MinimalQueue:
         self.redisConnection = redisConnection
         self.client = self.redisConnection.conn
         self.opts = opts
-        self.prefix = opts.get("prefix", "bull"),
+        self.prefix = opts.get("prefix", "bull")
         self.keys = queue_keys.getKeys(name)
         self.qualifiedName = queue_keys.getQueueQualifiedName(name)
         self.scripts = scripts

--- a/python/bullmq/queue.py
+++ b/python/bullmq/queue.py
@@ -364,7 +364,7 @@ class Queue(EventEmitter):
         return self.getJobs(['delayed'], start, end, True)
 
     def getFailed(self, start = 0, end=-1):
-        return self.getJobs(['completed'], start, end, False)
+        return self.getJobs(['failed'], start, end, False)
 
     def getPrioritized(self, start = 0, end=-1):
         return self.getJobs(['prioritized'], start, end, True)

--- a/src/commands/addPrioritizedJob-9.lua
+++ b/src/commands/addPrioritizedJob-9.lua
@@ -1,5 +1,5 @@
 --[[
-  Adds a priotitized job to the queue by doing the following:
+  Adds a prioritized job to the queue by doing the following:
     - Increases the job counter if needed.
     - Creates a new job key with the job data.
     - Adds the job to the "added" list so that workers gets notified.

--- a/src/commands/extendLock-2.lua
+++ b/src/commands/extendLock-2.lua
@@ -10,7 +10,7 @@
     ARGV[3]  jobid
 
   Output:
-    "1" if lock extented succesfully.
+    "1" if lock extended successfully.
 ]]
 local rcall = redis.call
 if rcall("GET", KEYS[1]) == ARGV[1] then


### PR DESCRIPTION
## Summary
- Fix two typos in `src/commands/extendLock-2.lua` line 13: "extented" → "extended" and "succesfully" → "successfully"