### PR TITLE
docs(worker-options): fix typos checkd and halv in JSDoc

### DIFF
--- a/src/interfaces/worker-options.ts
+++ b/src/interfaces/worker-options.ts
@@ -99,7 +99,7 @@ export interface WorkerOptions extends QueueBaseOptions, SandboxedOptions {
 
   /**
    *  Skip stalled check for this worker. Note that other workers could still
-   *  perform stalled checkd and move jobs back to wait for jobs being processed
+   *  perform stalled checks and move jobs back to wait for jobs being processed
    *  by this worker.
    *
    *  @defaultValue false
@@ -136,7 +136,7 @@ export interface WorkerOptions extends QueueBaseOptions, SandboxedOptions {
    * The time in milliseconds before the lock is automatically renewed.
    *
    * It is not recommended to modify this value, which is by default set to
-   * halv the lockDuration value, which is optimal for most use cases.
+   * half the lockDuration value, which is optimal for most use cases.
    */
   lockRenewTime?: number;
 


### PR DESCRIPTION
## Summary

Fixes two typos in the `WorkerOptions` JSDoc comments in `src/interfaces/worker-options.ts`:

- `perform stalled checkd and move jobs back to wait` -> `perform stalled checks and move jobs back to wait` (`checkd` -> `checks`)
- `halv the lockDuration value` -> `half the lockDuration value` (`halv` -> `half`)

## Test plan

- [x] Documentation-only change; no code behavior affected
- [x] Verified surrounding JSDoc context reads naturally after fixes