### PR TITLE
chore: remove trailing comma that creates tuple for prefix in MinimalQueue [python]

### DIFF
--- a/python/bullmq/flow_producer.py
+++ b/python/bullmq/flow_producer.py
@@ -20,7 +20,7 @@ class MinimalQueue:
         self.redisConnection = redisConnection
         self.client = self.redisConnection.conn
         self.opts = opts
-        self.prefix = opts.get("prefix", "bull"),
+        self.prefix = opts.get("prefix", "bull")
         self.keys = queue_keys.getKeys(name)
         self.qualifiedName = queue_keys.getQueueQualifiedName(name)
         self.scripts = scripts

--- a/src/commands/addPrioritizedJob-9.lua
+++ b/src/commands/addPrioritizedJob-9.lua
@@ -1,5 +1,5 @@
 --[[
-  Adds a priotitized job to the queue by doing the following:
+  Adds a prioritized job to the queue by doing the following:
     - Increases the job counter if needed.
     - Creates a new job key with the job data.
     - Adds the job to the "added" list so that workers gets notified.


### PR DESCRIPTION
## Summary
- In `python/bullmq/flow_producer.py`, `MinimalQueue.__init__` had a trailing comma on the `self.prefix` assignment (line 23), which caused `self.prefix` to be set to a tuple `("bull",)` instead of the string `"bull"`.
- Removed the trailing comma so `self.prefix` is correctly assigned as a string.

## Test plan
- Verify that `MinimalQueue.prefix` returns a string (`"bull"`) and not a tuple (`("bull",)`).
- Run existing Python test suite to confirm no regressions.