### PR TITLE
docs(events): document QueueEvents best-effort delivery semantics (#2517)

### DIFF
--- a/docs/gitbook/guide/events/README.md
+++ b/docs/gitbook/guide/events/README.md
@@ -51,10 +51,14 @@ queueEvents.on(
 );
 ```
 
-The `QueueEvents` class is implemented using [Redis streams](https://redis.io/topics/streams-intro). This has some nice properties, for example, it provides guarantees that the events are delivered and not lost during disconnections such as it would be the case with standard pub-sub.
+The `QueueEvents` class is implemented using [Redis streams](https://redis.io/topics/streams-intro). Compared to standard pub-sub this is more robust across short consumer disconnections, since events buffered in the stream while the consumer is offline can still be read once it reconnects — up to the limits described below.
 
 {% hint style="danger" %}
-The event stream is auto-trimmed so that its size does not grow too much, by default it is \~10.000 events, but this can be configured with the `streams.events.maxLen` option.
+**`QueueEvents` is best-effort, not at-least-once.** The events stream is auto-trimmed on every job state transition with `XTRIM MAXLEN ~ <maxLenEvents>` (default `10000`). If producers (e.g. workers completing jobs) emit events faster than your `QueueEvents` instance drains them, the backlog can exceed `maxLenEvents` and the oldest unread events will be evicted by Redis before the consumer ever reads them. This is consistent with the internal `QueueMeta.maxLenEvents` documentation, which already describes the cap as best-effort — note also that the `~` modifier in `XTRIM` is approximate, so the actual length may briefly exceed `maxLenEvents` by a small amount, but it remains a hard cap.
+
+You can widen the buffer with the [`streams.events.maxLen`](https://api.docs.bullmq.io/interfaces/v5.QueueOptions.html#streams) option on the `Queue` (e.g. `100000` or higher) to reduce the risk of loss when producer and consumer rates differ. Note that this only reduces the risk; it does not eliminate it. Under sustained back-pressure — many concurrent workers finishing jobs faster than a single Node process can drain via `XREAD` — events can still be lost regardless of how large `maxLen` is set.
+
+If you need guaranteed delivery of completion notifications (for example, to count exactly how many jobs finished), prefer the per-`Worker` `'completed'` and `'failed'` listeners. Those are driven by the worker's own active-list bookkeeping and are not subject to stream trimming. Use `QueueEvents` for monitoring, dashboards, and aggregation across workers — scenarios where occasional missed events are acceptable.
 {% endhint %}
 
 ### Manual trim events


### PR DESCRIPTION
### Port Impact Checklist
<!--
  Review each port and tick every box that applies.
  If a port is not affected at all, leave its box unchecked.
-->

- [ ] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?

<!--
  Note: the Python/Elixir/PHP ports likely have analogous events docs that
  carry the same misleading wording, but propagating this correction is out
  of scope for this PR — those ports have their own docs structures and
  should be addressed in separate PRs. Boxes intentionally left unchecked.
-->

### Why
<!--
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->

Refs #2517. The reporter expected `QueueEvents` to deliver every `'completed'` event for every job, and the current docs reinforce that expectation by stating that the Redis-streams backing "provides guarantees that the events are delivered and not lost". In practice the events stream is auto-trimmed on every job state transition (`XTRIM MAXLEN ~ <maxLenEvents>`, default `10000`), so under high producer rate or a slow consumer the oldest unread events are evicted by Redis before the consumer reads them. The internal `QueueMeta.maxLenEvents` doc already calls this cap "best-effort"; the user-facing guide should match, so users don't build correctness-critical logic on top of an at-most-once channel.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->

Surgical, docs-only edit to `docs/gitbook/guide/events/README.md`. No code, no tests, no public API changes.

The two original sentences (the "guarantees that the events are delivered and not lost" paragraph and the one-line danger hint about `streams.events.maxLen`) are replaced with:

1. A revised intro paragraph that scopes the streams advantage over pub-sub to surviving short consumer disconnections, rather than implying durable delivery.
2. An expanded danger hint that:
   - Names the trim mechanism explicitly (`XTRIM MAXLEN ~ <maxLenEvents>`, default `10000`) and notes that the `~` modifier is approximate.
   - States the best-effort guarantee in bold, in line with the existing `QueueMeta.maxLenEvents` internal doc.
   - Documents the `streams.events.maxLen` lever via a link to the `QueueOptions.streams` API doc, and clarifies that increasing it only **reduces** — does not eliminate — the loss risk under sustained back-pressure.
   - Recommends per-`Worker` `'completed'` / `'failed'` listeners as the at-least-once alternative for users who need guaranteed delivery (these are driven by the worker's own active-list bookkeeping and are not subject to stream trimming), and frames `QueueEvents` as appropriate for monitoring, dashboards, and cross-worker aggregation where occasional missed events are acceptable.

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->

- **Documentation-only.** No runtime behavior is changed. A real behavior fix — migrating `QueueEvents` to a Redis Streams consumer group with `XACK` / `XAUTOCLAIM` for at-least-once delivery — is a separate, larger design discussion and is intentionally out of scope here.
- The Python, Elixir, and PHP ports likely carry sibling docs pages with the same misleading wording. Those should be corrected in their own PRs against the respective port repositories; the Port Impact Checklist boxes are deliberately left unchecked because this PR does not touch those ports.
- No new tests; markdown-only change. Verified the rendered output (headings, link, code spans, bold) parses cleanly in the existing GitBook hint block.