### PR TITLE
fix: handle ioredis Cluster connect status in waitUntilReady (#2402)

### DIFF
--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -158,6 +158,14 @@ export class RedisConnection extends EventEmitter {
       return;
     }
 
+    // ioredis Cluster reports 'connect' as its connected status instead of
+    // 'ready' that standalone Redis uses. Treat it as already connected so we
+    // don't hang waiting for a 'ready' event that will never fire and end up
+    // throwing a spurious "Connection is closed" error during disconnect.
+    if (client.status === 'connect' && isRedisCluster(client)) {
+      return;
+    }
+
     if (client.status === 'wait') {
       return client.connect();
     }

--- a/tests/connection.test.ts
+++ b/tests/connection.test.ts
@@ -101,6 +101,51 @@ describe('RedisConnection', () => {
     });
   });
 
+  describe('waitUntilReady()', () => {
+    it('returns immediately when standalone client status is "ready"', async () => {
+      const fakeClient: any = {
+        status: 'ready',
+        isCluster: false,
+        connect: sinon.stub().resolves(),
+        on: sinon.stub(),
+        once: sinon.stub(),
+        removeListener: sinon.stub(),
+        setMaxListeners: sinon.stub(),
+        getMaxListeners: sinon.stub().returns(10),
+      };
+
+      await expect(
+        RedisConnection.waitUntilReady(fakeClient),
+      ).resolves.toBeUndefined();
+      expect(fakeClient.connect.called).toBe(false);
+    });
+
+    // Regression test for https://github.com/taskforcesh/bullmq/issues/2402.
+    // ioredis Cluster reports its connected status as 'connect' rather than
+    // 'ready', which previously caused waitUntilReady to hang and emit a
+    // spurious "Connection is closed" error during disconnect.
+    it('returns immediately when cluster client status is "connect"', async () => {
+      const fakeCluster: any = {
+        status: 'connect',
+        isCluster: true,
+        connect: sinon.stub().resolves(),
+        disconnect: sinon.stub(),
+        duplicate: sinon.stub(),
+        on: sinon.stub(),
+        once: sinon.stub(),
+        removeListener: sinon.stub(),
+        setMaxListeners: sinon.stub(),
+        getMaxListeners: sinon.stub().returns(10),
+      };
+
+      await expect(
+        RedisConnection.waitUntilReady(fakeCluster),
+      ).resolves.toBeUndefined();
+      expect(fakeCluster.connect.called).toBe(false);
+      expect(fakeCluster.once.called).toBe(false);
+    });
+  });
+
   describe('Queue', () => {
     it('propagates skipWaitingForReady to RedisConnection', () => {
       const queue = new Queue('test', {


### PR DESCRIPTION
### Why
Closes #2402. ioredis Cluster reports its connection status as `'connect'` rather than `'ready'`, so `RedisConnection.waitUntilReady()` never early-returns for Cluster clients. This caused `Connection is closed` errors during disconnect handling on Cluster setups.

### How
Added an early-return for Cluster clients when `status === 'connect'` (via the existing `isRedisCluster` type guard). The standalone Redis code path is untouched. Regression tests added in `tests/connection.test.ts` covering both standalone and Cluster scenarios.

### Additional Notes
- No behavior change for standalone Redis.
- No Lua / wire-protocol changes.
- Tests use mocked clients to avoid requiring a live Redis Cluster.