### PR TITLE
fix(python): use slice reversal instead of reverse() which returns None

### DIFF
--- a/python/bullmq/scripts.py
+++ b/python/bullmq/scripts.py
@@ -247,7 +247,8 @@ class Scripts:
             result = response or []
 
             if asc and commands[i] == "lrange":
-                results+=result[::-1]
+                result.reverse()
+                results+=result
             else:
                 results+=result
 

--- a/python/bullmq/scripts.py
+++ b/python/bullmq/scripts.py
@@ -247,7 +247,7 @@ class Scripts:
             result = response or []
 
             if asc and commands[i] == "lrange":
-                results+=result.reverse()
+                results+=result[::-1]
             else:
                 results+=result
 

--- a/python/tests/queue_test.py
+++ b/python/tests/queue_test.py
@@ -54,7 +54,8 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
         # Exercises getRanges asc=True + lrange path (waiting -> wait -> lrange).
         # Regression test for a bug where list.reverse() returned None and
         # caused a TypeError in `results+=None`.
-        queue = Queue(queueName, {"prefix": prefix})
+        queue_name = f"__test_queue__{uuid4().hex}"
+        queue = Queue(queue_name, {"prefix": prefix})
         job1 = await queue.add("test-job", {"foo": "bar"}, {})
         job2 = await queue.add("test-job", {"foo": "baz"}, {})
         job3 = await queue.add("test-job", {"foo": "qux"}, {})

--- a/python/tests/queue_test.py
+++ b/python/tests/queue_test.py
@@ -50,6 +50,25 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(job1.id, jobs[1].id)
         await queue.close()
 
+    async def test_get_waiting_returns_jobs_in_ascending_order(self):
+        # Exercises getRanges asc=True + lrange path (waiting -> wait -> lrange).
+        # Regression test for a bug where list.reverse() returned None and
+        # caused a TypeError in `results+=None`.
+        queue = Queue(queueName, {"prefix": prefix})
+        job1 = await queue.add("test-job", {"foo": "bar"}, {})
+        job2 = await queue.add("test-job", {"foo": "baz"}, {})
+        job3 = await queue.add("test-job", {"foo": "qux"}, {})
+
+        waiting_jobs = await queue.getWaiting()
+
+        self.assertIsInstance(waiting_jobs, list)
+        self.assertEqual(len(waiting_jobs), 3)
+        # asc=True should return jobs in insertion order (oldest first).
+        self.assertEqual(waiting_jobs[0].id, job1.id)
+        self.assertEqual(waiting_jobs[1].id, job2.id)
+        self.assertEqual(waiting_jobs[2].id, job3.id)
+        await queue.close()
+
     async def test_get_job_state(self):
         queue = Queue(queueName, {"prefix": prefix})
         job = await queue.add("test-job", {"foo": "bar"}, {})


### PR DESCRIPTION
## Summary

Fixes a bug in `python/bullmq/scripts.py` where `list.reverse()` was used in a `+=` expression. In Python, `list.reverse()` reverses the list in-place and returns `None`, so `results += result.reverse()` would raise `TypeError: unsupported operand type(s) for +=: 'list' and 'NoneType'` whenever the `asc and commands[i] == "lrange"` branch was taken.

Replaced with slice reversal `result[::-1]`, which returns a new reversed list and can be concatenated with `+=`.

## Test plan

- [ ] Exercise `getRanges` with `asc=True` and an `lrange` command to confirm no TypeError is raised and results are appended in reversed order.