### PR TITLE
test(stalled): address race condition

### DIFF
--- a/tests/deduplication.test.ts
+++ b/tests/deduplication.test.ts
@@ -326,39 +326,57 @@ describe('deduplication', () => {
       const testName = 'test';
       const dedupId = 'dedupId';
 
-      const waitingEvent = new Promise<void>((resolve, reject) => {
-        queueEvents.once(
-          'deduplicated',
-          async ({ jobId, deduplicationId, deduplicatedJobId }) => {
-            try {
-              const job = await queue.getJob(jobId);
-              expect(job).toBeDefined();
-              expect(jobId).toBe('a1');
-              expect(deduplicationId).toBe(dedupId);
-
-              const deduplicatedJob = await queue.getJob(deduplicatedJobId);
-              expect(deduplicatedJob).toBeUndefined();
-              expect(deduplicatedJobId).toBe('a2');
-              resolve();
-            } catch (error) {
-              reject(error);
-            }
-          },
-        );
-      });
+      let deduplicatedResult:
+        | {
+            jobId: string;
+            deduplicationId: string;
+            deduplicatedJobId: string;
+            job: any;
+            deduplicatedJob: any;
+          }
+        | undefined;
+      const waitingEvent = Promise.race([
+        new Promise<void>((resolve, reject) => {
+          queueEvents.once(
+            'deduplicated',
+            async ({ jobId, deduplicationId, deduplicatedJobId }) => {
+              try {
+                const job = await queue.getJob(jobId);
+                const deduplicatedJob = await queue.getJob(deduplicatedJobId);
+                deduplicatedResult = {
+                  jobId,
+                  deduplicationId,
+                  deduplicatedJobId,
+                  job,
+                  deduplicatedJob,
+                };
+                resolve();
+              } catch (error) {
+                reject(error);
+              }
+            },
+          );
+        }),
+        delay(100),
+      ]);
 
       await queue.add(
         testName,
         { foo: 'bar' },
         { jobId: 'a1', deduplication: { id: dedupId } },
       );
-      queue.add(
+      await queue.add(
         testName,
         { foo: 'bar' },
         { jobId: 'a2', deduplication: { id: dedupId } },
       );
 
       await waitingEvent;
+      expect(deduplicatedResult?.job).toBeDefined();
+      expect(deduplicatedResult?.jobId).toBe('a1');
+      expect(deduplicatedResult?.deduplicationId).toBe(dedupId);
+      expect(deduplicatedResult?.deduplicatedJob).toBeUndefined();
+      expect(deduplicatedResult?.deduplicatedJobId).toBe('a2');
     });
 
     describe('when removing deduplication key', () => {

--- a/tests/deduplication.test.ts
+++ b/tests/deduplication.test.ts
@@ -352,7 +352,7 @@ describe('deduplication', () => {
         { foo: 'bar' },
         { jobId: 'a1', deduplication: { id: dedupId } },
       );
-      await queue.add(
+      queue.add(
         testName,
         { foo: 'bar' },
         { jobId: 'a2', deduplication: { id: dedupId } },

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -477,22 +477,19 @@ describe('events', { timeout: 8000 }, () => {
       let waitingResult:
         | { prev: string; jobName: string | undefined }
         | undefined;
-      const waiting = Promise.race([
-        new Promise<void>((resolve, reject) => {
-          queueEvents.on('waiting', async ({ jobId, prev }) => {
-            try {
-              const job = await queue.getJob(jobId);
-              if (job?.name === name) {
-                waitingResult = { prev, jobName: job?.name };
-                resolve();
-              }
-            } catch (err) {
-              reject(err);
+      const waiting = new Promise<void>((resolve, reject) => {
+        queueEvents.on('waiting', async ({ jobId, prev }) => {
+          try {
+            const job = await queue.getJob(jobId);
+            if (job?.name === name) {
+              waitingResult = { prev, jobName: job?.name };
+              resolve();
             }
-          });
-        }),
-        delay(100),
-      ]);
+          } catch (err) {
+            reject(err);
+          }
+        });
+      });
 
       const flow = new FlowProducer({ connection, prefix });
       await flow.add({

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -484,7 +484,7 @@ describe('events', { timeout: 8000 }, () => {
       });
 
       const flow = new FlowProducer({ connection, prefix });
-      await flow.add({
+      flow.add({
         name,
         queueName,
         data: {},
@@ -495,8 +495,7 @@ describe('events', { timeout: 8000 }, () => {
       worker.run();
       childrenWorker.run();
 
-      await waitingChildren;
-      await waiting;
+      await Promise.all([waitingChildren, waiting]);
 
       await worker.close();
       await childrenWorker.close();

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -493,9 +493,12 @@ describe('events', { timeout: 8000 }, () => {
         ],
       });
       worker.run();
+
+      await waitingChildren;
+
       childrenWorker.run();
 
-      await Promise.all([waitingChildren, waiting]);
+      await waiting;
 
       await worker.close();
       await childrenWorker.close();

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -455,36 +455,47 @@ describe('events', { timeout: 8000 }, () => {
           prefix,
         },
       );
-      const waitingChildren = new Promise<void>((resolve, reject) => {
-        queueEvents.once('waiting-children', async ({ jobId }) => {
-          try {
-            const job = await queue.getJob(jobId);
-            const state = await job?.getState();
-            expect(state).toBe('waiting-children');
-            expect(job?.name).toBe(name);
-            resolve();
-          } catch (err) {
-            reject(err);
-          }
-        });
-      });
-
-      const waiting = new Promise<void>((resolve, reject) => {
-        queueEvents.on('waiting', async ({ jobId, prev }) => {
-          try {
-            const job = await queue.getJob(jobId);
-            expect(prev).toBe('waiting-children');
-            if (job?.name === name) {
+      let waitingChildrenJob:
+        | { state: string | undefined; jobName: string | undefined }
+        | undefined;
+      const waitingChildren = Promise.race([
+        new Promise<void>((resolve, reject) => {
+          queueEvents.once('waiting-children', async ({ jobId }) => {
+            try {
+              const job = await queue.getJob(jobId);
+              const state = await job?.getState();
+              waitingChildrenJob = { state, jobName: job?.name };
               resolve();
+            } catch (err) {
+              reject(err);
             }
-          } catch (err) {
-            reject(err);
-          }
-        });
-      });
+          });
+        }),
+        delay(100),
+      ]);
+
+      let waitingResult:
+        | { prev: string; jobName: string | undefined }
+        | undefined;
+      const waiting = Promise.race([
+        new Promise<void>((resolve, reject) => {
+          queueEvents.on('waiting', async ({ jobId, prev }) => {
+            try {
+              const job = await queue.getJob(jobId);
+              if (job?.name === name) {
+                waitingResult = { prev, jobName: job?.name };
+                resolve();
+              }
+            } catch (err) {
+              reject(err);
+            }
+          });
+        }),
+        delay(100),
+      ]);
 
       const flow = new FlowProducer({ connection, prefix });
-      flow.add({
+      await flow.add({
         name,
         queueName,
         data: {},
@@ -495,10 +506,13 @@ describe('events', { timeout: 8000 }, () => {
       worker.run();
 
       await waitingChildren;
+      expect(waitingChildrenJob?.state).toBe('waiting-children');
+      expect(waitingChildrenJob?.jobName).toBe(name);
 
       childrenWorker.run();
 
       await waiting;
+      expect(waitingResult?.prev).toBe('waiting-children');
 
       await worker.close();
       await childrenWorker.close();

--- a/tests/stalled_jobs.test.ts
+++ b/tests/stalled_jobs.test.ts
@@ -1021,7 +1021,7 @@ describe('stalled jobs', () => {
     });
 
     describe('when removeOnFail is provided as a object', () => {
-      it.only('keeps the specified number of jobs in failed respecting the age', async () => {
+      it('keeps the specified number of jobs in failed respecting the age', async () => {
         // TODO: Move timeout to test options: { timeout: 6000 }
         const concurrency = 4;
 

--- a/tests/stalled_jobs.test.ts
+++ b/tests/stalled_jobs.test.ts
@@ -1048,6 +1048,10 @@ describe('stalled jobs', () => {
           worker.on('active', after(concurrency, resolve));
         });
 
+        const twoFailed = new Promise(resolve => {
+          worker.on('failed', after(2, resolve));
+        });
+
         await worker.waitUntilReady();
 
         const jobs = Array.from(Array(4).keys()).map(index => ({
@@ -1060,10 +1064,6 @@ describe('stalled jobs', () => {
             },
           },
         }));
-
-        const twoFailed = new Promise(resolve => {
-          worker.on('failed', after(2, resolve));
-        });
 
         queue.addBulk(jobs);
 

--- a/tests/stalled_jobs.test.ts
+++ b/tests/stalled_jobs.test.ts
@@ -1021,7 +1021,7 @@ describe('stalled jobs', () => {
     });
 
     describe('when removeOnFail is provided as a object', () => {
-      it('keeps the specified number of jobs in failed respecting the age', async () => {
+      it.only('keeps the specified number of jobs in failed respecting the age', async () => {
         // TODO: Move timeout to test options: { timeout: 6000 }
         const concurrency = 4;
 
@@ -1061,8 +1061,6 @@ describe('stalled jobs', () => {
           },
         }));
 
-        await queue.addBulk(jobs);
-
         const twoFailed = new Promise<void>(resolve => {
           let count = 0;
           worker.on('failed', () => {
@@ -1071,6 +1069,8 @@ describe('stalled jobs', () => {
             }
           });
         });
+
+        await queue.addBulk(jobs);
 
         worker.run();
 

--- a/tests/stalled_jobs.test.ts
+++ b/tests/stalled_jobs.test.ts
@@ -1062,7 +1062,7 @@ describe('stalled jobs', () => {
         }));
 
         const twoFailed = new Promise(resolve => {
-          worker.on('active', after(2, resolve));
+          worker.on('failed', after(2, resolve));
         });
 
         queue.addBulk(jobs);

--- a/tests/stalled_jobs.test.ts
+++ b/tests/stalled_jobs.test.ts
@@ -1023,7 +1023,7 @@ describe('stalled jobs', () => {
     describe('when removeOnFail is provided as a object', () => {
       it('keeps the specified number of jobs in failed respecting the age', async () => {
         // TODO: Move timeout to test options: { timeout: 6000 }
-        const concurrency = 4;
+        const concurrency = 2;
 
         const worker = new Worker(
           queueName,
@@ -1044,6 +1044,8 @@ describe('stalled jobs', () => {
           },
         );
 
+        await worker.waitUntilReady();
+
         const allActive = Promise.race([
           new Promise(resolve => {
             worker.on('active', after(concurrency, resolve));
@@ -1058,8 +1060,6 @@ describe('stalled jobs', () => {
           delay(100),
         ]);
 
-        await worker.waitUntilReady();
-
         const jobs = Array.from(Array(4).keys()).map(index => ({
           name: 'test',
           data: { index },
@@ -1071,7 +1071,7 @@ describe('stalled jobs', () => {
           },
         }));
 
-        queue.addBulk(jobs);
+        await queue.addBulk(jobs);
 
         worker.run();
 
@@ -1088,16 +1088,20 @@ describe('stalled jobs', () => {
         });
 
         const errorMessage = 'job stalled more than allowable limit';
-        const allFailed = new Promise<void>(resolve => {
+        const allFailed = new Promise<void>((resolve, reject) => {
           worker2.on('failed', async (job, failedReason, prev) => {
-            if (job.id == '4') {
-              const failedCount = await queue.getFailedCount();
-              expect(failedCount).toBe(2);
+            try {
+              if (job.id == '4') {
+                const failedCount = await queue.getFailedCount();
+                expect(failedCount).toBe(2);
 
-              expect(job.data.index).toBe(3);
-              expect(prev).toBe('active');
-              expect(failedReason.message).toBe(errorMessage);
-              resolve();
+                expect(job.data.index).toBe(3);
+                expect(prev).toBe('active');
+                expect(failedReason.message).toBe(errorMessage);
+                resolve();
+              }
+            } catch (error) {
+              reject(error);
             }
           });
         });

--- a/tests/stalled_jobs.test.ts
+++ b/tests/stalled_jobs.test.ts
@@ -1044,13 +1044,19 @@ describe('stalled jobs', () => {
           },
         );
 
-        const allActive = new Promise(resolve => {
-          worker.on('active', after(concurrency, resolve));
-        });
+        const allActive = Promise.race([
+          new Promise(resolve => {
+            worker.on('active', after(concurrency, resolve));
+          }),
+          delay(100),
+        ]);
 
-        const twoFailed = new Promise(resolve => {
-          worker.on('failed', after(2, resolve));
-        });
+        const failures = Promise.race([
+          new Promise(resolve => {
+            worker.on('failed', after(2, resolve));
+          }),
+          delay(100),
+        ]);
 
         await worker.waitUntilReady();
 
@@ -1069,7 +1075,7 @@ describe('stalled jobs', () => {
 
         worker.run();
 
-        await Promise.all([allActive, twoFailed]);
+        await Promise.all([allActive, failures]);
 
         await worker.close(true);
 

--- a/tests/stalled_jobs.test.ts
+++ b/tests/stalled_jobs.test.ts
@@ -1063,9 +1063,19 @@ describe('stalled jobs', () => {
 
         await queue.addBulk(jobs);
 
+        const twoFailed = new Promise<void>(resolve => {
+          let count = 0;
+          worker.on('failed', () => {
+            if (++count >= 2) {
+              resolve();
+            }
+          });
+        });
+
         worker.run();
 
         await allActive;
+        await twoFailed;
 
         await worker.close(true);
 

--- a/tests/stalled_jobs.test.ts
+++ b/tests/stalled_jobs.test.ts
@@ -1061,21 +1061,15 @@ describe('stalled jobs', () => {
           },
         }));
 
-        const twoFailed = new Promise<void>(resolve => {
-          let count = 0;
-          worker.on('failed', () => {
-            if (++count >= 2) {
-              resolve();
-            }
-          });
+        const twoFailed = new Promise(resolve => {
+          worker.on('active', after(2, resolve));
         });
 
-        await queue.addBulk(jobs);
+        queue.addBulk(jobs);
 
         worker.run();
 
-        await allActive;
-        await twoFailed;
+        await Promise.all([allActive, twoFailed]);
 
         await worker.close(true);
 


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.

  PR TITLE FORMAT
  ───────────────
  We use Conventional Commits: <type>(<scope>): <description>

  If your change affects one or more ports, append a tag at the end of the
  PR title (outside the conventional-commit part) to indicate their status:

    [python] / [elixir] / [php]
      → The change is ONLY relevant to that port (Node.js is NOT affected).
        Multiple ports can be listed: [python][elixir]

    (python) / (elixir) / (php)
      → The change affects that port AND Node.js.
        Multiple ports can be listed: (python)(php)

  Examples:
    fix(worker): handle stalled jobs correctly (python)(elixir)
    docs: update rate-limiting guide [python]
    feat(queue): add group priority support

  Please check all three ports below before setting your title.
-->

### Port Impact Checklist
<!--
  Review each port and tick every box that applies.
  If a port is not affected at all, leave its box unchecked.
-->

- [ ] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?

### Why
<!-- 
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
  1. Why is this change necessary? Need to wait to fail the jobs that are not stalled before closing the worker, if not subsequent validation could fail because a race condition

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
_Enter the implementation details here._

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
