### PR TITLE
feat(queue): add type hints to QueueKeys methods [python]

### DIFF
--- a/python/bullmq/queue_keys.py
+++ b/python/bullmq/queue_keys.py
@@ -3,10 +3,10 @@ class QueueKeys:
     This class handles all keys parser logic.
     """
 
-    def __init__(self, prefix: str = 'bull'):
+    def __init__(self, prefix: str = 'bull') -> None:
         self.prefix = prefix
 
-    def getKeys(self, name: str):
+    def getKeys(self, name: str) -> dict[str, str]:
         names = ["", "active", "wait", "waiting-children", "paused", "completed", "failed", "delayed", "repeat",
                  "stalled", "limiter", "prioritized", "id", "stalled-check", "meta", "pc", "events", "marker"]
         keys = {}
@@ -15,8 +15,8 @@ class QueueKeys:
 
         return keys
 
-    def toKey(self, name: str, name_type: str):
+    def toKey(self, name: str, name_type: str) -> str:
         return f"{self.getQueueQualifiedName(name)}:{name_type}"
 
-    def getQueueQualifiedName(self, name: str):
+    def getQueueQualifiedName(self, name: str) -> str:
         return f"{self.prefix}:{name}"


### PR DESCRIPTION
## Summary
- Add return type hints to all methods in `QueueKeys` class (`python/bullmq/queue_keys.py`)
- Add `-> None` return hint to `__init__`
- Annotate `getKeys` -> `dict[str, str]`, `toKey` -> `str`, `getQueueQualifiedName` -> `str`

## Test plan
- [ ] Existing Python tests continue to pass
- [ ] Type hints render correctly in IDE / type checkers