### PR TITLE
fix(redis-connection): fix typo custon -> custom in comment

### DIFF
--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -188,7 +188,7 @@ export class RedisConnection extends EventEmitter {
             if (lastError) {
               reject(lastError);
             } else {
-              // when custon 'end' status is set we already closed
+              // when custom 'end' status is set we already closed
               resolve();
             }
           }


### PR DESCRIPTION
## Summary
- Fixes a typo in `src/classes/redis-connection.ts` line 191: `custon` -> `custom`

## Test plan
- No functional change; comment-only fix