### PR TITLE
feat(python): add priority, lifo, keepLogs, sizeLimit to JobOptions

### DIFF
--- a/python/bullmq/types/job_options.py
+++ b/python/bullmq/types/job_options.py
@@ -36,6 +36,21 @@ class JobOptions(TypedDict, total=False):
     @defaultValue 0
     """
 
+    priority: int
+    """
+    Ranges from 0 (highest priority) to 2 097 152 (lowest priority). Note that
+    using priorities has a slight impact on performance, so do not use it if not required.
+
+    @default 0
+    """
+
+    lifo: bool
+    """
+    If true, adds the job to the right of the queue instead of the left (default false).
+
+    @see https://docs.bullmq.io/guide/jobs/lifo
+    """
+
     attempts: int
     """
     The total number of attempts to try the job until it completes.
@@ -64,6 +79,18 @@ class JobOptions(TypedDict, total=False):
     stackTraceLimit: int
     """
     Limits the amount of stack trace lines that will be recorded in the stacktrace.
+    """
+
+    keepLogs: int
+    """
+    Limits the number of log entries that will be preserved for the job.
+    If not specified, all logs are kept.
+    """
+
+    sizeLimit: int
+    """
+    Limits the size in bytes of the job's data. If the job data
+    exceeds this limit, the job will be rejected.
     """
 
     deduplication: DeduplicationOptions

--- a/python/bullmq/types/job_options.py
+++ b/python/bullmq/types/job_options.py
@@ -41,7 +41,7 @@ class JobOptions(TypedDict, total=False):
     Ranges from 0 (highest priority) to 2 097 152 (lowest priority). Note that
     using priorities has a slight impact on performance, so do not use it if not required.
 
-    @default 0
+    @defaultValue 0
     """
 
     lifo: bool
@@ -89,8 +89,11 @@ class JobOptions(TypedDict, total=False):
 
     sizeLimit: int
     """
-    Limits the size in bytes of the job's data. If the job data
-    exceeds this limit, the job will be rejected.
+    Optional size limit in bytes for the job's data.
+
+    Note: not currently enforced by the Python client; this field exists for
+    option-parity with the JS SDK and for IDE autocomplete. Validation may be
+    added in the future.
     """
 
     deduplication: DeduplicationOptions


### PR DESCRIPTION
These fields exist in JS `DefaultJobOptions` and are commonly used. Adding them to Python's `JobOptions` TypedDict provides IDE autocomplete parity.