### PR TITLE
fix(python): getFailed() incorrectly returns completed jobs

### DIFF
--- a/python/bullmq/queue.py
+++ b/python/bullmq/queue.py
@@ -364,7 +364,7 @@ class Queue(EventEmitter):
         return self.getJobs(['delayed'], start, end, True)
 
     def getFailed(self, start = 0, end=-1):
-        return self.getJobs(['completed'], start, end, False)
+        return self.getJobs(['failed'], start, end, False)
 
     def getPrioritized(self, start = 0, end=-1):
         return self.getJobs(['prioritized'], start, end, True)

--- a/python/tests/queue_test.py
+++ b/python/tests/queue_test.py
@@ -692,6 +692,48 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
         
         await queue.close()
 
+    async def test_get_failed_returns_only_failed_jobs(self):
+        """Regression test: getFailed() should return only failed jobs, not completed."""
+        queue_name_local = f"__test_queue__{uuid4().hex}"
+        queue = Queue(queue_name_local, {"prefix": prefix})
+
+        async def process(job: Job, token: str):
+            if job.data.get("shouldFail"):
+                raise Exception("intentional failure")
+            return "ok"
+
+        worker = Worker(queue_name_local, process, {"prefix": prefix})
+
+        finished_count = 0
+        done_future = Future()
+
+        def on_finished(job: Job, result):
+            nonlocal finished_count
+            finished_count += 1
+            if finished_count == 2 and not done_future.done():
+                done_future.set_result(None)
+
+        worker.on("completed", on_finished)
+        worker.on("failed", on_finished)
+
+        await queue.add("test", {"shouldFail": True}, {"attempts": 1})
+        await queue.add("test", {"shouldFail": False}, {})
+
+        await done_future
+
+        failed = await queue.getFailed()
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0].data["shouldFail"], True)
+
+        completed = await queue.getCompleted()
+        self.assertEqual(len(completed), 1)
+        self.assertEqual(completed[0].data["shouldFail"], False)
+
+        await worker.close()
+        await queue.pause()
+        await queue.obliterate()
+        await queue.close()
+
     async def test_default_job_options(self):
         """Test that defaultJobOptions are applied to jobs added to the queue"""
         queue_name = f"__test_queue__{uuid4().hex}"


### PR DESCRIPTION
## Summary
- `Queue.getFailed()` in the Python SDK was calling `self.getJobs(['completed'], ...)` instead of `self.getJobs(['failed'], ...)`, causing it to return completed jobs instead of failed ones.
- This is a copy-paste bug — `getCompleted()` directly above uses `['completed']` correctly, but `getFailed()` was never updated to use `['failed']`.

## Test plan
- [ ] Call `queue.getFailed()` and verify it returns only jobs in the `failed` state
- [ ] Call `queue.getCompleted()` and verify it still returns only completed jobs
- [ ] Confirm no other `get<State>()` methods have the same issue