### PR TITLE
fix(queue): widen upsertJobScheduler id parameter to free string

### DIFF
--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -466,7 +466,7 @@ export class Queue<
    * @returns The next job to be scheduled (would normally be in delayed state).
    */
   async upsertJobScheduler(
-    jobSchedulerId: NameType,
+    jobSchedulerId: string,
     repeatOpts: Omit<RepeatOptions, 'key'>,
     jobTemplate?: {
       name?: NameType;
@@ -487,7 +487,7 @@ export class Queue<
     >(
       jobSchedulerId,
       repeatOpts,
-      jobTemplate?.name ?? jobSchedulerId,
+      jobTemplate?.name ?? (jobSchedulerId as NameType),
       jobTemplate?.data ?? <DataType>{},
       { ...this.jobsOpts, ...jobTemplate?.opts },
       { override: true },

--- a/tests/job_scheduler.test.ts
+++ b/tests/job_scheduler.test.ts
@@ -111,6 +111,37 @@ describe('Job Scheduler', () => {
     });
   });
 
+  // Regression for https://github.com/taskforcesh/bullmq/issues/3937:
+  // the scheduler id is an identity (e.g. a per-instance UUID) and must
+  // not inherit the queue's NameType constraint — otherwise typed
+  // queues reject any scheduler id that isn't also a job-name literal.
+  describe('when the queue has a constrained NameType', () => {
+    it('accepts a free-string scheduler id distinct from any job name', async () => {
+      type ReportJobs = 'generate-report' | 'send-email';
+      const typedQueueName = `typed-${randomUUID()}`;
+      const typedQueue = new Queue<unknown, unknown, ReportJobs>(
+        typedQueueName,
+        { connection, prefix },
+      );
+      await typedQueue.waitUntilReady();
+
+      try {
+        const dynamicInstanceId = `inst_${randomUUID()}`;
+        const job = await typedQueue.upsertJobScheduler(
+          dynamicInstanceId,
+          { every: 60_000 },
+          { name: 'generate-report', data: {} },
+        );
+
+        expect(job!.repeatJobKey).toBeDefined();
+        expect(job!.name).toBe('generate-report');
+      } finally {
+        await typedQueue.close();
+        await removeAllQueueData(new IORedis(redisHost), typedQueueName);
+      }
+    });
+  });
+
   it('it should stop repeating after endDate', async () => {
     const every = 100;
     const date = new Date('2017-02-07 9:24:00');

--- a/tests/job_scheduler.test.ts
+++ b/tests/job_scheduler.test.ts
@@ -106,6 +106,37 @@ describe('Job Scheduler', () => {
     });
   });
 
+  // Regression for https://github.com/taskforcesh/bullmq/issues/3937:
+  // the scheduler id is an identity (e.g. a per-instance UUID) and must
+  // not inherit the queue's NameType constraint — otherwise typed
+  // queues reject any scheduler id that isn't also a job-name literal.
+  describe('when the queue has a constrained NameType', () => {
+    it('accepts a free-string scheduler id distinct from any job name', async () => {
+      type ReportJobs = 'generate-report' | 'send-email';
+      const typedQueueName = `typed-${randomUUID()}`;
+      const typedQueue = new Queue<unknown, unknown, ReportJobs>(
+        typedQueueName,
+        { connection, prefix },
+      );
+      await typedQueue.waitUntilReady();
+
+      try {
+        const dynamicInstanceId = `inst_${randomUUID()}`;
+        const job = await typedQueue.upsertJobScheduler(
+          dynamicInstanceId,
+          { every: 60_000 },
+          { name: 'generate-report', data: {} },
+        );
+
+        expect(job!.repeatJobKey).toBeDefined();
+        expect(job!.name).toBe('generate-report');
+      } finally {
+        await typedQueue.close();
+        await removeAllQueueData(new IORedis(redisHost), typedQueueName);
+      }
+    });
+  });
+
   it('it should stop repeating after endDate', async () => {
     const every = 100;
     const date = new Date('2017-02-07 9:24:00');


### PR DESCRIPTION
### Port Impact Checklist

- [ ] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?

### Why

Fixes #3937.

`Queue.upsertJobScheduler`'s first parameter `jobSchedulerId` was typed as the queue's `NameType` generic. This created a hard coupling between the **scheduler's unique identifier** and the **union of job names** the queue produces. In real distributed setups the scheduler id is typically a per-instance UUID (`inst_12345`, a database row id, etc.) that has nothing to do with the job-name literal union, so any typed queue rejected the call at compile time:

```ts
type MyJobs = Job<any, any, 'generate-report'> | Job<any, any, 'send-email'>;
const queue = new Queue<MyJobs>('q');

queue.upsertJobScheduler(
  'inst_12345',                                  // ❌ TS error before this PR
  { pattern: '0 * * * *' },
  { name: 'generate-report', data: { foo: 'bar' } },
);
```

The underlying `JobScheduler.upsertJobScheduler` already types the id correctly as `string` (with the job name as a separate `N extends string = string` generic) — the bug was a leak in the public `Queue` wrapper.

### How

- `src/classes/queue.ts`: change the parameter type from `jobSchedulerId: NameType` to `jobSchedulerId: string`. This matches the underlying `JobScheduler.upsertJobScheduler` signature.
- The fallback `jobTemplate?.name ?? jobSchedulerId` is now `jobTemplate?.name ?? (jobSchedulerId as NameType)`. The cast is intentional and preserves the existing runtime behaviour: when the caller does not supply a template name, the resulting job's name is still the scheduler id. Users who want strict type safety on the produced job's name should pass `jobTemplate.name` explicitly (which the issue's example already does).
- No changes to `JobScheduler` itself — the underlying API was already correct.

### Additional Notes (Optional)

- New regression test in `tests/job_scheduler.test.ts` (`when the queue has a constrained NameType`) that builds a `Queue<unknown, unknown, 'generate-report' | 'send-email'>` and calls `upsertJobScheduler` with a free-string id. Before the fix this fails to compile; after, it compiles and the runtime asserts the resulting job's name is `'generate-report'`.
- No public API behaviour change — only the type signature is widened. Existing callers keep compiling.
- Scope is purely Node.js / TypeScript types; no Python / Elixir / PHP port work needed.