### PR TITLE
feat(python): sync ErrorCode enum with TypeScript version

### DIFF
--- a/python/bullmq/error_code.py
+++ b/python/bullmq/error_code.py
@@ -9,4 +9,7 @@ class ErrorCode(Enum):
     ParentJobNotExist = -5
     JobLockMismatch = -6
     ParentJobCannotBeReplaced = -7
+    JobBelongsToJobScheduler = -8
     JobHasFailedChildren = -9
+    SchedulerJobIdCollision = -10
+    SchedulerJobSlotsBusy = -11


### PR DESCRIPTION
## Summary

The Python `ErrorCode` enum in `python/bullmq/error_code.py` was out of sync with the TypeScript version at `src/enums/error-code.ts`. Three error codes returned by the shared Lua scripts existed on the TS side but were missing from the Python enum:

- `JobBelongsToJobScheduler = -8`
- `SchedulerJobIdCollision = -10`
- `SchedulerJobSlotsBusy = -11`

Because both SDKs consume the same Redis/Lua scripts, Python code that received these numeric error codes had no matching enum member and could not identify them by name, making error handling inconsistent between the two SDKs.

## Changes

- Add the three missing error codes to the Python `ErrorCode` enum so their values match the TypeScript definition one-to-one.
- Only additions are made; existing members (including `JobPendingDependencies = -4`) are preserved as-is to avoid breaking existing Python consumers. Note that TypeScript names this same code `JobPendingChildren`, but renaming on the Python side is intentionally deferred to keep this change backward compatible.

## Test plan

- [ ] `from bullmq.error_code import ErrorCode` and confirm `ErrorCode(-8)`, `ErrorCode(-10)`, and `ErrorCode(-11)` resolve to `JobBelongsToJobScheduler`, `SchedulerJobIdCollision`, and `SchedulerJobSlotsBusy` respectively.
- [ ] Verify existing Python tests still pass (no existing members were renamed or removed).