### PR TITLE
test(pause): move timeout value to it() options

### DIFF
--- a/tests/pause.test.ts
+++ b/tests/pause.test.ts
@@ -361,7 +361,7 @@ describe('Pause', () => {
     await delay(10);
 
     return worker.close();
-  }); // TODO: Add { timeout: 8000 } to the it() options
+  }, 8000);
 
   describe('when backoff is 0', () => {
     it('moves job into paused queue', async () => {


### PR DESCRIPTION
### Why
During the Mocha → Vitest migration (#3745), a timeout value in `tests/pause.test.ts` was not applied to the test runner. Vitest requires timeouts to be passed as an argument to `it()`, otherwise the default timeout is used. The `should pause and resume worker without error` test involves multiple pause/resume cycles and worker lifecycle operations that may exceed the default timeout in slower environments such as CI runners.

### How
Passed the timeout value as the last argument to the relevant `it()` call.

Before:
```typescript
it('should pause and resume worker without error', async () => {
  ...
}); // TODO: Add { timeout: 8000 } to the it() options
```

After:
```typescript
it('should pause and resume worker without error', async () => {
  ...
}, 8000);
```

No logic, assertions, or timeout values were changed.

### Additional Notes
- All 11 tests pass before and after this change
- 1 timeout value moved across 1 test case
- This is a follow-up to the same fix applied in `lock_manager.test.ts`
  and `concurrency.test.ts`