### PR TITLE
docs(utils): complete JSDoc for lengthInUtf8Bytes

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -34,9 +34,10 @@ export function tryCatch(
 }
 
 /**
- * Checks the size of string for ascii/non-ascii characters
+ * Returns the size of a string in UTF-8 bytes (handles multi-byte characters correctly).
  * @see https://stackoverflow.com/a/23318053/1347170
- * @param str -
+ * @param str - The string to measure.
+ * @returns The byte length of the string when encoded as UTF-8.
  */
 export function lengthInUtf8Bytes(str: string): number {
   return Buffer.byteLength(str, 'utf8');


### PR DESCRIPTION
## Summary

Completes the JSDoc for `lengthInUtf8Bytes` in `src/utils/index.ts`:

- Adds a meaningful description clarifying the function returns the UTF-8 byte length (correctly handling multi-byte characters).
- Fills in the `@param str` description (previously empty after the dash).
- Adds the missing `@returns` tag.

No behavior changes — documentation only.

## Test plan

- [x] No runtime changes; JSDoc-only update.
- [x] Verified the block still references the original StackOverflow source.