### PR TITLE
chore(utils): add type hints to utils functions [python]

### DIFF
--- a/python/bullmq/utils.py
+++ b/python/bullmq/utils.py
@@ -1,15 +1,16 @@
+import asyncio
 import json
 import traceback
-from typing import Any
+from typing import Any, Callable, Optional
 
 import semver
 
 
-def isRedisVersionLowerThan(current_version, minimum_version):
+def isRedisVersionLowerThan(current_version: str, minimum_version: str) -> bool:
     return semver.Version.parse(current_version).compare(minimum_version) == -1
 
 
-def extract_result(job_task, emit_callback):
+def extract_result(job_task: asyncio.Task, emit_callback: Callable[[str, Any], None]) -> Any:
     try:
         return job_task.result()
     except Exception as e:
@@ -19,7 +20,7 @@ def extract_result(job_task, emit_callback):
             traceback.print_exc()
             emit_callback("error", e)
 
-def get_parent_key(opts: dict[str, str]):
+def get_parent_key(opts: dict[str, str]) -> Optional[str]:
     if opts:
         return f"{opts.get('queue')}:{opts.get('id')}"
 

--- a/python/bullmq/utils.py
+++ b/python/bullmq/utils.py
@@ -1,16 +1,18 @@
 import asyncio
 import json
 import traceback
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 import semver
 
 
-def isRedisVersionLowerThan(current_version: str, minimum_version: str) -> bool:
+def isRedisVersionLowerThan(current_version: str | None, minimum_version: str) -> bool:
+    if current_version is None:
+        return False
     return semver.Version.parse(current_version).compare(minimum_version) == -1
 
 
-def extract_result(job_task: asyncio.Task, emit_callback: Callable[[str, Any], None]) -> Any:
+def extract_result(job_task: asyncio.Future[Any], emit_callback: Callable[[str, Any], None]) -> Any:
     try:
         return job_task.result()
     except Exception as e:
@@ -20,9 +22,10 @@ def extract_result(job_task: asyncio.Task, emit_callback: Callable[[str, Any], N
             traceback.print_exc()
             emit_callback("error", e)
 
-def get_parent_key(opts: dict[str, str]) -> Optional[str]:
+def get_parent_key(opts: dict[str, str] | None) -> str | None:
     if opts:
         return f"{opts.get('queue')}:{opts.get('id')}"
+    return None
 
 def parse_json_string_values(input_dict: dict[str, str]) -> dict[str, dict]:
     return {key: json.loads(value) for key, value in input_dict.items()}


### PR DESCRIPTION
## Summary

Adds missing type hints to three functions in `python/bullmq/utils.py`:

- `isRedisVersionLowerThan(current_version: str | None, minimum_version: str) -> bool`
- `extract_result(job_task: asyncio.Task, emit_callback: Callable[[str, Any], None]) -> Any`
- `get_parent_key(opts: dict[str, str]) -> Optional[str]`

Also adds the necessary imports (`asyncio`, `Callable`, `Optional`).

Note: `isRedisVersionLowerThan` now treats `current_version=None` as "not lower" (returns `False`) instead of raising. This is a small but intentional runtime change: callers like `RedisConnection.version` are typed as `str | None` and previously would have crashed if checked before `getRedisVersion()` ran.

## Motivation

These functions previously lacked type annotations, while the rest of the file (e.g. `parse_json_string_values`, `object_to_flat_array`, `is_redis_cluster`, `get_cluster_nodes`, `get_node_client`) is fully typed. This change brings consistency and improves IDE support / static analysis. Apart from the documented `None`-guard above, no other runtime behavior is altered.

## Test plan

- [ ] No runtime behavior changes apart from the documented `None`-guard in `isRedisVersionLowerThan`
- [ ] Existing Python tests continue to pass