### PR TITLE
fix(deps): upgrade cron-parser to v5.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "tsc:all": "tsc && tsc -p tsconfig-cjs.json"
   },
   "dependencies": {
-    "cron-parser": "4.9.0",
+    "cron-parser": "5.5.0",
     "ioredis": "5.10.1",
     "msgpackr": "1.11.5",
     "node-abort-controller": "3.1.1",

--- a/src/classes/job-scheduler.ts
+++ b/src/classes/job-scheduler.ts
@@ -1,4 +1,4 @@
-import { parseExpression } from 'cron-parser';
+import { CronExpressionParser } from 'cron-parser';
 import {
   JobSchedulerJson,
   JobSchedulerTemplateJson,
@@ -417,7 +417,7 @@ export const defaultRepeatStrategy = (
   const dateFromMillis = new Date(millis);
   const startDate = opts.startDate && new Date(opts.startDate);
   const currentDate = startDate > dateFromMillis ? startDate : dateFromMillis;
-  const interval = parseExpression(pattern, {
+  const interval = CronExpressionParser.parse(pattern, {
     ...opts,
     currentDate,
   });

--- a/src/classes/repeat.ts
+++ b/src/classes/repeat.ts
@@ -1,4 +1,4 @@
-import { parseExpression } from 'cron-parser';
+import { CronExpressionParser } from 'cron-parser';
 import { createHash } from 'crypto';
 import {
   RedisClient,
@@ -333,7 +333,7 @@ export const getNextMillis = (
     opts.startDate && new Date(opts.startDate) > new Date(millis)
       ? new Date(opts.startDate)
       : new Date(millis);
-  const interval = parseExpression(pattern, {
+  const interval = CronExpressionParser.parse(pattern, {
     ...opts,
     currentDate,
   });

--- a/src/interfaces/repeat-options.ts
+++ b/src/interfaces/repeat-options.ts
@@ -1,11 +1,11 @@
-import { ParserOptions } from 'cron-parser';
+import { CronExpressionOptions } from 'cron-parser';
 
 /**
  * Settings for repeatable jobs
  *
  * @see {@link https://docs.bullmq.io/guide/jobs/repeatable}
  */
-export interface RepeatOptions extends Omit<ParserOptions, 'iterator'> {
+export interface RepeatOptions extends CronExpressionOptions {
   /**
    * A repeat pattern
    */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2176,12 +2176,12 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cron-parser@4.9.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-4.9.0.tgz#0340694af3e46a0894978c6f52a6dbb5c0f11ad5"
-  integrity sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==
+cron-parser@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-5.5.0.tgz#7706b441f5761b60a915c2661de2ee64194bd407"
+  integrity sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==
   dependencies:
-    luxon "^3.2.1"
+    luxon "^3.7.1"
 
 cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
@@ -3846,7 +3846,7 @@ lunr@^2.3.9:
   resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
   integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
 
-luxon@^3.2.1:
+luxon@^3.7.1:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.7.2.tgz#d697e48f478553cca187a0f8436aff468e3ba0ba"
   integrity sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==


### PR DESCRIPTION
### Why

Closes #3252.

cron-parser v4.9.0 produced incorrect results for certain interval expressions (e.g. `*/N` step values and some range combinations), which caused BullMQ repeat jobs and job schedulers to compute wrong next-run times. The upstream project fixed this in the v5.x line.

### How

- Bumped `cron-parser` from `4.9.0` to `5.5.0` in `package.json` and refreshed `yarn.lock`.
- Adapted to the v5 API:
  - `parseExpression(...)` -> `CronExpressionParser.parse(...)` in `src/classes/repeat.ts` and `src/classes/job-scheduler.ts`.
  - `ParserOptions` -> `CronExpressionOptions` in `src/interfaces/repeat-options.ts`.
- v5 drops the `iterator` field from the options type, so the previous `Omit<ParserOptions, 'iterator'>` wrapper is simplified to extend `CronExpressionOptions` directly.

### Additional Notes

- No behavioral changes in BullMQ itself beyond delegating to the updated parser.
- The v5 API changes are internal to these three files; the public `RepeatOptions` surface remains compatible for consumers.