### PR TITLE
docs(queue-events): add @param JSDoc to 'error' event listener

### DIFF
--- a/src/classes/queue-events.ts
+++ b/src/classes/queue-events.ts
@@ -139,6 +139,8 @@ export interface QueueEventsListener extends IoredisListener {
    * Listen to 'error' event.
    *
    * This event is triggered when an error in the Redis backend is thrown.
+   *
+   * @param args - The error that was thrown.
    */
   error: (args: Error) => void;
 


### PR DESCRIPTION
## Summary

Adds a missing `@param args` JSDoc line to the `error` event listener in `QueueEventsListener` for consistency with the other event listeners in the file (e.g. `duplicated`, `failed`, etc.) which all document their `args`.

```ts
/**
 * Listen to 'error' event.
 *
 * This event is triggered when an error in the Redis backend is thrown.
 *
 * @param args - The error that was thrown.
 */
error: (args: Error) => void;
```

## Test plan

- [x] Docs-only change; no runtime behavior affected.
- [x] Verified surrounding listeners use the same `@param args - ...` style.