### PR TITLE
fix(flow-producer): surface aborted transactions instead of silent fail

### DIFF
--- a/src/classes/flow-producer.ts
+++ b/src/classes/flow-producer.ts
@@ -225,12 +225,26 @@ export class FlowProducer extends EventEmitter {
         const results = (await multi.exec()) as
           | [null | Error, string | number][]
           | null;
-        const [result] = results || [];
-        if (result) {
-          const [err, jobId] = result;
-          if (!err && typeof jobId === 'string') {
-            jobsTree.job.id = jobId;
+
+        // Surface transaction-level and per-command failures instead
+        // of silently returning a half-formed JobNode (issue #3851).
+        // ioredis returns `null` from exec() when the multi was
+        // aborted (READONLY replica, WATCH conflict, pipeline error)
+        // and `[err, value]` per command otherwise.
+        if (!results) {
+          throw new Error(
+            'Flow could not be added: Redis transaction was aborted',
+          );
+        }
+        for (const [err] of results) {
+          if (err) {
+            throw err;
           }
+        }
+
+        const [, jobId] = results[0] ?? [];
+        if (typeof jobId === 'string') {
+          jobsTree.job.id = jobId;
         }
 
         return jobsTree;
@@ -302,8 +316,22 @@ export class FlowProducer extends EventEmitter {
         const results = (await multi.exec()) as
           | [null | Error, string | number][]
           | null;
+
+        // Surface a transaction-level abort (e.g. READONLY replica or
+        // pipeline error) so callers can distinguish "nothing was
+        // added" from "some flows partially failed" (issue #3851).
+        // Per-command errors are NOT thrown here on purpose: callers
+        // can detect partially-failed roots via the returned tree's
+        // missing job id (and there is an existing test that relies
+        // on that semantics for addBulk).
+        if (!results) {
+          throw new Error(
+            'Flows could not be added: Redis transaction was aborted',
+          );
+        }
+
         for (let index = 0; index < jobsTrees.length; ++index) {
-          const result = results?.[index];
+          const result = results[index];
           if (!result) {
             continue;
           }

--- a/src/classes/flow-producer.ts
+++ b/src/classes/flow-producer.ts
@@ -231,7 +231,7 @@ export class FlowProducer extends EventEmitter {
         // ioredis returns `null` from exec() when the multi was
         // aborted (READONLY replica, WATCH conflict, pipeline error)
         // and `[err, value]` per command otherwise.
-        if (!results) {
+        if (results === null) {
           throw new Error(
             'Flow could not be added: Redis transaction was aborted',
           );
@@ -324,7 +324,7 @@ export class FlowProducer extends EventEmitter {
         // can detect partially-failed roots via the returned tree's
         // missing job id (and there is an existing test that relies
         // on that semantics for addBulk).
-        if (!results) {
+        if (results === null) {
           throw new Error(
             'Flows could not be added: Redis transaction was aborted',
           );

--- a/tests/flow.test.ts
+++ b/tests/flow.test.ts
@@ -7,6 +7,7 @@ import {
   afterAll,
   it,
   expect,
+  vi,
 } from 'vitest';
 
 import {
@@ -6320,6 +6321,62 @@ describe('flows', () => {
       expect(uniqueIds.size).toBe(1);
 
       await flow.close();
+    });
+
+    // Regression for https://github.com/taskforcesh/bullmq/issues/3851:
+    // FlowProducer.add() and addBulk() ignored a `null` return from
+    // `multi.exec()` (which ioredis emits when the transaction is
+    // aborted, e.g. against a READONLY replica). The reporter saw
+    // .add() resolve with a half-formed JobNode whose id pointed at
+    // nothing in Redis. The producer must surface the abort.
+    it('throws when redis transaction is aborted on FlowProducer.add', async () => {
+      const flow = new FlowProducer({ connection, prefix });
+      await flow.waitUntilReady();
+
+      const client = (await (flow as any).connection.client) as IORedis;
+      const realMulti = client.multi.bind(client);
+      const multiSpy = vi
+        .spyOn(client, 'multi')
+        .mockImplementationOnce((...args: any[]) => {
+          const m = realMulti(...args);
+          // Override exec() to mirror the ioredis behaviour when the
+          // transaction is aborted: a single null return.
+          (m as any).exec = async () => null;
+          return m;
+        });
+
+      try {
+        await expect(
+          flow.add({ name: 'parent', data: {}, queueName }),
+        ).rejects.toThrow(/transaction was aborted/);
+      } finally {
+        multiSpy.mockRestore();
+        await flow.close();
+      }
+    });
+
+    it('throws when redis transaction is aborted on FlowProducer.addBulk', async () => {
+      const flow = new FlowProducer({ connection, prefix });
+      await flow.waitUntilReady();
+
+      const client = (await (flow as any).connection.client) as IORedis;
+      const realMulti = client.multi.bind(client);
+      const multiSpy = vi
+        .spyOn(client, 'multi')
+        .mockImplementationOnce((...args: any[]) => {
+          const m = realMulti(...args);
+          (m as any).exec = async () => null;
+          return m;
+        });
+
+      try {
+        await expect(
+          flow.addBulk([{ name: 'parent', data: {}, queueName }]),
+        ).rejects.toThrow(/transaction was aborted/);
+      } finally {
+        multiSpy.mockRestore();
+        await flow.close();
+      }
     });
 
     it('should not corrupt id mapping for successful jobs when some addBulk commands fail', async () => {

--- a/tests/flow.test.ts
+++ b/tests/flow.test.ts
@@ -6333,7 +6333,7 @@ describe('flows', () => {
       const flow = new FlowProducer({ connection, prefix });
       await flow.waitUntilReady();
 
-      const client = (await (flow as any).connection.client) as IORedis;
+      const client = (await flow.client) as IORedis;
       const realMulti = client.multi.bind(client);
       const multiSpy = vi
         .spyOn(client, 'multi')
@@ -6359,7 +6359,7 @@ describe('flows', () => {
       const flow = new FlowProducer({ connection, prefix });
       await flow.waitUntilReady();
 
-      const client = (await (flow as any).connection.client) as IORedis;
+      const client = (await flow.client) as IORedis;
       const realMulti = client.multi.bind(client);
       const multiSpy = vi
         .spyOn(client, 'multi')


### PR DESCRIPTION
### Port Impact Checklist

- [ ] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?

### Why

Fixes #3851.

`FlowProducer.add()` and `FlowProducer.addBulk()` swallowed `multi.exec()` returning `null`. ioredis returns `null` from `Pipeline.exec()` whenever the transaction was aborted — for example issued against a READONLY replica, a WATCH conflict, or a pipeline-level error — and the producer would happily resolve with a half-formed `JobNode` whose `job.id` was the locally-generated UUID, pointing at nothing in Redis.

The reporter saw exactly that shape under an Upstash failover window where Redis is briefly read-only:

```
Adding jobs with FlowProducer...
Job added with FlowProducer unexpectedly: 6d82aace-3808-4750-8040-f9feb5149023
.add() did not throw but flow does not exist: undefined
```

`Queue.add()` correctly throws in the same scenario; the bug was in `flow-producer.ts:225` and the parallel block in `addBulk` at line 302.

### How

Two paths needed slightly different treatment because the API contract differs.

- **`add()`** (single flow — atomic by design): throw when `results === null`, and throw the first per-command error if any. Without this, a transaction abort or a per-command failure leaves the user with a JobNode whose UUID id is unrecoverable.
- **`addBulk()`** (partial-success semantics): an existing regression test (`should not corrupt id mapping for successful jobs when some addBulk commands fail`) explicitly relies on `addBulk` letting some root commands fail while others succeed. So we throw **only** on `results === null` (the entire transaction aborted, every flow is dead). Per-command errors continue to leave that root's `job.id` unassigned, and callers detect partial failure via `await queue.getJob(tree.job.id) === undefined` — the same contract that test asserts.

The error message names the cause:

```
Flow could not be added: Redis transaction was aborted
```

### Additional Notes (Optional)

- Two new regression tests in `tests/flow.test.ts` use a vitest spy on the next `client.multi()` call to swap in a multi whose `.exec()` returns `null`. Both `add()` and `addBulk()` are asserted to throw `/transaction was aborted/`. The original Pipeline is otherwise pristine — no impact on neighbouring tests.
- The existing partial-success test (`should not corrupt id mapping...`) is preserved unchanged and still passes against the new logic.
- TypeScript / Node-only. No port work required.