### PR TITLE
docs(queue-meta): add JSDoc to QueueMeta interface and fields

### DIFF
--- a/src/interfaces/queue-meta.ts
+++ b/src/interfaces/queue-meta.ts
@@ -27,12 +27,13 @@ export interface QueueMeta {
   duration?: number;
 
   /**
-   * Approximate maximum length of the queue's events stream
-   * (`XADD ... MAXLEN ~ N`). Older events are evicted in FIFO order.
+   * Maximum length of the queue's events stream. Older events are evicted
+   * in FIFO order once the stream grows beyond this size.
    *
-   * Note: this is a best-effort target — Redis's `~` (fast trim) mode
-   * may retain more events than this value. Set without `~` semantics
-   * is not exposed by BullMQ.
+   * Note: `maxLenEvents` is not a guaranteed upper bound. BullMQ relies on
+   * Redis's `XTRIM` "fast trim" (`MAXLEN ~ N`), which is a best-effort
+   * cap — the stream may retain noticeably more events than this value at
+   * any given moment.
    */
   maxLenEvents?: number;
 

--- a/src/interfaces/queue-meta.ts
+++ b/src/interfaces/queue-meta.ts
@@ -1,8 +1,11 @@
 /**
- * Metadata about a Queue, stored under the queue's Redis `meta` key.
+ * Publicly relevant metadata fields for a Queue, read from the queue's
+ * Redis `meta` key.
  *
- * These values mirror the configuration applied via `Queue.setGlobalConcurrency`,
- * `Queue.setGlobalRateLimit`, and the queue's pause/version state.
+ * This interface documents the subset of meta-hash fields that BullMQ
+ * exposes to consumers (e.g. via `Queue.getQueueOpts`, `Queue.getRateLimit`,
+ * `Queue.isPaused`); the underlying hash also stores internal fields
+ * (e.g. metrics counters) that are not part of this type.
  */
 export interface QueueMeta {
   /**
@@ -24,8 +27,12 @@ export interface QueueMeta {
   duration?: number;
 
   /**
-   * Maximum length of the queue's events stream (`MAXLEN ~ N`).
-   * Older events are evicted in roughly-FIFO order when this is exceeded.
+   * Approximate maximum length of the queue's events stream
+   * (`XADD ... MAXLEN ~ N`). Older events are evicted in FIFO order.
+   *
+   * Note: this is a best-effort target — Redis's `~` (fast trim) mode
+   * may retain more events than this value. Set without `~` semantics
+   * is not exposed by BullMQ.
    */
   maxLenEvents?: number;
 

--- a/src/interfaces/queue-meta.ts
+++ b/src/interfaces/queue-meta.ts
@@ -1,8 +1,43 @@
+/**
+ * Metadata about a Queue, stored under the queue's Redis `meta` key.
+ *
+ * These values mirror the configuration applied via `Queue.setGlobalConcurrency`,
+ * `Queue.setGlobalRateLimit`, and the queue's pause/version state.
+ */
 export interface QueueMeta {
+  /**
+   * Maximum number of jobs that can be processed concurrently across all
+   * workers attached to this queue. Set via `Queue.setGlobalConcurrency`.
+   */
   concurrency?: number;
+
+  /**
+   * Maximum number of jobs allowed in the rate-limit window of `duration`
+   * milliseconds. Set via `Queue.setGlobalRateLimit`.
+   */
   max?: number;
+
+  /**
+   * Length of the rate-limit window in milliseconds, paired with `max`.
+   * Set via `Queue.setGlobalRateLimit`.
+   */
   duration?: number;
+
+  /**
+   * Maximum length of the queue's events stream (`MAXLEN ~ N`).
+   * Older events are evicted in roughly-FIFO order when this is exceeded.
+   */
   maxLenEvents?: number;
+
+  /**
+   * True when the queue has been paused. While paused, workers will not
+   * pick up new jobs.
+   */
   paused?: boolean;
+
+  /**
+   * BullMQ version that produced this queue's data, used for compatibility
+   * checks across upgrades.
+   */
   version?: string;
 }


### PR DESCRIPTION
## Summary

Adds JSDoc comments to the `QueueMeta` interface and each of its fields in `src/interfaces/queue-meta.ts`. These values mirror the configuration applied via `Queue.setGlobalConcurrency`, `Queue.setGlobalRateLimit`, and the queue's pause/version state, all stored under the queue's Redis `meta` key.

## Changes

- Document the interface as a whole, explaining that it represents queue metadata stored under the Redis `meta` key.
- Document each field (`concurrency`, `max`, `duration`, `maxLenEvents`, `paused`, `version`) with how it is set and what it controls.

## Test plan

- [x] Documentation-only change; no runtime impact.
- [x] TypeScript types unchanged.