### PR TITLE
feat(python): export UnrecoverableError from package root

### DIFF
--- a/python/bullmq/__init__.py
+++ b/python/bullmq/__init__.py
@@ -11,4 +11,4 @@ from bullmq.queue import Queue
 from bullmq.job import Job
 from bullmq.flow_producer import FlowProducer
 from bullmq.worker import Worker
-from bullmq.custom_errors import WaitingChildrenError
+from bullmq.custom_errors import WaitingChildrenError, UnrecoverableError

--- a/python/tests/test_imports.py
+++ b/python/tests/test_imports.py
@@ -1,0 +1,24 @@
+"""
+Tests that ensure the public API re-exports are stable.
+"""
+
+import unittest
+
+import bullmq
+import bullmq.custom_errors
+
+
+class TestImports(unittest.TestCase):
+    def test_unrecoverable_error_importable_from_package_root(self):
+        """Ensure UnrecoverableError can be imported directly from bullmq."""
+        from bullmq import UnrecoverableError
+        self.assertIs(UnrecoverableError, bullmq.custom_errors.UnrecoverableError)
+
+    def test_waiting_children_error_importable_from_package_root(self):
+        """Ensure WaitingChildrenError can be imported directly from bullmq."""
+        from bullmq import WaitingChildrenError
+        self.assertIs(WaitingChildrenError, bullmq.custom_errors.WaitingChildrenError)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Export `UnrecoverableError` from the Python package root (`bullmq/__init__.py`) so users can do `from bullmq import UnrecoverableError`.
- Previously only `WaitingChildrenError` was re-exported at the top level, even though `UnrecoverableError` was already exported from `bullmq.custom_errors`.

## Test plan
- [ ] `from bullmq import UnrecoverableError` succeeds
- [ ] `from bullmq import WaitingChildrenError` still succeeds (no regression)