### PR TITLE
docs(types): complete JSDoc on MetricsOptions interface

### DIFF
--- a/src/interfaces/metrics-options.ts
+++ b/src/interfaces/metrics-options.ts
@@ -1,12 +1,13 @@
 /**
+ * Options for configuring metrics collection on a queue.
  *
- *
+ * @see {@link https://docs.bullmq.io/guide/metrics}
  */
 export interface MetricsOptions {
   /**
-   * Enable gathering metrics for finished jobs.
-   * Output refers to all finished jobs, completed or
-   * failed.
+   * Maximum number of data points to keep for the metrics.
+   * Each data point represents the number of finished jobs (completed or failed)
+   * collected over a one-minute granularity window.
    */
   maxDataPoints?: number;
 }


### PR DESCRIPTION
## Summary

The `MetricsOptions` interface in `src/interfaces/metrics-options.ts` had two documentation issues:

1. The JSDoc on the interface itself was empty (just asterisks with no content).
2. The JSDoc on the `maxDataPoints` property described it as if it were a boolean toggle ("Enable gathering metrics for finished jobs"), but the field is actually a number representing the maximum number of data points to retain.

This PR fills in the interface-level JSDoc and rewrites the `maxDataPoints` description to accurately reflect what the property controls, along with a link to the metrics guide.

## Changes

- Added a descriptive summary and `@see` link to the metrics docs on the `MetricsOptions` interface.
- Rewrote the `maxDataPoints` JSDoc to describe it as the maximum number of data points kept, noting the one-minute granularity window over finished (completed or failed) jobs.

## Test plan

- [x] No runtime behavior changed; this is a documentation-only change to a type declaration file.
- [x] `tsc` will still compile the interface identically.