### PR TITLE
docs: add docstrings to PromoteJobsOptions and RetryJobsOptions fields [python]

### DIFF
--- a/python/bullmq/types/promote_jobs_options.py
+++ b/python/bullmq/types/promote_jobs_options.py
@@ -3,4 +3,11 @@ from typing import TypedDict
 
 
 class PromoteJobsOptions(TypedDict, total=False):
+    """
+    Options for the promoteJobs method.
+    """
+
     count: int
+    """
+    Maximum number of jobs to promote.
+    """

--- a/python/bullmq/types/retry_jobs_options.py
+++ b/python/bullmq/types/retry_jobs_options.py
@@ -3,6 +3,22 @@ from typing import TypedDict
 
 
 class RetryJobsOptions(TypedDict, total=False):
+    """
+    Options for the retryJobs method.
+    """
+
     state: str
+    """
+    The state of the jobs to retry, e.g. 'failed' or 'completed'.
+    """
+
     count: int
+    """
+    Maximum number of jobs to retry per batch.
+    """
+
     timestamp: int
+    """
+    Timestamp threshold; only jobs older than this will be retried.
+    """
+


### PR DESCRIPTION
## Summary
- Add class and field docstrings to `PromoteJobsOptions` TypedDict in `python/bullmq/types/promote_jobs_options.py`.
- Add class and field docstrings to `RetryJobsOptions` TypedDict in `python/bullmq/types/retry_jobs_options.py`.

## Test plan
- [x] No runtime behavior changes; docs-only update.
- [x] Verified files still parse as valid Python TypedDicts.