### PR TITLE
docs(lua): fix grammar in checkItemInList comment

### DIFF
--- a/src/commands/includes/checkItemInList.lua
+++ b/src/commands/includes/checkItemInList.lua
@@ -1,5 +1,5 @@
 --[[
-  Functions to check if a item belongs to a list.
+  Function to check if an item belongs to a list.
 ]]
 
 local function checkItemInList(list, item)


### PR DESCRIPTION
## Summary

Fixes two minor grammar issues in the header comment of `src/commands/includes/checkItemInList.lua`:

- `Functions` (plural) -> `Function` (only one function is defined in the file)
- `a item` -> `an item` (correct article usage before a vowel)

Before:
```lua
--[[
  Functions to check if a item belongs to a list.
]]
```

After:
```lua
--[[
  Function to check if an item belongs to a list.
]]
```

Comment-only change; no behavior impact.

## Test plan

- [x] No runtime changes; only an in-file Lua block comment was updated.