### PR TITLE
feat(backoffs): add type hints to Backoffs methods [python]

### DIFF
--- a/python/bullmq/backoffs.py
+++ b/python/bullmq/backoffs.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Any, Callable
 from bullmq.types import BackoffOptions
 
 import math
@@ -9,10 +9,10 @@ class Backoffs:
     builtin_strategies = {
         "fixed": lambda delay: lambda attempts_made, type, err, job: delay,
         "exponential": lambda delay: lambda attempts_made, type, err, job: int(round(pow(2, attempts_made - 1) * delay))
-    }    
+    }
 
     @staticmethod
-    def normalize(backoff: Union[int, BackoffOptions]):
+    def normalize(backoff: int | BackoffOptions) -> BackoffOptions | None:
         if type(backoff) == int and math.isfinite(backoff):
             return {
                 "type": "fixed",
@@ -22,13 +22,22 @@ class Backoffs:
             return backoff
 
     @staticmethod
-    async def calculate(backoff: BackoffOptions, attempts_made: int, err, job, customStrategy):
+    async def calculate(
+        backoff: BackoffOptions | None,
+        attempts_made: int,
+        err: Any,
+        job: Any,
+        customStrategy: Callable[..., int] | None,
+    ) -> int | None:
         if backoff:
             strategy = lookup_strategy(backoff, customStrategy)
             return strategy(attempts_made, backoff.get("type"), err, job)
 
 
-def lookup_strategy(backoff: BackoffOptions, custom_strategy):
+def lookup_strategy(
+    backoff: BackoffOptions,
+    custom_strategy: Callable[..., int] | None,
+) -> Callable[..., int]:
     backoff_type = backoff.get("type")
     if backoff_type in Backoffs.builtin_strategies:
         return Backoffs.builtin_strategies[backoff_type](backoff.get("delay"))


### PR DESCRIPTION
## Summary
- Adds parameter and return type annotations to `Backoffs.normalize`, `Backoffs.calculate`, and the module-level `lookup_strategy` helper.
- Uses PEP 604 unions (`int | BackoffOptions`, `BackoffOptions | None`, `Callable[..., int] | None`) consistent with the rest of the Python codebase after recent typing PRs.
- Drops the now-unused `Union` import from `typing` in favor of built-in unions.
- No runtime behavior change.

## Test plan
- [x] Runtime semantics unchanged (annotations only)
- [x] `python -m py_compile python/bullmq/backoffs.py` passes
- [x] Existing strategy resolution and `normalize` behavior preserved