### PR TITLE
docs(lua): fix typos in releaseLock comment

### DIFF
--- a/src/commands/releaseLock-1.lua
+++ b/src/commands/releaseLock-1.lua
@@ -8,7 +8,7 @@
       ARGV[2]  lock duration in milliseconds
       
     Output:
-      "OK" if lock extented succesfully.
+      "OK" if lock extended successfully.
 ]]
 local rcall = redis.call
 


### PR DESCRIPTION
## Summary
- Fix two typos in the header comment of `src/commands/releaseLock-1.lua`: `extented` -> `extended` and `succesfully` -> `successfully`.

## Test plan
- [x] Comment-only change; no runtime behavior affected.