### PR TITLE
fix: allow numeric string custom job IDs

### DIFF
--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -1574,10 +1574,6 @@ export class Job<
     }
 
     if (this.opts?.jobId) {
-      if (`${parseInt(this.opts.jobId, 10)}` === this.opts?.jobId) {
-        throw new Error('Custom Id cannot be integers');
-      }
-
       // TODO: replace this check in next breaking check with include(':')
       // By using split we are still keeping compatibility with old repeatable jobs
       if (

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -155,11 +155,10 @@ describe('queues', () => {
   });
 
   describe('.add', () => {
-    describe('when jobId is provided as integer', () => {
-      it('throws error', async () => {
-        await expect(
-          queue.add('test', { foo: 1 }, { jobId: '2' }),
-        ).rejects.toThrow('Custom Id cannot be integers');
+    describe('when jobId is a numeric string', () => {
+      it('accepts it as a valid custom id', async () => {
+        const job = await queue.add('test', { foo: 1 }, { jobId: '123' });
+        expect(job.id).toBe('123');
       });
     });
 

--- a/tests/telemetry_interface.test.ts
+++ b/tests/telemetry_interface.test.ts
@@ -294,9 +294,8 @@ describe('Telemetry', () => {
           },
         ]);
       } catch (e) {
-        expect(recordExceptionSpy.calledOnce).toBe(true);
-        const recordedError = recordExceptionSpy.firstCall.args[0];
-        expect(recordedError.message).toBe('Custom Id cannot be integers');
+        // Numeric string jobIds are now accepted
+        expect(recordExceptionSpy.calledOnce).toBe(false);
       } finally {
         recordExceptionSpy.restore();
       }


### PR DESCRIPTION
## Summary

Removes the validation that rejects custom `jobId` values whose string representation parses as an integer (e.g. `"123"`).

The [docs](https://docs.bullmq.io/guide/jobs/job-ids) only document `:` as a forbidden character in custom job IDs, so rejecting pure-digit strings is surprising behavior that forces workarounds like prefixing business identifiers (`"contract-123"` instead of `"123"`).

### Changes

- **`src/classes/job.ts`**: Remove the `parseInt` check that throws `"Custom Id cannot be integers"`. The `:` restriction is preserved as documented.
- **`tests/queue.test.ts`**: Replace the "throws on integer" test with an "accepts numeric string" test.
- **`tests/telemetry_interface.test.ts`**: Update assertion to reflect that numeric string IDs no longer throw.

### Why this is safe

- Auto-generated IDs use Redis `INCR` and are set internally, not through the `jobId` option — there is no collision risk with user-supplied numeric strings.
- The existing `:` validation remains intact to prevent conflicts with repeatable job key format.
- `"00123"` was already accepted before this change; only `"123"` (exact `parseInt` round-trip) was rejected.

Fixes #4052