### PR TITLE
docs(queue-events): correct delayed event payload doc and type

### DIFF
--- a/src/classes/queue-events.ts
+++ b/src/classes/queue-events.ts
@@ -107,10 +107,14 @@ export interface QueueEventsListener extends IoredisListener {
    *
    * @param args - An object containing details about the delayed job.
    *  - `jobId` - The unique identifier of the job that was delayed.
-   *  - `delay` - The delay duration in milliseconds before the job becomes active.
+   *  - `delay` - When the job becomes active, in milliseconds since the Unix
+   *    epoch (January 1, 1970, UTC). The value is delivered as a string
+   *    because it travels through the Redis events stream; call
+   *    `Number(delay)` (or `parseInt(delay, 10)`) before doing arithmetic
+   *    on it.
    * @param id - The identifier of the event.
    */
-  delayed: (args: { jobId: string; delay: number }, id: string) => void;
+  delayed: (args: { jobId: string; delay: string }, id: string) => void;
 
   /**
    * Listen to 'drained' event.

--- a/tests/flow.test.ts
+++ b/tests/flow.test.ts
@@ -4723,7 +4723,7 @@ describe('flows', () => {
       const delayed = new Promise<void>((resolve, reject) => {
         queueEvents.on('delayed', async ({ jobId, delay }) => {
           try {
-            const milliseconds = delay - Date.now();
+            const milliseconds = Number(delay) - Date.now();
             expect(milliseconds).to.be.lessThanOrEqual(3000);
             expect(milliseconds).toBeGreaterThan(2000);
             resolve();

--- a/tests/job_scheduler.test.ts
+++ b/tests/job_scheduler.test.ts
@@ -3099,7 +3099,7 @@ describe('Job Scheduler', () => {
       const completedJobs: Job[] = [];
       const workerErrors: Error[] = [];
       const processedJobIds: string[] = [];
-      const delayedEvents: { jobId: string; delay: number }[] = [];
+      const delayedEvents: { jobId: string; delay: string }[] = [];
       let schedulerUpdateAttempts = 0;
 
       // Create a worker that will process jobs
@@ -3306,7 +3306,7 @@ describe('Job Scheduler', () => {
       // TODO: Move timeout to test options: { timeout: 8000 } // Reduced timeout since delay will be mocked
 
       const workerErrors: Error[] = [];
-      const delayedEvents: { jobId: string; delay: number }[] = [];
+      const delayedEvents: { jobId: string; delay: string }[] = [];
       let schedulerUpdateFailures = 0;
 
       // Create a worker that will process jobs


### PR DESCRIPTION
### Port Impact Checklist

- [ ] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?

### Why

Fixes #3267.

The `QueueEventsListener.delayed` callback documented `delay` as

> The delay duration in milliseconds before the job becomes active.

and typed it as `number`. Both are wrong:

1. The underlying Lua source (`src/commands/includes/addDelayedJob.lua`) emits `delayedTimestamp` — the **absolute** Unix-millis timestamp at which the job becomes active — not a duration:
   ```lua
   local score, delayedTimestamp = getDelayedScore(...)
   rcall("XADD", eventsKey, ..., "delay", delayedTimestamp)
   ```
2. Because the value travels through a Redis events stream, it is delivered to the consumer as a string. Existing internal callers in the codebase already work around this (`Number(e.delay)` in `tests/job_scheduler.test.ts:3397`), and the issue reporter saw the same on user code.

### How

- `src/classes/queue-events.ts`: `delay: number` → `delay: string`, and the JSDoc now reads "When the job becomes active, in milliseconds since the Unix epoch (January 1, 1970, UTC)" plus a note that the value arrives as a string and needs `Number(delay)` for arithmetic.
- `tests/flow.test.ts`: the one test site that did `delay - Date.now()` now coerces explicitly: `Number(delay) - Date.now()`. The same JS coercion happens at runtime, but the new type would otherwise flag it.
- `tests/job_scheduler.test.ts`: the two `delayedEvents` arrays that pre-declared `delay: number` now declare `delay: string`. Downstream usage (`Number(e.delay)`) is unaffected.

### Additional Notes (Optional)

- This is technically a type-signature change but no runtime behaviour shifts — the value has always been a string at runtime. User code that did `args.delay - Date.now()` would have worked accidentally via JS's binary-minus coercion; user code that did `args.delay + 1` would have been silently broken (string concatenation). The new type makes both visible at compile time.
- No release note is needed beyond what semantic-release will derive from this `docs(...)` subject — the change is backwards-compatible at runtime.
- TypeScript / Node-only. No port work required.