### PR TITLE
fix(types): correct unsafe type cast in getJob to include undefined

### DIFF
--- a/src/classes/queue-getters.ts
+++ b/src/classes/queue-getters.ts
@@ -13,7 +13,7 @@ import type { Cluster } from 'ioredis';
  */
 export class QueueGetters<JobBase extends Job = Job> extends QueueBase {
   getJob(jobId: string): Promise<JobBase | undefined> {
-    return this.Job.fromId(this, jobId) as Promise<JobBase>;
+    return this.Job.fromId(this, jobId) as Promise<JobBase | undefined>;
   }
 
   private commandByType(


### PR DESCRIPTION
## Summary
- The `getJob` method in `QueueGetters` declared a return type of `Promise<JobBase | undefined>`, but cast the result as `Promise<JobBase>`, stripping `| undefined` from the actual return.
- This cast was unsafe and misleading since `Job.fromId` can legitimately resolve to `undefined` when the job does not exist.
- Updated the cast to `Promise<JobBase | undefined>` so it matches the declared return type.

## Test plan
- [x] Type cast now aligns with the declared return signature.
- [ ] Existing test suite continues to pass.