### PR TITLE
fix: use Callable typing instead of built-in callable in EventEmitter [python]

### DIFF
--- a/python/bullmq/event_emitter.py
+++ b/python/bullmq/event_emitter.py
@@ -1,11 +1,11 @@
 # Credits: https://gist.github.com/marc-x-andre/1c55b3fafd1d00cfdaa205ec53a08cf3
-from typing import Dict
+from typing import Dict, Callable, List
 
 
 class EventEmitter:
 
     def __init__(self):
-        self._callbacks: Dict[str, callable] = {}
+        self._callbacks: Dict[str, List[Callable]] = {}
 
     def on(self, event_name: str, function):
         self._callbacks[event_name] = self._callbacks.get(


### PR DESCRIPTION
## Summary

Fixes an incorrect type hint in `python/bullmq/event_emitter.py`.

- `EventEmitter.__init__` used the Python builtin `callable` (a function) as a type hint, which is semantically incorrect and rejected by strict type checkers.
- The `_callbacks` attribute actually stores a `list` of callables (see `on`: `self._callbacks.get(event_name, []) + [function]`), so the annotation should reflect that.

Changed:

```python
from typing import Dict
...
self._callbacks: Dict[str, callable] = {}
```

to:

```python
from typing import Dict, Callable, List
...
self._callbacks: Dict[str, List[Callable]] = {}
```

## Test plan

- [ ] Existing Python tests pass
- [ ] Static type checker (e.g. mypy/pyright) no longer flags the annotation