### PR TITLE
test(events): move timeout value to describe() options

### DIFF
--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -21,11 +21,10 @@ import {
 } from '../src/classes';
 import { delay, randomUUID, removeAllQueueData } from '../src/utils';
 
-describe('events', () => {
+describe('events', { timeout: 8000 }, () => {
   const redisHost = process.env.REDIS_HOST || 'localhost';
   const prefix = process.env.BULLMQ_TEST_PREFIX || 'bull';
 
-  // TODO: Move timeout to test options: { timeout: 8000 }
   let queue: Queue;
   let queueEvents: QueueEvents;
   let queueName: string;


### PR DESCRIPTION
### Why
During the Mocha → Vitest migration (#3745), a timeout value in `tests/events.test.ts` was not applied to the test runner. The timeout was left as a comment at the `describe` block level. Vitest supports passing options directly to `describe()`, which allows setting a default timeout for all tests within that block.

### How
Moved the timeout value from a comment into the `describe()` options.

Before:
```typescript
// TODO: Move timeout to test options: { timeout: 8000 }
describe('events', () => {
```

After:
```typescript
describe('events', { timeout: 8000 }, () => {
```

No logic, assertions, or timeout values were changed.

### Additional Notes
- All 23 tests pass before and after this change
- This is a follow-up to the same fix applied in previous PRs