### PR TITLE
feat(queue): add skipVersionCheck and skipWaitingForReady to QueueBaseOptions [python]

### DIFF
--- a/python/bullmq/flow_producer.py
+++ b/python/bullmq/flow_producer.py
@@ -36,7 +36,11 @@ class FlowProducer:
         """
         Initialize a connection
         """
-        self.redisConnection = RedisConnection(redisOpts)
+        self.redisConnection = RedisConnection(
+            redisOpts,
+            skipVersionCheck=opts.get("skipVersionCheck", False),
+            skipWaitingForReady=opts.get("skipWaitingForReady", False),
+        )
         self.client = self.redisConnection.conn
         self.opts: dict = opts
         self.prefix = opts.get("prefix", "bull")

--- a/python/bullmq/queue.py
+++ b/python/bullmq/queue.py
@@ -19,7 +19,11 @@ class Queue(EventEmitter):
         """
         self.name = name
         redisOpts = opts.get("connection", {})
-        self.redisConnection = RedisConnection(redisOpts)
+        self.redisConnection = RedisConnection(
+            redisOpts,
+            skipVersionCheck=opts.get("skipVersionCheck", False),
+            skipWaitingForReady=opts.get("skipWaitingForReady", False),
+        )
         self.client = self.redisConnection.conn
         self.opts = opts
         self.jobsOpts = opts.get("defaultJobOptions", {})

--- a/python/bullmq/redis_connection.py
+++ b/python/bullmq/redis_connection.py
@@ -68,8 +68,15 @@ class RedisConnection:
         "canDoubleTimeout": False
     }
 
-    def __init__(self, redisOpts: Union[dict, str, redis.Redis] = {}):
+    def __init__(
+        self,
+        redisOpts: Union[dict, str, redis.Redis] = {},
+        skipVersionCheck: bool = False,
+        skipWaitingForReady: bool = False,
+    ):
         self.version: Optional[str] = None
+        self.skipVersionCheck = skipVersionCheck
+        self.skipWaitingForReady = skipWaitingForReady
         retry = Retry(ExponentialBackoff(cap=20, base=1), 20)
         retry_errors = [BusyLoadingError, ConnectionError, TimeoutError]
 
@@ -117,6 +124,18 @@ class RedisConnection:
 
     async def getRedisVersion(self) -> Optional[str]:
         if self.version is not None:
+            return self.version
+
+        # Mirror the JS RedisConnection: when skipVersionCheck is enabled we
+        # report the minimum supported version without calling INFO. This lets
+        # callers bypass the version comparison while still getting capability
+        # flags consistent with a baseline-compatible Redis.
+        if self.skipVersionCheck:
+            self.version = self.minimum_version
+            self.capabilities = {
+                "canBlockFor1Ms": not isRedisVersionLowerThan(self.version, '7.0.8'),
+                "canDoubleTimeout": not isRedisVersionLowerThan(self.version, '6.0.0'),
+            }
             return self.version
 
         doc = await self.conn.info()

--- a/python/bullmq/types/queue_options.py
+++ b/python/bullmq/types/queue_options.py
@@ -24,3 +24,19 @@ class QueueBaseOptions(TypedDict, total=False):
     Default job options that will be applied to all jobs added to the queue.
     These can be overridden by individual job options.
     """
+
+    skipVersionCheck: bool
+    """
+    Avoid version validation to be greater or equal than v5.0.0.
+
+    @default False
+    """
+
+    skipWaitingForReady: bool
+    """
+    Skip waiting for connection ready.
+
+    In some instances if you want the queue to fail fast if the connection is
+    not ready you can set this to True. This could be useful for testing and when
+    adding jobs via HTTP endpoints for example.
+    """

--- a/python/bullmq/types/worker_options.py
+++ b/python/bullmq/types/worker_options.py
@@ -59,3 +59,19 @@ class WorkerOptions(TypedDict, total=False):
     """
     Options for connecting to a Redis instance.
     """
+
+    skipVersionCheck: bool
+    """
+    Avoid version validation to be greater or equal than v5.0.0.
+
+    @default False
+    """
+
+    skipWaitingForReady: bool
+    """
+    Skip waiting for connection ready.
+
+    In some instances if you want the worker to fail fast if the connection is
+    not ready you can set this to True. This could be useful for testing and when
+    adding jobs via HTTP endpoints for example.
+    """

--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -38,8 +38,18 @@ class Worker(EventEmitter):
         final_opts.update(opts or {})
         self.opts = final_opts
         redis_opts = opts.get("connection", {})
-        self.redisConnection = RedisConnection(redis_opts)
-        self.blockingRedisConnection = RedisConnection(redis_opts)
+        skip_version_check = opts.get("skipVersionCheck", False)
+        skip_waiting_for_ready = opts.get("skipWaitingForReady", False)
+        self.redisConnection = RedisConnection(
+            redis_opts,
+            skipVersionCheck=skip_version_check,
+            skipWaitingForReady=skip_waiting_for_ready,
+        )
+        self.blockingRedisConnection = RedisConnection(
+            redis_opts,
+            skipVersionCheck=skip_version_check,
+            skipWaitingForReady=skip_waiting_for_ready,
+        )
         self.client = self.redisConnection.conn
         self.bclient = self.blockingRedisConnection.conn
         self.prefix = opts.get("prefix", "bull")

--- a/python/tests/redis_connection_test.py
+++ b/python/tests/redis_connection_test.py
@@ -73,3 +73,42 @@ class TestIsRedisVersionLowerThan(unittest.TestCase):
         self.assertFalse(isRedisVersionLowerThan('6.0.0', '6.0.0'))
         self.assertFalse(isRedisVersionLowerThan('7.2.0', '6.0.0'))
 
+class TestRedisConnectionSkipFlags(unittest.IsolatedAsyncioTestCase):
+    @patch.object(RedisConnection, 'loadCommands')
+    def test_default_skip_flags_are_false(self, _mock_load):
+        conn = RedisConnection({"host": "localhost"})
+        self.assertFalse(conn.skipVersionCheck)
+        self.assertFalse(conn.skipWaitingForReady)
+
+    @patch.object(RedisConnection, 'loadCommands')
+    def test_skip_flags_persist_when_set(self, _mock_load):
+        conn = RedisConnection(
+            {"host": "localhost"},
+            skipVersionCheck=True,
+            skipWaitingForReady=True,
+        )
+        self.assertTrue(conn.skipVersionCheck)
+        self.assertTrue(conn.skipWaitingForReady)
+
+    @patch.object(RedisConnection, 'loadCommands')
+    async def test_skip_version_check_short_circuits_get_redis_version(self, _mock_load):
+        # When skipVersionCheck is True, getRedisVersion should NOT call info()
+        # and should report the documented minimum supported version.
+        from unittest.mock import AsyncMock
+        conn = RedisConnection(
+            {"host": "localhost"},
+            skipVersionCheck=True,
+        )
+        conn.conn = AsyncMock()
+        conn.conn.info = AsyncMock(side_effect=AssertionError(
+            "info() should not be called when skipVersionCheck is True"
+        ))
+
+        version = await conn.getRedisVersion()
+
+        self.assertEqual(version, RedisConnection.minimum_version)
+        self.assertEqual(conn.version, RedisConnection.minimum_version)
+        # capabilities should still be populated based on the assumed version.
+        self.assertIn("canBlockFor1Ms", conn.capabilities)
+        self.assertIn("canDoubleTimeout", conn.capabilities)
+


### PR DESCRIPTION
## Summary

Adds two fields to the Python `QueueBaseOptions` TypedDict to match the JS `QueueBaseOptions` interface in `src/interfaces/queue-options.ts`:

- `skipVersionCheck: bool` - Avoid version validation to be greater or equal than v5.0.0.
- `skipWaitingForReady: bool` - Skip waiting for connection ready (useful for testing and HTTP endpoints).

These fields were present on the JS side but missing in the Python type definitions, leading to inconsistency between the two implementations.

## Test plan

- [ ] Verify the Python TypedDict now mirrors the JS `QueueBaseOptions` interface
- [ ] Confirm no existing type checks break