### PR TITLE
docs(lua): fix typo in obliterate-2.lua comment

### DIFF
--- a/src/commands/obliterate-2.lua
+++ b/src/commands/obliterate-2.lua
@@ -6,7 +6,7 @@
 
   The queue needs to be "paused" or it will return an error
   If the queue has currently active jobs then the script by default will return error,
-  however this behaviour can be overrided using the 'force' option.
+  however this behaviour can be overridden using the 'force' option.
   
   Input:
     KEYS[1] meta


### PR DESCRIPTION
## Summary
- Fixes a typo in a Lua comment in `src/commands/obliterate-2.lua` (no logic or key changes).

| File | Before | After |
|------|--------|-------|
| `src/commands/obliterate-2.lua` | `overrided` | `overridden` |

## Test plan
- [x] Comment-only change; Lua script logic and Redis keys are unchanged