### PR TITLE
docs(queue-events): fix typo xtream -> stream in TODO comment

### DIFF
--- a/src/classes/queue-events.ts
+++ b/src/classes/queue-events.ts
@@ -394,7 +394,7 @@ export class QueueEvents extends QueueBase {
           const args = array2obj(events[i][1]);
 
           //
-          // TODO: we may need to have a separate xtream for progress data
+          // TODO: we may need to have a separate stream for progress data
           // to avoid this hack.
           switch (args.event) {
             case 'progress':


### PR DESCRIPTION
## Summary
- Fix a small typo in a TODO comment in `src/classes/queue-events.ts`: `xtream` -> `stream`.

## Test plan
- [x] No code/behavior changes; comment-only fix.