### PR TITLE
fix(job): rename dstPropagationMedatadata to dstPropagationMetadata

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -815,12 +815,12 @@ export class Job<
       SpanKind.INTERNAL,
       this.getSpanOperation(shouldRetry, retryDelay),
       this.queue.name,
-      async (span, dstPropagationMedatadata) => {
+      async (span, dstPropagationMetadata) => {
         this.setSpanJobAttributes(span);
 
         let tm;
-        if (!this.opts?.telemetry?.omitContext && dstPropagationMedatadata) {
-          tm = dstPropagationMedatadata;
+        if (!this.opts?.telemetry?.omitContext && dstPropagationMetadata) {
+          tm = dstPropagationMetadata;
         }
         let result;
 


### PR DESCRIPTION
## Summary
- Fixes a typo in the callback parameter name `dstPropagationMedatadata` (extra "a") inside `src/classes/job.ts`.
- Renames all 3 occurrences to `dstPropagationMetadata`, matching the spelling already used in `src/utils/index.ts`, `src/classes/queue-base.ts`, and `src/interfaces/minimal-queue.ts`.

## Test plan
- [ ] Existing test suite passes (no behavioral change; local variable rename only)