### PR TITLE
docs(lua): fix multiple typos in pause-7 comments

### DIFF
--- a/src/commands/pause-7.lua
+++ b/src/commands/pause-7.lua
@@ -1,14 +1,14 @@
 --[[
-  Pauses or resumes a queue globably.
+  Pauses or resumes a queue globally.
 
   Input:
-    KEYS[1] 'wait' or 'paused''
+    KEYS[1] 'wait' or 'paused'
     KEYS[2] 'paused' or 'wait'
     KEYS[3] 'meta'
     KEYS[4] 'prioritized'
     KEYS[5] events stream key
     KEYS[6] 'delayed'
-    KEYS|7] 'marker'
+    KEYS[7] 'marker'
 
     ARGV[1] 'paused' or 'resumed'
 


### PR DESCRIPTION
## Summary

Fixes three typos in the header comment of `src/commands/pause-7.lua`:

- Line 2: `globably` -> `globally`
- Line 5: removed an extra trailing apostrophe in `KEYS[1] 'wait' or 'paused''`
- Line 11: `KEYS|7] 'marker'` -> `KEYS[7] 'marker'` (pipe replaced with bracket)

Comment-only changes; no behavior change.

## Test plan

- [x] Verified diff only touches comments in `src/commands/pause-7.lua`