### PR TITLE
docs(lua): fix typo emiting -> emitting in event comments

### DIFF
--- a/src/commands/moveStalledJobsToWait-8.lua
+++ b/src/commands/moveStalledJobsToWait-8.lua
@@ -46,7 +46,7 @@ end
 
 rcall("SET", stalledCheckKey, timestamp, "PX", maxCheckTime)
 
--- Trim events before emiting them to avoid trimming events emitted in this script
+-- Trim events before emitting them to avoid trimming events emitted in this script
 trimEvents(metaKey, eventStreamKey)
 
 -- Move all stalled jobs to wait

--- a/src/commands/moveToFinished-14.lua
+++ b/src/commands/moveToFinished-14.lua
@@ -127,7 +127,7 @@ if rcall("EXISTS", jobIdKey) == 1 then -- Make sure job exists
 
     local eventStreamKey = KEYS[4]
     local metaKey = KEYS[9]
-    -- Trim events before emiting them to avoid trimming events emitted in this script
+    -- Trim events before emitting them to avoid trimming events emitted in this script
     trimEvents(metaKey, eventStreamKey)
 
     local prefix = ARGV[7]


### PR DESCRIPTION
## Summary
- Fix typo "emiting" -> "emitting" in two Lua script comments:
  - `src/commands/moveStalledJobsToWait-8.lua` (line 49)
  - `src/commands/moveToFinished-14.lua` (line 130)

Comment-only change, no functional impact.

## Test plan
- [x] No code logic changed; comments only