### PR TITLE
fix(job): make isCompleted/isFailed/isDelayed/isWaitingChildren/isActive async [python]

### DIFF
--- a/python/bullmq/job.py
+++ b/python/bullmq/job.py
@@ -148,35 +148,35 @@ class Job:
         if not removed:
             raise Exception(f"Job {self.id} could not be removed because it is locked by another worker")
 
-    def isCompleted(self):
+    async def isCompleted(self) -> bool:
         """
         Returns true if the job has completed.
         """
-        return self.isInZSet('completed')
+        return await self.isInZSet('completed')
 
-    def isFailed(self):
+    async def isFailed(self) -> bool:
         """
         Returns true if the job has failed.
         """
-        return self.isInZSet('failed')
+        return await self.isInZSet('failed')
 
-    def isDelayed(self):
+    async def isDelayed(self) -> bool:
         """
         Returns true if the job is delayed.
         """
-        return self.isInZSet('delayed')
+        return await self.isInZSet('delayed')
 
-    def isWaitingChildren(self):
+    async def isWaitingChildren(self) -> bool:
         """
         Returns true if the job is waiting for children.
         """
-        return self.isInZSet('waiting-children')
+        return await self.isInZSet('waiting-children')
 
-    def isActive(self):
+    async def isActive(self) -> bool:
         """
         Returns true if the job is active.
         """
-        return self.isInList('active')
+        return await self.isInList('active')
 
     async def isWaiting(self):
         return ( await self.isInList('wait') or await self.isInList('paused'))

--- a/python/bullmq/job.py
+++ b/python/bullmq/job.py
@@ -178,7 +178,7 @@ class Job:
         """
         return await self.isInList('active')
 
-    async def isWaiting(self):
+    async def isWaiting(self) -> bool:
         return ( await self.isInList('wait') or await self.isInList('paused'))
 
     async def isInZSet(self, set: str):

--- a/python/bullmq/job.py
+++ b/python/bullmq/job.py
@@ -186,8 +186,8 @@ class Job:
 
         return score is not None
 
-    def isInList(self, list_name: str):
-        return self.scripts.isJobInList(self.scripts.toKey(list_name), self.id)
+    async def isInList(self, list_name: str) -> bool:
+        return await self.scripts.isJobInList(self.scripts.toKey(list_name), self.id)
 
     async def moveToCompleted(self, return_value, token:str, fetchNext:bool = False):
         stringified_return_value = json.dumps(return_value, separators=(',', ':'), allow_nan=False)

--- a/python/tests/job_test.py
+++ b/python/tests/job_test.py
@@ -277,5 +277,36 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
 
         await queue.close()
 
+    async def test_is_state_methods_return_false_when_awaited_for_pending_job(self):
+        """Regression: prior to making these methods async, calling them without
+        ``await`` returned a coroutine object. In Python a coroutine is always
+        truthy, so ``if job.isCompleted():`` reported True regardless of state.
+        This test ensures the now-awaitable forms return False for a freshly
+        queued (waiting) job."""
+        import inspect
+
+        queue = Queue(queueName, {"prefix": prefix})
+        job = await queue.add("test", {"foo": "bar"}, {})
+
+        # All five converted methods are coroutines now and return False
+        # when awaited on a freshly added (waiting) job.
+        for method in (
+            job.isCompleted,
+            job.isFailed,
+            job.isDelayed,
+            job.isWaitingChildren,
+            job.isActive,
+        ):
+            self.assertTrue(
+                inspect.iscoroutinefunction(method),
+                f"{method.__name__} should be async",
+            )
+            self.assertFalse(
+                await method(),
+                f"awaited {method.__name__}() should be False for a waiting job",
+            )
+
+        await queue.close()
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/job_test.py
+++ b/python/tests/job_test.py
@@ -220,10 +220,12 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         child_queue_name = f"__test_child_queue__{uuid4().hex}"
 
         moved_to_waiting = Future()
+        parent_in_waiting_children = asyncio.Event()
 
         async def child_process(job: Job, token: str):
-            # Sleep so parent has a chance to move to waiting-children before we finish.
-            await asyncio.sleep(0.5)
+            # Wait until parent has signalled it has entered waiting-children
+            # state. This avoids relying on an arbitrary sleep to force ordering.
+            await asyncio.wait_for(parent_in_waiting_children.wait(), timeout=10)
             return "child-done"
 
         async def parent_process(job: Job, token: str):
@@ -231,6 +233,7 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
             if should_wait:
                 if not moved_to_waiting.done():
                     moved_to_waiting.set_result(job)
+                parent_in_waiting_children.set()
                 raise WaitingChildrenError
             return "parent-done"
 
@@ -238,35 +241,41 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         child_worker = Worker(child_queue_name, child_process, {"prefix": prefix})
 
         flow = FlowProducer({}, {"prefix": prefix})
-        await flow.add(
-            {
-                "name": 'parent-job',
-                "queueName": parent_queue_name,
-                "data": {},
-                "children": [
-                    {"name": 'child-job', "data": {"foo": 'bar'}, "queueName": child_queue_name}
-                ]
-            }
-        )
+        try:
+            await flow.add(
+                {
+                    "name": 'parent-job',
+                    "queueName": parent_queue_name,
+                    "data": {},
+                    "children": [
+                        {"name": 'child-job', "data": {"foo": 'bar'}, "queueName": child_queue_name}
+                    ]
+                }
+            )
 
-        parent_job = await moved_to_waiting
+            parent_job = await asyncio.wait_for(moved_to_waiting, timeout=10)
 
-        # Parent should be in waiting-children state
-        self.assertTrue(await parent_job.isWaitingChildren())
+            # Parent should be in waiting-children state
+            self.assertTrue(await parent_job.isWaitingChildren())
+        finally:
+            # Make sure cleanup runs even if the assertion or wait_for fails so
+            # the test process does not hang on lingering workers/queues.
+            if not parent_in_waiting_children.is_set():
+                parent_in_waiting_children.set()
 
-        await parent_worker.close()
-        await child_worker.close()
-        await flow.close()
+            await parent_worker.close()
+            await child_worker.close()
+            await flow.close()
 
-        parent_queue = Queue(parent_queue_name, {"prefix": prefix})
-        await parent_queue.pause()
-        await parent_queue.obliterate()
-        await parent_queue.close()
+            parent_queue = Queue(parent_queue_name, {"prefix": prefix})
+            await parent_queue.pause()
+            await parent_queue.obliterate()
+            await parent_queue.close()
 
-        child_queue = Queue(child_queue_name, {"prefix": prefix})
-        await child_queue.pause()
-        await child_queue.obliterate()
-        await child_queue.close()
+            child_queue = Queue(child_queue_name, {"prefix": prefix})
+            await child_queue.pause()
+            await child_queue.obliterate()
+            await child_queue.close()
 
     async def test_is_waiting_children_returns_false_when_job_is_waiting(self):
         """isWaitingChildren should return False when job is not in waiting-children state."""

--- a/python/tests/job_test.py
+++ b/python/tests/job_test.py
@@ -4,11 +4,13 @@ Tests for job class.
 https://bbc.github.io/cloudfit-public-docs/asyncio/testing.html
 """
 
+import asyncio
 import unittest
 import os
 import redis.asyncio as redis
 
-from bullmq import Queue, Job, Worker
+from asyncio import Future
+from bullmq import Queue, Job, Worker, FlowProducer, WaitingChildrenError
 from uuid import uuid4
 
 queueName = ""
@@ -210,6 +212,69 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(result)
 
         await worker.close(force=True)
+        await queue.close()
+
+    async def test_is_waiting_children_returns_true_when_in_waiting_children_state(self):
+        """Regression test: isWaitingChildren should return True when job is in waiting-children state."""
+        parent_queue_name = f"__test_parent_queue__{uuid4().hex}"
+        child_queue_name = f"__test_child_queue__{uuid4().hex}"
+
+        moved_to_waiting = Future()
+
+        async def child_process(job: Job, token: str):
+            # Sleep so parent has a chance to move to waiting-children before we finish.
+            await asyncio.sleep(0.5)
+            return "child-done"
+
+        async def parent_process(job: Job, token: str):
+            should_wait = await job.moveToWaitingChildren(token, {})
+            if should_wait:
+                if not moved_to_waiting.done():
+                    moved_to_waiting.set_result(job)
+                raise WaitingChildrenError
+            return "parent-done"
+
+        parent_worker = Worker(parent_queue_name, parent_process, {"prefix": prefix})
+        child_worker = Worker(child_queue_name, child_process, {"prefix": prefix})
+
+        flow = FlowProducer({}, {"prefix": prefix})
+        await flow.add(
+            {
+                "name": 'parent-job',
+                "queueName": parent_queue_name,
+                "data": {},
+                "children": [
+                    {"name": 'child-job', "data": {"foo": 'bar'}, "queueName": child_queue_name}
+                ]
+            }
+        )
+
+        parent_job = await moved_to_waiting
+
+        # Parent should be in waiting-children state
+        self.assertTrue(await parent_job.isWaitingChildren())
+
+        await parent_worker.close()
+        await child_worker.close()
+        await flow.close()
+
+        parent_queue = Queue(parent_queue_name, {"prefix": prefix})
+        await parent_queue.pause()
+        await parent_queue.obliterate()
+        await parent_queue.close()
+
+        child_queue = Queue(child_queue_name, {"prefix": prefix})
+        await child_queue.pause()
+        await child_queue.obliterate()
+        await child_queue.close()
+
+    async def test_is_waiting_children_returns_false_when_job_is_waiting(self):
+        """isWaitingChildren should return False when job is not in waiting-children state."""
+        queue = Queue(queueName, {"prefix": prefix})
+        job = await queue.add("test", {"foo": "bar"}, {})
+
+        self.assertFalse(await job.isWaitingChildren())
+
         await queue.close()
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

In `python/bullmq/job.py`, the methods `isCompleted`, `isFailed`, `isDelayed`, `isWaitingChildren`, and `isActive` were declared as synchronous (`def`) but internally called async methods (`isInZSet`, `isInList`) without `await`. This caused them to return coroutines rather than booleans, forcing callers to `await` them while the signatures suggested a direct boolean return.

This change makes these methods `async def`, adds `await` on the internal async calls, and annotates the `-> bool` return type, making them consistent with `isWaiting` (already declared `async def`).

## Changes

- `isCompleted`, `isFailed`, `isDelayed`, `isWaitingChildren` now `async def ... -> bool` and `await self.isInZSet(...)`.
- `isActive` now `async def ... -> bool` and `await self.isInList(...)`.

## Test plan

- [ ] Existing Python test suite still passes
- [ ] Calling `await job.isCompleted()` (and siblings) returns a `bool`