### PR TITLE
docs(queue-events): fix grammar in TODO comment

### DIFF
--- a/src/classes/queue-events.ts
+++ b/src/classes/queue-events.ts
@@ -353,7 +353,7 @@ export class QueueEvents extends QueueBase {
         this.running = true;
         const client = await this.client;
 
-        // TODO: Planed for deprecation as it has no really a use case
+        // TODO: Planned for deprecation as it really has no use case
         try {
           await client.client('SETNAME', this.clientName(QUEUE_EVENT_SUFFIX));
         } catch (err) {


### PR DESCRIPTION
## Summary
- Fix grammar in a TODO comment in `src/classes/queue-events.ts`.
- "Planed" corrected to "Planned" and "has no really a use case" rephrased to "really has no use case".

## Test plan
- [x] Comment-only change; no runtime or behavioral impact.