### PR TITLE
fix(types): add null to stacktrace type annotation in Job class

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -82,7 +82,7 @@ export class Job<
    * Stacktrace for the error (for failed jobs).
    * @defaultValue null
    */
-  stacktrace: string[] = null;
+  stacktrace: string[] | null = null;
 
   /**
    * An amount of milliseconds to wait until this job can be processed.

--- a/src/interfaces/minimal-job.ts
+++ b/src/interfaces/minimal-job.ts
@@ -86,7 +86,7 @@ export interface MinimalJob<
    * Stacktrace for the error (for failed jobs).
    * @defaultValue null
    */
-  stacktrace: string[];
+  stacktrace: string[] | null;
   /**
    * An amount of milliseconds to wait until this job can be processed.
    * @defaultValue 0


### PR DESCRIPTION
## Summary

- The `stacktrace` property in the `Job` class is initialized to `null` but its type annotation is `string[]`, which is incorrect under strict null checks.
- Updated the type to `string[] | null` to accurately reflect that the property can be `null`.

## Test plan

- Verify the project compiles without type errors.
- Existing tests should pass without modification since this is a type-only change that matches the existing runtime behavior.