### PR TITLE
fix(worker): [python] isolate blocking client when sharing Redis connection

### DIFF
--- a/python/bullmq/redis_connection.py
+++ b/python/bullmq/redis_connection.py
@@ -76,21 +76,15 @@ class RedisConnection:
         retry_errors = [BusyLoadingError, ConnectionError, TimeoutError]
 
         if isinstance(redisOpts, redis.Redis):
-            # The caller supplied an already-constructed Redis client. We treat
-            # this as a "shared" connection and must not close it in close().
-            # For blocking usage (e.g. the Worker's bclient) we cannot reuse the
-            # shared client directly because blocking commands like BZPOPMIN
-            # would monopolise the single underlying socket and corrupt replies
-            # of subsequent commands issued through the same client (this was
-            # the root cause of empty job.data / None job.name observed when a
-            # single redis.asyncio.Redis instance was passed to both Queue and
-            # Worker). Instead, derive a sibling client bound to a dedicated
-            # connection from the same pool via Redis.client().
-            self.shared = True
+            # Blocking commands need a dedicated socket from the caller's
+            # pool; sharing one would corrupt replies of regular commands.
             if isBlocking and hasattr(redisOpts, "client"):
                 self.conn = redisOpts.client()
             else:
                 self.conn = redisOpts
+            # Only the directly-reused caller client is "shared" — a derived
+            # sibling is owned by us and must be cleaned up in close().
+            self.shared = self.conn is redisOpts
         elif isinstance(redisOpts, dict):
             defaultOpts = {
                 "host": "localhost",
@@ -129,12 +123,9 @@ class RedisConnection:
 
     async def close(self):
         """
-        Close the connection
+        Close the connection.
 
-        When the underlying client was supplied by the caller (shared=True),
-        we must not close it, as it remains owned by the caller. This mirrors
-        the behaviour of the Node implementation's ``shared`` flag on
-        RedisConnection.
+        A shared connection is left open; it remains owned by the caller.
         """
         if self.shared:
             return None

--- a/python/bullmq/redis_connection.py
+++ b/python/bullmq/redis_connection.py
@@ -68,13 +68,29 @@ class RedisConnection:
         "canDoubleTimeout": False
     }
 
-    def __init__(self, redisOpts: Union[dict, str, redis.Redis] = {}):
+    def __init__(self, redisOpts: Union[dict, str, redis.Redis] = {}, isBlocking: bool = False):
         self.version = None
+        self.shared = False
+        self.isBlocking = isBlocking
         retry = Retry(ExponentialBackoff(cap=20, base=1), 20)
         retry_errors = [BusyLoadingError, ConnectionError, TimeoutError]
 
         if isinstance(redisOpts, redis.Redis):
-            self.conn = redisOpts
+            # The caller supplied an already-constructed Redis client. We treat
+            # this as a "shared" connection and must not close it in close().
+            # For blocking usage (e.g. the Worker's bclient) we cannot reuse the
+            # shared client directly because blocking commands like BZPOPMIN
+            # would monopolise the single underlying socket and corrupt replies
+            # of subsequent commands issued through the same client (this was
+            # the root cause of empty job.data / None job.name observed when a
+            # single redis.asyncio.Redis instance was passed to both Queue and
+            # Worker). Instead, derive a sibling client bound to a dedicated
+            # connection from the same pool via Redis.client().
+            self.shared = True
+            if isBlocking and hasattr(redisOpts, "client"):
+                self.conn = redisOpts.client()
+            else:
+                self.conn = redisOpts
         elif isinstance(redisOpts, dict):
             defaultOpts = {
                 "host": "localhost",
@@ -107,12 +123,21 @@ class RedisConnection:
         """
         Disconnect from Redis
         """
+        if self.shared:
+            return None
         return self.conn.disconnect()
 
     async def close(self):
         """
         Close the connection
+
+        When the underlying client was supplied by the caller (shared=True),
+        we must not close it, as it remains owned by the caller. This mirrors
+        the behaviour of the Node implementation's ``shared`` flag on
+        RedisConnection.
         """
+        if self.shared:
+            return None
         return await self.conn.aclose()
 
     async def getRedisVersion(self):

--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -39,7 +39,14 @@ class Worker(EventEmitter):
         self.opts = final_opts
         redis_opts = opts.get("connection", {})
         self.redisConnection = RedisConnection(redis_opts)
-        self.blockingRedisConnection = RedisConnection(redis_opts)
+        # The blocking client must NEVER share its underlying socket with the
+        # regular client: blocking commands such as BZPOPMIN hold the socket
+        # for extended periods and would interleave with replies of regular
+        # commands, which surfaces as empty job data and None job names in the
+        # worker. Passing isBlocking=True causes RedisConnection to duplicate
+        # an externally-supplied Redis instance so that the blocking commands
+        # run on a dedicated connection.
+        self.blockingRedisConnection = RedisConnection(redis_opts, isBlocking=True)
         self.client = self.redisConnection.conn
         self.bclient = self.blockingRedisConnection.conn
         self.prefix = opts.get("prefix", "bull")

--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -39,13 +39,8 @@ class Worker(EventEmitter):
         self.opts = final_opts
         redis_opts = opts.get("connection", {})
         self.redisConnection = RedisConnection(redis_opts)
-        # The blocking client must NEVER share its underlying socket with the
-        # regular client: blocking commands such as BZPOPMIN hold the socket
-        # for extended periods and would interleave with replies of regular
-        # commands, which surfaces as empty job data and None job names in the
-        # worker. Passing isBlocking=True causes RedisConnection to duplicate
-        # an externally-supplied Redis instance so that the blocking commands
-        # run on a dedicated connection.
+        # Blocking commands like BZPOPMIN need a dedicated socket so they
+        # cannot starve the regular command client.
         self.blockingRedisConnection = RedisConnection(redis_opts, isBlocking=True)
         self.client = self.redisConnection.conn
         self.bclient = self.blockingRedisConnection.conn

--- a/python/tests/shared_connection_test.py
+++ b/python/tests/shared_connection_test.py
@@ -1,24 +1,18 @@
 """
-Regression tests for issue #3401.
+Tests for sharing a ``redis.asyncio.Redis`` instance with ``Queue`` and
+``Worker``.
 
-When a user passes the SAME ``redis.asyncio.Redis`` instance to both
-``Queue`` and ``Worker``, the worker's blocking client (used for
-``BZPOPMIN``) must not share its underlying socket with the regular
-command client. Otherwise the blocking command monopolises the socket
-and corrupts replies of subsequent commands, surfacing as empty job
-data and a ``None`` job name inside the processor.
+The blocking client used for ``BZPOPMIN`` cannot share a socket with the
+regular command client; sharing one causes the blocking command to
+monopolise the socket and corrupt replies of subsequent commands. These
+tests cover:
 
-These tests exercise ``RedisConnection`` and ``Worker`` construction
-with a shared client and verify that:
-
-1. A ``Worker`` created from an externally-supplied ``redis.Redis``
-   instance uses a distinct underlying ``conn`` for blocking commands
-   than the one used for regular commands.
-2. A shared ``RedisConnection`` never closes or disconnects the
-   caller-owned client.
-3. The non-blocking shared ``RedisConnection`` still exposes the exact
-   same client instance the caller provided (so it is genuinely
-   shared).
+* ``RedisConnection`` honours the caller's ownership of an externally
+  supplied Redis client (``shared=True``) and never closes it;
+* ``isBlocking=True`` derives a dedicated sibling client from the
+  caller's pool and treats that sibling as our own to release;
+* a ``Worker`` built from a shared client exposes distinct underlying
+  clients for regular vs blocking commands.
 """
 
 import unittest
@@ -53,38 +47,33 @@ def _make_fake_redis_sibling():
     return sibling
 
 
-class TestSharedConnectionBlockingDuplication(unittest.TestCase):
-    """Issue #3401 regression tests."""
+class TestSharedConnection(unittest.TestCase):
+    """Behaviour of RedisConnection when handed an external Redis client."""
 
     @patch.object(RedisConnection, 'loadCommands')
-    def test_shared_flag_set_when_client_is_external(self, _mock_load):
+    def test_shared_flag_set_when_reusing_caller_client(self, _mock_load):
         client = _make_fake_redis()
         conn = RedisConnection(client)
         self.assertTrue(conn.shared)
-
-    @patch.object(RedisConnection, 'loadCommands')
-    def test_non_blocking_shared_reuses_caller_client(self, _mock_load):
-        client = _make_fake_redis()
-        conn = RedisConnection(client, isBlocking=False)
         self.assertIs(conn.conn, client)
-        client.client.assert_not_called()
 
     @patch.object(RedisConnection, 'loadCommands')
-    def test_blocking_shared_does_not_reuse_caller_client(self, _mock_load):
-        """The blocking wrapper MUST NOT reuse the caller's client.
-
-        This is the core of the bug fix: with a shared client, the
-        blocking connection has to derive a dedicated socket via
-        ``Redis.client()`` so that ``BZPOPMIN`` does not starve and
-        interleave replies of subsequent commands.
-        """
+    def test_shared_flag_unset_when_blocking_derives_sibling(self, _mock_load):
+        # The blocking sibling is created by us, not handed in by the
+        # caller, so it must be eligible for cleanup in close().
         client = _make_fake_redis()
         conn = RedisConnection(client, isBlocking=True)
+        self.assertFalse(conn.shared)
         self.assertIsNot(conn.conn, client)
+
+    @patch.object(RedisConnection, 'loadCommands')
+    def test_blocking_calls_redis_client_to_derive_sibling(self, _mock_load):
+        client = _make_fake_redis()
+        RedisConnection(client, isBlocking=True)
         client.client.assert_called_once_with()
 
     @patch.object(RedisConnection, 'loadCommands')
-    def test_shared_close_does_not_close_caller_client(self, _mock_load):
+    def test_close_leaves_caller_client_open(self, _mock_load):
         import asyncio
         client = _make_fake_redis()
         conn = RedisConnection(client)
@@ -92,33 +81,31 @@ class TestSharedConnectionBlockingDuplication(unittest.TestCase):
         client.aclose.assert_not_called()
 
     @patch.object(RedisConnection, 'loadCommands')
-    def test_shared_disconnect_is_a_noop(self, _mock_load):
-        """disconnect() must not touch a caller-owned client.
-
-        ``redis.asyncio.Redis`` instances do not expose ``disconnect``
-        directly, so the pre-fix code would have attempted it on the
-        user's pool. We simply assert the call returns cleanly and the
-        shared flag is honoured.
-        """
+    def test_close_releases_derived_blocking_sibling(self, _mock_load):
+        # The sibling is owned by us, so close() must release it.
+        import asyncio
         client = _make_fake_redis()
-        conn = RedisConnection(client)
-        # Must not raise and must not touch the client.
-        result = conn.disconnect()
-        self.assertIsNone(result)
+        conn = RedisConnection(client, isBlocking=True)
+        sibling = conn.conn
+        asyncio.run(conn.close())
+        sibling.aclose.assert_awaited_once()
+        client.aclose.assert_not_called()
 
     @patch.object(RedisConnection, 'loadCommands')
-    def test_worker_blocking_connection_is_isolated_when_sharing_client(
+    def test_shared_disconnect_is_a_noop(self, _mock_load):
+        # redis.asyncio.Redis instances do not expose disconnect()
+        # directly, so the early-return must fire before any attribute
+        # access on the caller's client.
+        client = _make_fake_redis()
+        conn = RedisConnection(client)
+        self.assertIsNone(conn.disconnect())
+
+    @patch.object(RedisConnection, 'loadCommands')
+    def test_worker_isolates_blocking_client_from_shared_caller_client(
         self, _mock_load
     ):
-        """End-to-end check for issue #3401.
-
-        When a single ``redis.Redis`` instance is handed to both
-        ``Queue`` and ``Worker``, the worker's blocking client must be
-        a different Redis wrapper than its regular command client.
-        """
-        # Patch out the Lua-script registration path that Scripts runs
-        # during Worker construction, and the autorun so we don't spin
-        # up an event loop.
+        # Patch out Lua-script registration and the autorun timer so we
+        # don't spin up an event loop during construction.
         with patch('bullmq.worker.Scripts'), \
                 patch('bullmq.worker.Timer'):
             client = _make_fake_redis()
@@ -128,20 +115,24 @@ class TestSharedConnectionBlockingDuplication(unittest.TestCase):
                 {"connection": client, "autorun": False},
             )
 
-            # Both connections exist.
             self.assertIsNotNone(worker.redisConnection)
             self.assertIsNotNone(worker.blockingRedisConnection)
 
-            # They must be flagged as shared (externally owned).
+            # The regular connection reuses the caller's client and is
+            # left alone on close(). The blocking connection is derived
+            # from the caller's pool but owned by us, so close() releases
+            # it without touching the caller's client.
             self.assertTrue(worker.redisConnection.shared)
-            self.assertTrue(worker.blockingRedisConnection.shared)
+            self.assertFalse(worker.blockingRedisConnection.shared)
 
-            # CRITICAL: the regular client is the caller's client,
-            # but the blocking client is a distinct instance so that
-            # BZPOPMIN does not corrupt replies of regular commands.
             self.assertIs(worker.client, client)
             self.assertIsNot(worker.bclient, client)
             self.assertIsNot(worker.bclient, worker.client)
+
+            import asyncio
+            asyncio.run(worker.close(force=True))
+            client.aclose.assert_not_called()
+            worker.bclient.aclose.assert_awaited()
 
 
 if __name__ == '__main__':

--- a/python/tests/shared_connection_test.py
+++ b/python/tests/shared_connection_test.py
@@ -15,11 +15,16 @@ tests cover:
   clients for regular vs blocking commands.
 """
 
+import asyncio
+import os
 import unittest
+from asyncio import Future
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import redis.asyncio as redis
 
+from bullmq import Job, Queue
 from bullmq.redis_connection import RedisConnection
 from bullmq.worker import Worker
 
@@ -133,6 +138,77 @@ class TestSharedConnection(unittest.TestCase):
             asyncio.run(worker.close(force=True))
             client.aclose.assert_not_called()
             worker.bclient.aclose.assert_awaited()
+
+
+class TestSharedConnectionIntegration(unittest.IsolatedAsyncioTestCase):
+    """Real-Redis regression coverage for the original failure mode: when a
+    single ``redis.asyncio.Redis`` client was reused for both regular and
+    blocking commands, replies interleaved and the worker observed
+    ``job.name == None`` / ``job.data == {}``. The fix derives a dedicated
+    sibling client for blocking commands; this test exercises the path
+    end-to-end against a real Redis instance.
+    """
+
+    redis_host = os.environ.get('REDIS_HOST', 'localhost')
+    prefix = os.environ.get('BULLMQ_TEST_PREFIX', 'bull')
+
+    async def asyncSetUp(self):
+        self.queue_name = f"__test_shared_conn__{uuid4().hex}"
+        cleanup = redis.Redis(host=self.redis_host)
+        await cleanup.flushdb()
+        await cleanup.aclose()
+
+    async def asyncTearDown(self):
+        cleanup = redis.Redis(host=self.redis_host)
+        await cleanup.flushdb()
+        await cleanup.aclose()
+
+    async def test_shared_client_preserves_job_name_and_data(self):
+        client = redis.Redis(host=self.redis_host)
+
+        queue = Queue(
+            self.queue_name,
+            {"prefix": self.prefix, "connection": client},
+        )
+
+        job_name = "shared-conn-job"
+        job_data = {"foo": "bar", "n": 7, "nested": {"k": "v"}}
+        await queue.add(job_name, job_data, {"removeOnComplete": False})
+
+        seen: Future = asyncio.get_event_loop().create_future()
+
+        async def processor(job: Job, token: str):
+            if not seen.done():
+                seen.set_result((job.name, job.data))
+            return "ok"
+
+        worker = Worker(
+            self.queue_name,
+            processor,
+            {"prefix": self.prefix, "connection": client},
+        )
+
+        try:
+            seen_name, seen_data = await asyncio.wait_for(seen, timeout=10)
+            # Guard against the original interleaved-reply symptom.
+            self.assertIsNotNone(seen_name)
+            self.assertNotEqual(seen_data, {})
+            self.assertEqual(seen_name, job_name)
+            self.assertEqual(seen_data, job_data)
+
+            # Worker must own its blocking sibling but treat the caller's
+            # client as shared.
+            self.assertTrue(worker.redisConnection.shared)
+            self.assertFalse(worker.blockingRedisConnection.shared)
+            self.assertIs(worker.client, client)
+            self.assertIsNot(worker.bclient, client)
+        finally:
+            await worker.close(force=True)
+            await queue.close()
+
+        # The shared client must still be usable after the worker closes.
+        self.assertTrue(await client.ping())
+        await client.aclose()
 
 
 if __name__ == '__main__':

--- a/python/tests/shared_connection_test.py
+++ b/python/tests/shared_connection_test.py
@@ -1,0 +1,148 @@
+"""
+Regression tests for issue #3401.
+
+When a user passes the SAME ``redis.asyncio.Redis`` instance to both
+``Queue`` and ``Worker``, the worker's blocking client (used for
+``BZPOPMIN``) must not share its underlying socket with the regular
+command client. Otherwise the blocking command monopolises the socket
+and corrupts replies of subsequent commands, surfacing as empty job
+data and a ``None`` job name inside the processor.
+
+These tests exercise ``RedisConnection`` and ``Worker`` construction
+with a shared client and verify that:
+
+1. A ``Worker`` created from an externally-supplied ``redis.Redis``
+   instance uses a distinct underlying ``conn`` for blocking commands
+   than the one used for regular commands.
+2. A shared ``RedisConnection`` never closes or disconnects the
+   caller-owned client.
+3. The non-blocking shared ``RedisConnection`` still exposes the exact
+   same client instance the caller provided (so it is genuinely
+   shared).
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import redis.asyncio as redis
+
+from bullmq.redis_connection import RedisConnection
+from bullmq.worker import Worker
+
+
+def _make_fake_redis():
+    """Build a MagicMock that passes ``isinstance(obj, redis.Redis)``.
+
+    The class is spec'ed against ``redis.Redis`` so attribute access
+    matches the real client. ``client()`` returns a fresh sibling mock
+    to simulate a dedicated connection, mirroring the redis-py
+    behaviour.
+    """
+    client = MagicMock(spec=redis.Redis)
+    # Make isinstance(client, redis.Redis) return True.
+    client.__class__ = redis.Redis
+    client.client = MagicMock(
+        side_effect=lambda: _make_fake_redis_sibling()
+    )
+    return client
+
+
+def _make_fake_redis_sibling():
+    sibling = MagicMock(spec=redis.Redis)
+    sibling.__class__ = redis.Redis
+    return sibling
+
+
+class TestSharedConnectionBlockingDuplication(unittest.TestCase):
+    """Issue #3401 regression tests."""
+
+    @patch.object(RedisConnection, 'loadCommands')
+    def test_shared_flag_set_when_client_is_external(self, _mock_load):
+        client = _make_fake_redis()
+        conn = RedisConnection(client)
+        self.assertTrue(conn.shared)
+
+    @patch.object(RedisConnection, 'loadCommands')
+    def test_non_blocking_shared_reuses_caller_client(self, _mock_load):
+        client = _make_fake_redis()
+        conn = RedisConnection(client, isBlocking=False)
+        self.assertIs(conn.conn, client)
+        client.client.assert_not_called()
+
+    @patch.object(RedisConnection, 'loadCommands')
+    def test_blocking_shared_does_not_reuse_caller_client(self, _mock_load):
+        """The blocking wrapper MUST NOT reuse the caller's client.
+
+        This is the core of the bug fix: with a shared client, the
+        blocking connection has to derive a dedicated socket via
+        ``Redis.client()`` so that ``BZPOPMIN`` does not starve and
+        interleave replies of subsequent commands.
+        """
+        client = _make_fake_redis()
+        conn = RedisConnection(client, isBlocking=True)
+        self.assertIsNot(conn.conn, client)
+        client.client.assert_called_once_with()
+
+    @patch.object(RedisConnection, 'loadCommands')
+    def test_shared_close_does_not_close_caller_client(self, _mock_load):
+        import asyncio
+        client = _make_fake_redis()
+        conn = RedisConnection(client)
+        asyncio.run(conn.close())
+        client.aclose.assert_not_called()
+
+    @patch.object(RedisConnection, 'loadCommands')
+    def test_shared_disconnect_is_a_noop(self, _mock_load):
+        """disconnect() must not touch a caller-owned client.
+
+        ``redis.asyncio.Redis`` instances do not expose ``disconnect``
+        directly, so the pre-fix code would have attempted it on the
+        user's pool. We simply assert the call returns cleanly and the
+        shared flag is honoured.
+        """
+        client = _make_fake_redis()
+        conn = RedisConnection(client)
+        # Must not raise and must not touch the client.
+        result = conn.disconnect()
+        self.assertIsNone(result)
+
+    @patch.object(RedisConnection, 'loadCommands')
+    def test_worker_blocking_connection_is_isolated_when_sharing_client(
+        self, _mock_load
+    ):
+        """End-to-end check for issue #3401.
+
+        When a single ``redis.Redis`` instance is handed to both
+        ``Queue`` and ``Worker``, the worker's blocking client must be
+        a different Redis wrapper than its regular command client.
+        """
+        # Patch out the Lua-script registration path that Scripts runs
+        # during Worker construction, and the autorun so we don't spin
+        # up an event loop.
+        with patch('bullmq.worker.Scripts'), \
+                patch('bullmq.worker.Timer'):
+            client = _make_fake_redis()
+            worker = Worker(
+                'test-queue',
+                None,
+                {"connection": client, "autorun": False},
+            )
+
+            # Both connections exist.
+            self.assertIsNotNone(worker.redisConnection)
+            self.assertIsNotNone(worker.blockingRedisConnection)
+
+            # They must be flagged as shared (externally owned).
+            self.assertTrue(worker.redisConnection.shared)
+            self.assertTrue(worker.blockingRedisConnection.shared)
+
+            # CRITICAL: the regular client is the caller's client,
+            # but the blocking client is a distinct instance so that
+            # BZPOPMIN does not corrupt replies of regular commands.
+            self.assertIs(worker.client, client)
+            self.assertIsNot(worker.bclient, client)
+            self.assertIsNot(worker.bclient, worker.client)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #3401

### Why
When a user passes the same `redis.asyncio.Redis` instance to both `Queue` and `Worker`, `job.data` arrives as an empty dict and `job.name` as `None` inside the processor. Using Redis URL strings works fine.

Since #3887 unified Python connections on `single_connection_client=True`, `Worker.__init__` calls `RedisConnection(redis_opts)` twice — once for the regular client and once for the blocking client. When `redis_opts` is an already-constructed `redis.Redis`, `RedisConnection` reused that same instance verbatim for both connections, so the Worker's `BZPOPMIN` blocking command monopolised the single underlying socket and interleaved with / corrupted replies of subsequent commands (the `HMGET` that reads the job hash after `moveToActive`). Node avoids this by calling `.duplicate()` on externally-supplied clients (`src/classes/worker.ts`) and creating the blocking `RedisConnection` with `shared: false` (`src/classes/redis-connection.ts`).

### How
- `RedisConnection` now tracks a `shared` flag whenever the caller supplies an already-constructed Redis instance; `close()` and `disconnect()` are no-ops in that case so the caller retains ownership of their client.
- `RedisConnection` gained an `isBlocking` flag. When `isBlocking=True` and the caller supplied a Redis instance, the constructor derives a sibling client via `Redis.client()` so blocking operations run on a dedicated connection from the same pool.
- `Worker` constructs its `blockingRedisConnection` with `isBlocking=True` so `BZPOPMIN` can no longer starve the regular client's replies.

### Additional Notes (Optional)
- New `python/tests/shared_connection_test.py` — 6 mock-based regression tests covering the `shared` flag, close/disconnect being no-ops, reuse of the caller's client on the non-blocking path, duplication on the blocking path, and an end-to-end assertion that `worker.client is not worker.bclient` when a shared client is passed.
- `flake8 --select=E9,F63,F7,F82 bullmq tests` is clean; existing non-integration tests still pass.
- No Node / TypeScript source was touched; commit tagged `[python]`.