### PR TITLE
fix(scheduler): align first 'every' job to the next offset slot

### DIFF
--- a/src/classes/job-scheduler.ts
+++ b/src/classes/job-scheduler.ts
@@ -88,7 +88,7 @@ export class JobScheduler extends QueueBase {
     const { immediately, ...filteredRepeatOpts } = repeatOpts;
 
     let nextMillis: number;
-    const newOffset: number | null = null;
+    const newOffset: number | null = every && offset ? offset : null;
 
     if (pattern) {
       nextMillis = await this.repeatStrategy(now, repeatOpts, jobName);

--- a/src/commands/includes/getJobSchedulerEveryNextMillis.lua
+++ b/src/commands/includes/getJobSchedulerEveryNextMillis.lua
@@ -9,6 +9,18 @@ local function getJobSchedulerEveryNextMillis(prevMillis, every, now, offset, st
             nextMillis = nextMillis > now and nextMillis or now
         else
             nextMillis = now
+            -- For the first iteration with no startDate and an explicit
+            -- offset, align nextMillis to the next `offset` slot
+            -- strictly after now. Without this the user-supplied offset
+            -- is recorded but ignored, and the first job fires at now
+            -- instead of the next aligned timestamp (issue #3705).
+            if offset and offset > 0 then
+                local aligned = math.floor(nextMillis / every) * every + offset
+                if aligned <= nextMillis then
+                    aligned = aligned + every
+                end
+                nextMillis = aligned
+            end
         end
     else
         nextMillis = prevMillis + every

--- a/src/commands/includes/getJobSchedulerEveryNextMillis.lua
+++ b/src/commands/includes/getJobSchedulerEveryNextMillis.lua
@@ -10,9 +10,9 @@ local function getJobSchedulerEveryNextMillis(prevMillis, every, now, offset, st
         else
             nextMillis = now
             -- For the first iteration with no startDate and an explicit
-            -- offset, align nextMillis to the next `offset` slot
-            -- strictly after now. Without this the user-supplied offset
-            -- is recorded but ignored, and the first job fires at now
+            -- offset, align nextMillis to the next offset slot strictly
+            -- after now. Without this the user-supplied offset is
+            -- recorded but ignored, and the first job fires at now
             -- instead of the next aligned timestamp (issue #3705).
             if offset and offset > 0 then
                 local aligned = math.floor(nextMillis / every) * every + offset

--- a/tests/job_scheduler.test.ts
+++ b/tests/job_scheduler.test.ts
@@ -1611,6 +1611,40 @@ describe('Job Scheduler', () => {
     });
   });
 
+  // Regression for https://github.com/taskforcesh/bullmq/issues/3705:
+  // upsertJobScheduler with `every` and an explicit `offset` used to
+  // align the first job to the next `offset` slot after now, e.g.
+  // `every: 15min, offset: 3min` produced jobs at :03, :18, :33, :48.
+  // PR #3446 (v5.58.8) regressed this — the offset was recorded but
+  // ignored, and the first job ran immediately at `now`.
+  describe("when 'every' and offset are provided on upsert", () => {
+    it('aligns the first job to the next offset slot after now', async () => {
+      const every = 15 * 60 * 1000;
+      const offset = 3 * 60 * 1000;
+      // 9:10 — between :03 and :18 within the 15-min slot.
+      const date = new Date('2017-02-07 9:10:00');
+      clock.setSystemTime(date);
+
+      await queue.upsertJobScheduler(
+        'test',
+        { every, offset },
+        { name: 'test', data: {} },
+      );
+
+      const expectedNext =
+        Math.floor(date.getTime() / every) * every + offset + every;
+
+      const schedulers = await queue.getJobSchedulers();
+      expect(schedulers).toHaveLength(1);
+      expect(schedulers[0].next).toBe(expectedNext);
+
+      const delayed = await queue.getDelayed();
+      expect(delayed).toHaveLength(1);
+      // The delayed job's timestamp + delay should equal the next slot.
+      expect(delayed[0].timestamp + delayed[0].delay).toBe(expectedNext);
+    });
+  });
+
   describe("when using 'every' and offset plus delay of being picked by a worker is same as delay", function () {
     it('should repeat every 2 seconds and start immediately', async () => {
       const offset = 1900;


### PR DESCRIPTION
### Port Impact Checklist

- [ ] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?

### Why

Fixes #3705.

`upsertJobScheduler({ every, offset })` used to schedule the first job at the next offset-aligned timestamp strictly after `now`. With `every: 15min, offset: 3min`, that is `:03, :18, :33, :48` per hour. The reporter saw this work on v5.56.1.

PR #3446 (v5.58.8) regressed it. The user-supplied `offset` reaches the Lua script (via `jobOpts['repeat']['offset']`) and is recorded on the scheduler hash, but the first-iteration branch of `getJobSchedulerEveryNextMillis.lua` returns `nextMillis = now` without applying the offset. Subsequent iterations correctly add `every` each time, so the cadence becomes `now, now + every, now + 2*every, …` — drifting from the calendar alignment the user expects.

```ts
queue.upsertJobScheduler('test',
  { every: 1000 * 60 * 15, offset: 1000 * 60 * 3 },
  { name: 'test', data: {} });

// Before this PR (now = 09:10:00):
//   first job → 09:10:00, then 09:25, 09:40, 09:55 …
// After this PR:
//   first job → 09:18:00, then 09:33, 09:48, 10:03 …
```

### How

`src/commands/includes/getJobSchedulerEveryNextMillis.lua`: in the first-iteration branch where `prevMillis` is nil and there is no `startDate`, compute the next offset-aligned slot strictly after `now`:

```lua
local aligned = math.floor(nextMillis / every) * every + offset
if aligned <= nextMillis then
    aligned = aligned + every
end
nextMillis = aligned
```

The change is local to the new-scheduler branch:

- The catch-up branch for missed iterations (`prevMillis < now - every`) is untouched. It already uses the same `floor(now/every)*every + every + offset` formula and continues to work.
- The `startDate` branch is untouched. An explicit `startDate` is the caller's authoritative first-run time and shouldn't be overridden by offset alignment.
- The downstream `if not offset or offset == 0` block (which derives an offset from a non-aligned `nextMillis` for storage) is untouched. With offset > 0 it never ran in the first place.

### Additional Notes (Optional)

- New regression test in `tests/job_scheduler.test.ts` (`when 'every' and offset are provided on upsert › aligns the first job to the next offset slot after now`). It fakes the clock at `2017-02-07 09:10:00`, calls `upsertJobScheduler('test', { every: 15min, offset: 3min })` and asserts both `getJobSchedulers()[0].next` and the delayed job's effective fire time (`timestamp + delay`) equal `floor(now/every)*every + offset + every` — i.e. the next `:18` slot.
- Pre-existing `every`-without-offset behaviour is untouched: when `offset` is 0/nil, the new alignment block is skipped and the original code path runs.
- TypeScript / Node-only on the test side; Lua source change applies to all ports that bundle the same scripts. No port-side code changes required since the scripts are the source of truth.