### PR TITLE
refactor(lua): rename misleading waitKey to pausedKey in obliterate

### DIFF
--- a/src/commands/obliterate-2.lua
+++ b/src/commands/obliterate-2.lua
@@ -81,8 +81,8 @@ if(maxCount <= 0) then
   return 1
 end
 
-local waitKey = baseKey .. 'paused'
-maxCount = removeListJobs(waitKey, true, baseKey, maxCount)
+local pausedKey = baseKey .. 'paused'
+maxCount = removeListJobs(pausedKey, true, baseKey, maxCount)
 if(maxCount <= 0) then
   return 1
 end


### PR DESCRIPTION
## Summary

In `src/commands/obliterate-2.lua`, a local variable was named `waitKey` but actually held the Redis `'paused'` list key:

```lua
local waitKey = baseKey .. 'paused'
maxCount = removeListJobs(waitKey, true, baseKey, maxCount)
```

This is misleading. The queue's pause operation (`pause-7.lua`) moves jobs from the `wait` list to the `paused` list before `obliterate` is allowed to run (obliterate requires the queue to be paused). So by the time this code runs, the list being cleaned is `paused`, not `wait`. The variable name should reflect that.

This PR renames the variable to `pausedKey` to match what it actually contains. No behavior change.

## Test plan

- [ ] Existing obliterate tests continue to pass (pure variable rename, no logic change)