### PR TITLE
docs(lua): fix typo in addPrioritizedJob comment

### DIFF
--- a/src/commands/addPrioritizedJob-9.lua
+++ b/src/commands/addPrioritizedJob-9.lua
@@ -1,5 +1,5 @@
 --[[
-  Adds a priotitized job to the queue by doing the following:
+  Adds a prioritized job to the queue by doing the following:
     - Increases the job counter if needed.
     - Creates a new job key with the job data.
     - Adds the job to the "added" list so that workers gets notified.


### PR DESCRIPTION
## Summary
- Fix typo in `src/commands/addPrioritizedJob-9.lua` line 2: "priotitized" -> "prioritized"