### PR TITLE
fix(queue-events-producer): serialize object payloads as JSON

### DIFF
--- a/src/classes/queue-events-producer.ts
+++ b/src/classes/queue-events-producer.ts
@@ -40,7 +40,15 @@ export class QueueEventsProducer extends QueueBase {
     const args: any[] = ['MAXLEN', '~', maxEvents, '*', 'event', eventName];
 
     for (const [key, value] of Object.entries(restArgs)) {
-      args.push(key, value);
+      // Object values would otherwise be stringified by Redis as
+      // "[object Object]". Serialize them as JSON so consumers can
+      // parse them back into the original structure.
+      args.push(
+        key,
+        typeof value === 'object' && value !== null
+          ? JSON.stringify(value)
+          : value,
+      );
     }
 
     await client.xadd(key, ...args);

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -905,5 +905,50 @@ describe('events', { timeout: 8000 }, () => {
       await queueEvents2.close();
       await removeAllQueueData(new IORedis(redisHost), queueName2);
     });
+
+    // Regression for https://github.com/taskforcesh/bullmq/issues/2984:
+    // nested object payloads were silently coerced to "[object Object]"
+    // because Redis xadd calls .toString() on each value. The producer
+    // now JSON-stringifies non-primitive values so consumers can parse
+    // them back.
+    it('serializes nested object payloads as JSON', async () => {
+      const queueName2 = `test-${randomUUID()}`;
+      const queueEventsProducer = new QueueEventsProducer(queueName2, {
+        connection,
+        prefix,
+      });
+      const queueEvents2 = new QueueEvents(queueName2, {
+        autorun: false,
+        connection,
+        prefix,
+        lastEventId: '0-0',
+      });
+      await queueEvents2.waitUntilReady();
+
+      interface CustomListener extends QueueEventsListener {
+        nested: (args: { nested: string }, id: string) => void;
+      }
+      const customEvent = new Promise<void>(resolve => {
+        queueEvents2.on<CustomListener>('nested', async ({ nested }) => {
+          // The value arrives as a JSON string; the consumer is
+          // responsible for parsing custom event payloads.
+          expect(typeof nested).toBe('string');
+          expect(JSON.parse(nested)).toEqual({ object: 'hello' });
+          resolve();
+        });
+      });
+
+      await queueEventsProducer.publishEvent({
+        eventName: 'nested',
+        nested: { object: 'hello' },
+      });
+
+      queueEvents2.run();
+      await customEvent;
+
+      await queueEventsProducer.close();
+      await queueEvents2.close();
+      await removeAllQueueData(new IORedis(redisHost), queueName2);
+    });
   });
 });


### PR DESCRIPTION
### Port Impact Checklist

- [ ] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?

### Why

Fixes #2984.

`QueueEventsProducer.publishEvent` pushed each value of the payload straight onto the XADD args array. Redis then coerces every arg to a string via `.toString()`. For plain objects that yields `"[object Object]"`, so a payload like `{ eventName: 'name', nested: { object: 'hello' } }` arrived on the consumer side as `{ eventName: 'name', nested: '[object Object]' }` — the original structure was unrecoverable.

The user reported the issue on `src/classes/queue-events-producer.ts` line 43 and noted that JSON serialization is the natural fix.

### How

- `src/classes/queue-events-producer.ts`: when a value is a non-null object (plain object, array, class instance), `JSON.stringify` it before pushing onto the args array. Primitive values (strings, numbers, booleans) are left alone so existing publishers that already pass primitives observe no change.
- This mirrors what the producer already does conceptually for the built-in `progress` / `completed` events: their payloads round-trip through `JSON.stringify` on the producer side and `JSON.parse` on the consumer side (`src/classes/queue-events.ts`).
- The consumer side is intentionally **not** modified. Auto-parsing every value would risk mis-parsing user strings that happen to look like JSON. Consumers of object-typed custom events can call `JSON.parse` themselves on the field they expect.

### Additional Notes (Optional)

- New regression test in `tests/events.test.ts` (`when publishing custom events › serializes nested object payloads as JSON`) publishes a `{ object: 'hello' }` payload and asserts the receiver gets a JSON-string that parses back to the original object. Before the fix the test fails with `'[object Object]'`.
- No public API change; the type signature of `publishEvent<T>` is unchanged.
- TypeScript / Node-only. No port work required.