### PR TITLE
docs(lua): fix typo Granualarity -> Granularity in collectMetrics

### DIFF
--- a/src/commands/includes/collectMetrics.lua
+++ b/src/commands/includes/collectMetrics.lua
@@ -1,6 +1,6 @@
 --[[
   Functions to collect metrics based on a current and previous count of jobs.
-  Granualarity is fixed at 1 minute.
+  Granularity is fixed at 1 minute.
 ]]
 --- @include "batches"
 local function collectMetrics(metaKey, dataPointsList, maxDataPoints,


### PR DESCRIPTION
## Summary
- Fix typo in `src/commands/includes/collectMetrics.lua` line 3: "Granualarity" -> "Granularity"