### PR TITLE
docs(queue-events): fix typo markes -> marked in close() comment

### DIFF
--- a/src/classes/queue-events.ts
+++ b/src/classes/queue-events.ts
@@ -431,7 +431,7 @@ export class QueueEvents extends QueueBase {
     if (!this.closing) {
       this.closing = (async () => {
         try {
-          // As the connection has been wrongly markes as "shared" by QueueBase,
+          // As the connection has been wrongly marked as "shared" by QueueBase,
           // we need to forcibly close it here. We should fix QueueBase to avoid this in the future.
           const client = await this.client;
           client.disconnect();


### PR DESCRIPTION
## Summary
- Fix a small typo in the inline comment inside `QueueEvents.close()` in `src/classes/queue-events.ts`: "wrongly markes" -> "wrongly marked".

## Test plan
- [x] Comment-only change, no behavior impact.