### PR TITLE
docs(job-ids): document all-digit custom id restriction

### DIFF
--- a/docs/gitbook/guide/jobs/job-ids.md
+++ b/docs/gitbook/guide/jobs/job-ids.md
@@ -30,6 +30,10 @@ await myQueue.add(
 Custom job ids must not contain the **:** separator as it will be translated in 2 different values, since we are also following Redis naming convention. So if you need to add a separator, use a different value, for example **-**, **\_**.
 {% endhint %}
 
+{% hint style="danger" %}
+Custom job ids must not be strings that consist only of digits (for example `"123"`), as these collide with the format used for automatically generated ids. An `Error: Custom Id cannot be integers` will be thrown when adding such a job. If you need to use a numeric business identifier, add a non-digit prefix such as `"job-123"` or `"#123"`.
+{% endhint %}
+
 ## Read more:
 
 - 💡 [Duplicated Event Reference](https://api.docs.bullmq.io/interfaces/v5.QueueEventsListener.html#duplicated)


### PR DESCRIPTION
## Summary

Updates the [Job Ids guide](https://docs.bullmq.io/guide/jobs/job-ids) to document the second validation rule that rejects custom `jobId` values consisting only of digits.

## Why

The current docs only mention that `:` is forbidden in custom job ids. However, the runtime validation in `src/classes/job.ts` also rejects any string that round-trips through `parseInt`, for example `"123"`:

```ts
if (`${parseInt(this.opts.jobId, 10)}` === this.opts?.jobId) {
  throw new Error('Custom Id cannot be integers');
}
```

This surprises users who have numeric business identifiers and expect `"123"` to be a valid custom id — they hit `Error: Custom Id cannot be integers` at runtime with no guidance in the docs on how to avoid it.

Closes #4052

## Changes

- `docs/gitbook/guide/jobs/job-ids.md`: added a second danger hint explaining that all-digit strings are rejected and suggesting a non-digit prefix (e.g. `"job-123"`, `"#123"`) as a workaround.

No code changes — this is a docs-only clarification of already-shipped behaviour.