### PR TITLE
fix: correct return type annotation for parse_json_string_values [python]

### DIFF
--- a/python/bullmq/utils.py
+++ b/python/bullmq/utils.py
@@ -23,7 +23,7 @@ def get_parent_key(opts: dict[str, str]):
     if opts:
         return f"{opts.get('queue')}:{opts.get('id')}"
 
-def parse_json_string_values(input_dict: dict[str, str]) -> dict[str, dict]:
+def parse_json_string_values(input_dict: dict[str, str]) -> dict[str, Any]:
     return {key: json.loads(value) for key, value in input_dict.items()}
 
 def object_to_flat_array(obj: dict[str, Any]) -> list[Any]:


### PR DESCRIPTION
## Summary

The return type annotation for `parse_json_string_values` in `python/bullmq/utils.py` was declared as `dict[str, dict]`, but `json.loads()` can return any JSON-decodable type (str, int, float, bool, list, dict, None). The annotation was misleading/incorrect for callers and type-checkers.

This changes the return type to `dict[str, Any]`, which accurately reflects what `json.loads()` can produce. `Any` is already imported from `typing` in this module, so no new imports are required.

## Test plan

- [ ] Static type check: `dict[str, Any]` accurately describes the returned dict whose values are the output of `json.loads(...)`.
- [ ] No runtime behavior change — only a type annotation fix.