### PR TITLE
docs(parent): add JSDoc to Parent and ParentKeys interfaces

### DIFF
--- a/src/interfaces/parent.ts
+++ b/src/interfaces/parent.ts
@@ -4,24 +4,44 @@ import { JobsOptions } from '../types/job-options';
  * Describes the parent for a Job.
  */
 export interface Parent<T> {
+  /** Parent job name. */
   name: string;
+  /** Prefix for the parent queue's keys. */
   prefix?: string;
+  /** Name of the parent queue. */
   queue?: string;
+  /** Parent job data. */
   data?: T;
+  /** Job options for the parent. */
   opts?: JobsOptions;
 }
 
+/**
+ * Redis-stored parent reference keys used internally by BullMQ.
+ */
 export interface ParentKeys {
+  /** Parent job id. */
   id?: string;
+  /** Fully-qualified Redis key for the parent queue. */
   queueKey: string;
+  /** failParentOnFailure - if true, parent fails when child fails. */
   fpof?: boolean;
+  /** removeDependencyOnFailure - if true, removes the child from parent's dependencies on failure. */
   rdof?: boolean;
+  /** ignoreDependencyOnFailure - if true, moves child's id to failed dependencies on failure. */
   idof?: boolean;
+  /** continueParentOnFailure - if true, parent starts processing when any child fails. */
   cpof?: boolean;
 }
 
+/**
+ * Options passed when associating a child job with a parent during creation.
+ */
 export type ParentKeyOpts = {
+  /** If true, adds the job to the parent's waiting-children set. */
   addToWaitingChildren?: boolean;
+  /** Redis key holding the parent's dependencies set. */
   parentDependenciesKey?: string;
+  /** Fully-qualified Redis key of the parent job. */
   parentKey?: string;
 };

--- a/src/interfaces/parent.ts
+++ b/src/interfaces/parent.ts
@@ -22,23 +22,28 @@ export interface Parent<T> {
 export interface ParentKeys {
   /** Parent job id. */
   id?: string;
-  /** Fully-qualified Redis key for the parent queue. */
+  /** Qualified parent queue key prefix/name (for example, `${prefix}:${queueName}`). */
   queueKey: string;
   /** failParentOnFailure - if true, parent fails when child fails. */
   fpof?: boolean;
   /** removeDependencyOnFailure - if true, removes the child from parent's dependencies on failure. */
   rdof?: boolean;
-  /** ignoreDependencyOnFailure - if true, moves child's id to failed dependencies on failure. */
+  /** ignoreDependencyOnFailure - if true, moves the child job key to failed dependencies on failure. */
   idof?: boolean;
   /** continueParentOnFailure - if true, parent starts processing when any child fails. */
   cpof?: boolean;
 }
 
 /**
- * Options passed when associating a child job with a parent during creation.
+ * Options used internally for parent/child relationship management when creating jobs
+ * (including associating a child with its parent, or creating a parent that starts in
+ * the `waiting-children` state).
  */
 export type ParentKeyOpts = {
-  /** If true, adds the job to the parent's waiting-children set. */
+  /**
+   * If true, the newly-created parent job will be placed into the parent queue's
+   * `waiting-children` state (waiting for children to complete) instead of `wait`.
+   */
   addToWaitingChildren?: boolean;
   /** Redis key holding the parent's dependencies set. */
   parentDependenciesKey?: string;


### PR DESCRIPTION
## Summary
- Add JSDoc comments to `Parent<T>`, `ParentKeys`, and `ParentKeyOpts` in `src/interfaces/parent.ts`.
- Expand the cryptic abbreviations (`fpof`, `rdof`, `idof`, `cpof`) to their full names (failParentOnFailure, removeDependencyOnFailure, ignoreDependencyOnFailure, continueParentOnFailure) and describe their behavior.
- Document each field in `Parent<T>` and `ParentKeyOpts` for better discoverability via editor tooling.

## Test plan
- [x] Docs-only change; no runtime behavior affected.
- [x] Verified `src/interfaces/parent.ts` still compiles (no structural changes).