### PR TITLE
fix(flow-producer): honour opts.connection when first arg empty [python]

### DIFF
--- a/python/bullmq/flow_producer.py
+++ b/python/bullmq/flow_producer.py
@@ -36,7 +36,13 @@ class FlowProducer:
         """
         Initialize a connection
         """
-        self.redisConnection = RedisConnection(redisOpts)
+        # Allow the connection to be supplied either as the first
+        # positional arg (legacy signature) or via opts["connection"]
+        # (matching the Queue / Worker convention). When redisOpts is
+        # empty we fall back to opts.connection so users who follow the
+        # newer convention are not silently routed to localhost.
+        connection_opts = redisOpts or opts.get("connection", {})
+        self.redisConnection = RedisConnection(connection_opts)
         self.client = self.redisConnection.conn
         self.opts: dict = opts
         self.prefix = opts.get("prefix", "bull")

--- a/python/tests/flow_test.py
+++ b/python/tests/flow_test.py
@@ -284,5 +284,52 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         await child_queue.obliterate()
         await child_queue.close()
 
+class TestFlowProducerConstruction(unittest.TestCase):
+    """Unit tests for FlowProducer construction (no Redis required)."""
+
+    def _make_producer(self, redis_opts=None, opts=None):
+        # Patch RedisConnection so we can assert on the connection
+        # argument it receives without actually opening a socket.
+        from unittest.mock import patch, MagicMock
+        with patch(
+            "bullmq.flow_producer.RedisConnection"
+        ) as redis_connection_cls, patch(
+            "bullmq.flow_producer.Scripts"
+        ):
+            redis_connection_cls.return_value = MagicMock(conn=MagicMock())
+            kwargs = {}
+            if redis_opts is not None:
+                kwargs["redisOpts"] = redis_opts
+            if opts is not None:
+                kwargs["opts"] = opts
+            FlowProducer(**kwargs)
+            return redis_connection_cls
+
+    def test_uses_first_positional_arg_when_supplied(self):
+        url = "redis://example.com:6379"
+        rc = self._make_producer(redis_opts=url)
+        rc.assert_called_once_with(url)
+
+    def test_falls_back_to_opts_connection_when_first_arg_is_empty(self):
+        # Regression for #3619: passing the connection via opts is the
+        # documented Queue/Worker convention. FlowProducer used to
+        # ignore it and silently default to localhost.
+        url = "redis://example.com:6379"
+        rc = self._make_producer(redis_opts={}, opts={"connection": url})
+        rc.assert_called_once_with(url)
+
+    def test_first_positional_arg_takes_precedence(self):
+        legacy_url = "redis://legacy:6379"
+        opts_url = "redis://opts:6379"
+        rc = self._make_producer(
+            redis_opts=legacy_url, opts={"connection": opts_url}
+        )
+        rc.assert_called_once_with(legacy_url)
+
+    def test_defaults_to_empty_dict_when_neither_supplied(self):
+        rc = self._make_producer()
+        rc.assert_called_once_with({})
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Port Impact Checklist

- [ ] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?

### Why

Fixes #3619.

The Python `FlowProducer` constructor has a two-arg legacy signature:

```python
def __init__(self, redisOpts: Union[dict, str] = {}, opts: QueueBaseOptions = {}):
```

The first arg is the connection, the second is queue options. Users following the `Queue` / `Worker` convention naturally pass the connection inside `opts`:

```python
FlowProducer({}, {"connection": f"redis://{host}:6379"})
```

The constructor only used the first positional arg and ignored `opts["connection"]`, so `RedisConnection({})` silently routed everything to `localhost:6379`. The existing `#TODO: pass only queueOpts, no need 2 parameters in next breaking change` comment in the constructor body acknowledges the redundancy.

### How

- `python/bullmq/flow_producer.py`: pick the connection from `opts.connection` when `redisOpts` is empty (`{}` or empty string), via `redisOpts or opts.get("connection", {})`. When both are provided the first positional arg still wins, so legacy callers observe no behavioural change.
- A short comment explains the precedence rule in place of the TODO marker (the TODO itself is preserved — it's a separate concern about cleaning up the signature in a breaking release).

### Additional Notes (Optional)

- New `TestFlowProducerConstruction` unit-test class in `python/tests/flow_test.py`. It patches `RedisConnection` so the test does not need a Redis server, and asserts the connection arg for the four relevant cases:
  - positional arg only
  - `opts.connection` only (regression for #3619)
  - both supplied — positional wins
  - neither supplied — defaults to `{}`
- All four tests pass locally (`pytest tests/flow_test.py::TestFlowProducerConstruction`). `flake8 --select=E9,F63,F7,F82` is clean.
- Python-only commit; tagged `[python]` so the Node semantic-release channel skips this.