### PR TITLE
fix(connection): reconnect wedged blocking cluster clients

### DIFF
--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -32,6 +32,16 @@ interface RedisCapabilities {
   canBlockFor1Ms: boolean;
 }
 
+interface BlockingClusterClient {
+  [clusterReconnectPromise]?: Promise<void> | null;
+  [clusterPatchedForBlocking]?: boolean;
+  bzpopmin: (...args: any[]) => Promise<unknown>;
+  connect: () => Promise<void>;
+  disconnect: (reconnect?: boolean) => void;
+  nodes?: () => unknown[];
+  status?: string;
+}
+
 export interface RawCommand {
   content: string;
   name: string;
@@ -309,43 +319,73 @@ export class RedisConnection extends EventEmitter {
   }
 
   private patchBlockingClusterClient(): void {
-    const client = this._client as any;
+    const client = this._client;
+    const blockingClient = client as unknown as BlockingClusterClient;
     if (
       !this.extraOptions.blocking ||
       !isRedisCluster(client) ||
-      typeof client.bzpopmin !== 'function' ||
-      client[clusterPatchedForBlocking]
+      typeof blockingClient.bzpopmin !== 'function' ||
+      blockingClient[clusterPatchedForBlocking]
     ) {
       return;
     }
 
-    const bzpopmin = client.bzpopmin.bind(client);
-    client[clusterPatchedForBlocking] = true;
-    client.bzpopmin = async (...args: any[]) => {
-      await this.reconnectClusterIfNeeded(client);
+    const bzpopmin = blockingClient.bzpopmin.bind(blockingClient);
+    blockingClient[clusterPatchedForBlocking] = true;
+    blockingClient.bzpopmin = async (...args: any[]) => {
+      await this.reconnectClusterIfNeeded(blockingClient);
 
       try {
         return await bzpopmin(...args);
       } catch (error) {
-        if (this.shouldReconnectClusterAfterError(client, error as Error)) {
-          await this.reconnectCluster(client);
+        const commandError = error as Error;
+        if (
+          this.shouldReconnectClusterAfterError(blockingClient, commandError)
+        ) {
+          try {
+            await this.reconnectCluster(blockingClient);
+          } catch {
+            // Preserve the original command failure if best-effort recovery fails.
+          }
         }
-        throw error;
+        throw commandError;
       }
     };
   }
 
-  private isClusterWithEmptyNodes(client: any): boolean {
+  private isClusterWithEmptyNodes(client: BlockingClusterClient): boolean {
     return typeof client.nodes === 'function' && client.nodes().length === 0;
   }
 
-  private async reconnectClusterIfNeeded(client: any): Promise<void> {
-    if (this.isClusterWithEmptyNodes(client)) {
+  private isReconnectingDisabled(client: BlockingClusterClient): boolean {
+    return (
+      this.closing ||
+      this.status === 'closing' ||
+      this.status === 'closed' ||
+      client.status === 'end' ||
+      client.status === 'closing'
+    );
+  }
+
+  private async reconnectClusterIfNeeded(
+    client: BlockingClusterClient,
+  ): Promise<void> {
+    if (
+      !this.isReconnectingDisabled(client) &&
+      this.isClusterWithEmptyNodes(client)
+    ) {
       await this.reconnectCluster(client);
     }
   }
 
-  private shouldReconnectClusterAfterError(client: any, error: Error): boolean {
+  private shouldReconnectClusterAfterError(
+    client: BlockingClusterClient,
+    error: Error,
+  ): boolean {
+    if (this.isReconnectingDisabled(client)) {
+      return false;
+    }
+
     const message = [
       error.message,
       (error as any).cause?.message,
@@ -358,7 +398,11 @@ export class RedisConnection extends EventEmitter {
     );
   }
 
-  private async reconnectCluster(client: any): Promise<void> {
+  private async reconnectCluster(client: BlockingClusterClient): Promise<void> {
+    if (this.isReconnectingDisabled(client)) {
+      return;
+    }
+
     if (!client[clusterReconnectPromise]) {
       client[clusterReconnectPromise] = (async () => {
         client.disconnect(false);

--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -24,6 +24,9 @@ const overrideMessage = [
 const deprecationMessage =
   'BullMQ: Your redis options maxRetriesPerRequest must be null.';
 
+const clusterReconnectPromise = Symbol('bullmqClusterReconnectPromise');
+const clusterPatchedForBlocking = Symbol('bullmqClusterPatchedForBlocking');
+
 interface RedisCapabilities {
   canDoubleTimeout: boolean;
   canBlockFor1Ms: boolean;
@@ -245,6 +248,8 @@ export class RedisConnection extends EventEmitter {
 
     this._client.on('ready', this.handleClientReady);
 
+    this.patchBlockingClusterClient();
+
     if (!this.extraOptions.skipWaitingForReady) {
       await RedisConnection.waitUntilReady(this._client);
     }
@@ -301,6 +306,69 @@ export class RedisConnection extends EventEmitter {
     }
 
     return this._client;
+  }
+
+  private patchBlockingClusterClient(): void {
+    const client = this._client as any;
+    if (
+      !this.extraOptions.blocking ||
+      !isRedisCluster(client) ||
+      typeof client.bzpopmin !== 'function' ||
+      client[clusterPatchedForBlocking]
+    ) {
+      return;
+    }
+
+    const bzpopmin = client.bzpopmin.bind(client);
+    client[clusterPatchedForBlocking] = true;
+    client.bzpopmin = async (...args: any[]) => {
+      await this.reconnectClusterIfNeeded(client);
+
+      try {
+        return await bzpopmin(...args);
+      } catch (error) {
+        if (this.shouldReconnectClusterAfterError(client, error as Error)) {
+          await this.reconnectCluster(client);
+        }
+        throw error;
+      }
+    };
+  }
+
+  private isClusterWithEmptyNodes(client: any): boolean {
+    return typeof client.nodes === 'function' && client.nodes().length === 0;
+  }
+
+  private async reconnectClusterIfNeeded(client: any): Promise<void> {
+    if (this.isClusterWithEmptyNodes(client)) {
+      await this.reconnectCluster(client);
+    }
+  }
+
+  private shouldReconnectClusterAfterError(client: any, error: Error): boolean {
+    const message = [
+      error.message,
+      (error as any).cause?.message,
+      (error as any).lastNodeError?.message,
+    ].join(' ');
+
+    return (
+      this.isClusterWithEmptyNodes(client) ||
+      /Command timed out|Failed to refresh slots cache/i.test(message)
+    );
+  }
+
+  private async reconnectCluster(client: any): Promise<void> {
+    if (!client[clusterReconnectPromise]) {
+      client[clusterReconnectPromise] = (async () => {
+        client.disconnect(false);
+        await client.connect();
+      })().finally(() => {
+        client[clusterReconnectPromise] = null;
+      });
+    }
+
+    await client[clusterReconnectPromise];
   }
 
   async disconnect(wait = true): Promise<void> {

--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -28,6 +28,8 @@ const clusterReconnectPromise = Symbol('bullmqClusterReconnectPromise');
 const clusterPatchedForBlocking = Symbol('bullmqClusterPatchedForBlocking');
 const clusterOriginalBzpopmin = Symbol('bullmqClusterOriginalBzpopmin');
 const clusterWrappedBzpopmin = Symbol('bullmqClusterWrappedBzpopmin');
+const clusterPatchRefCount = Symbol('bullmqClusterPatchRefCount');
+const clusterClosingRefCount = Symbol('bullmqClusterClosingRefCount');
 
 interface RedisCapabilities {
   canDoubleTimeout: boolean;
@@ -39,6 +41,8 @@ interface BlockingClusterClient {
   [clusterPatchedForBlocking]?: boolean;
   [clusterOriginalBzpopmin]?: BlockingClusterClient['bzpopmin'];
   [clusterWrappedBzpopmin]?: BlockingClusterClient['bzpopmin'];
+  [clusterPatchRefCount]?: number;
+  [clusterClosingRefCount]?: number;
   bzpopmin: (...args: any[]) => Promise<unknown>;
   connect: () => Promise<void>;
   disconnect: (reconnect?: boolean) => void;
@@ -77,6 +81,7 @@ export class RedisConnection extends EventEmitter {
   private handleClientClose: () => void;
   private handleClientReady: () => void;
   private patchedBlockingClusterClient?: BlockingClusterClient;
+  private disabledBlockingClusterReconnect = false;
 
   constructor(
     opts: ConnectionOptions,
@@ -329,25 +334,35 @@ export class RedisConnection extends EventEmitter {
     if (
       !this.extraOptions.blocking ||
       !isRedisCluster(client) ||
-      typeof blockingClient.bzpopmin !== 'function' ||
-      blockingClient[clusterPatchedForBlocking]
+      typeof blockingClient.bzpopmin !== 'function'
     ) {
+      return;
+    }
+
+    blockingClient[clusterPatchRefCount] =
+      (blockingClient[clusterPatchRefCount] || 0) + 1;
+    this.patchedBlockingClusterClient = blockingClient;
+
+    if (blockingClient[clusterPatchedForBlocking]) {
       return;
     }
 
     const bzpopmin = blockingClient.bzpopmin;
     const wrappedBzpopmin = async (...args: any[]) => {
-      await this.reconnectClusterIfNeeded(blockingClient);
+      await RedisConnection.reconnectClusterIfNeeded(blockingClient);
 
       try {
         return await bzpopmin.apply(blockingClient, args);
       } catch (error) {
         const commandError = error as Error;
         if (
-          this.shouldReconnectClusterAfterError(blockingClient, commandError)
+          RedisConnection.shouldReconnectClusterAfterError(
+            blockingClient,
+            commandError,
+          )
         ) {
           try {
-            await this.reconnectCluster(blockingClient);
+            await RedisConnection.reconnectCluster(blockingClient);
           } catch {
             // Preserve the original command failure if best-effort recovery fails.
           }
@@ -360,12 +375,38 @@ export class RedisConnection extends EventEmitter {
     blockingClient[clusterWrappedBzpopmin] = wrappedBzpopmin;
     blockingClient[clusterPatchedForBlocking] = true;
     blockingClient.bzpopmin = wrappedBzpopmin;
-    this.patchedBlockingClusterClient = blockingClient;
   }
 
-  private restoreBlockingClusterClient(): void {
+  private disableBlockingClusterReconnect(): void {
+    const client = this.patchedBlockingClusterClient;
+    if (!client || this.disabledBlockingClusterReconnect) {
+      return;
+    }
+
+    client[clusterClosingRefCount] = (client[clusterClosingRefCount] || 0) + 1;
+    this.disabledBlockingClusterReconnect = true;
+  }
+
+  private releaseBlockingClusterClientPatch(): void {
     const client = this.patchedBlockingClusterClient;
     if (!client) {
+      return;
+    }
+
+    if (this.disabledBlockingClusterReconnect) {
+      const closingRefCount = (client[clusterClosingRefCount] || 1) - 1;
+      if (closingRefCount > 0) {
+        client[clusterClosingRefCount] = closingRefCount;
+      } else {
+        delete client[clusterClosingRefCount];
+      }
+      this.disabledBlockingClusterReconnect = false;
+    }
+
+    const patchRefCount = (client[clusterPatchRefCount] || 1) - 1;
+    if (patchRefCount > 0) {
+      client[clusterPatchRefCount] = patchRefCount;
+      this.patchedBlockingClusterClient = undefined;
       return;
     }
 
@@ -376,42 +417,50 @@ export class RedisConnection extends EventEmitter {
       client.bzpopmin = client[clusterOriginalBzpopmin];
     }
 
+    delete client[clusterPatchRefCount];
+    delete client[clusterClosingRefCount];
     delete client[clusterOriginalBzpopmin];
     delete client[clusterWrappedBzpopmin];
     delete client[clusterPatchedForBlocking];
     this.patchedBlockingClusterClient = undefined;
   }
 
-  private isClusterWithEmptyNodes(client: BlockingClusterClient): boolean {
+  private static isClusterWithEmptyNodes(
+    client: BlockingClusterClient,
+  ): boolean {
     return typeof client.nodes === 'function' && client.nodes().length === 0;
   }
 
-  private isReconnectingDisabled(client: BlockingClusterClient): boolean {
+  private static isReconnectingDisabled(
+    client: BlockingClusterClient,
+  ): boolean {
+    const patchRefCount = client[clusterPatchRefCount] || 0;
+    const closingRefCount = client[clusterClosingRefCount] || 0;
+
     return (
-      this.closing ||
-      this.status === 'closing' ||
-      this.status === 'closed' ||
+      patchRefCount === 0 ||
+      closingRefCount >= patchRefCount ||
       client.status === 'end' ||
       client.status === 'closing'
     );
   }
 
-  private async reconnectClusterIfNeeded(
+  private static async reconnectClusterIfNeeded(
     client: BlockingClusterClient,
   ): Promise<void> {
     if (
-      !this.isReconnectingDisabled(client) &&
-      this.isClusterWithEmptyNodes(client)
+      !RedisConnection.isReconnectingDisabled(client) &&
+      RedisConnection.isClusterWithEmptyNodes(client)
     ) {
-      await this.reconnectCluster(client);
+      await RedisConnection.reconnectCluster(client);
     }
   }
 
-  private shouldReconnectClusterAfterError(
+  private static shouldReconnectClusterAfterError(
     client: BlockingClusterClient,
     error: Error,
   ): boolean {
-    if (this.isReconnectingDisabled(client)) {
+    if (RedisConnection.isReconnectingDisabled(client)) {
       return false;
     }
 
@@ -422,13 +471,15 @@ export class RedisConnection extends EventEmitter {
     ].join(' ');
 
     return (
-      this.isClusterWithEmptyNodes(client) ||
+      RedisConnection.isClusterWithEmptyNodes(client) ||
       /Command timed out|Failed to refresh slots cache/i.test(message)
     );
   }
 
-  private async reconnectCluster(client: BlockingClusterClient): Promise<void> {
-    if (this.isReconnectingDisabled(client)) {
+  private static async reconnectCluster(
+    client: BlockingClusterClient,
+  ): Promise<void> {
+    if (RedisConnection.isReconnectingDisabled(client)) {
       return;
     }
 
@@ -485,6 +536,7 @@ export class RedisConnection extends EventEmitter {
       const status = this.status;
       this.status = 'closing';
       this.closing = true;
+      this.disableBlockingClusterReconnect();
 
       try {
         if (status === 'ready') {
@@ -506,7 +558,7 @@ export class RedisConnection extends EventEmitter {
           throw error;
         }
       } finally {
-        this.restoreBlockingClusterClient();
+        this.releaseBlockingClusterClientPatch();
         this._client.off('error', this.handleClientError);
         this._client.off('close', this.handleClientClose);
         this._client.off('ready', this.handleClientReady);

--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -26,6 +26,8 @@ const deprecationMessage =
 
 const clusterReconnectPromise = Symbol('bullmqClusterReconnectPromise');
 const clusterPatchedForBlocking = Symbol('bullmqClusterPatchedForBlocking');
+const clusterOriginalBzpopmin = Symbol('bullmqClusterOriginalBzpopmin');
+const clusterWrappedBzpopmin = Symbol('bullmqClusterWrappedBzpopmin');
 
 interface RedisCapabilities {
   canDoubleTimeout: boolean;
@@ -35,6 +37,8 @@ interface RedisCapabilities {
 interface BlockingClusterClient {
   [clusterReconnectPromise]?: Promise<void> | null;
   [clusterPatchedForBlocking]?: boolean;
+  [clusterOriginalBzpopmin]?: BlockingClusterClient['bzpopmin'];
+  [clusterWrappedBzpopmin]?: BlockingClusterClient['bzpopmin'];
   bzpopmin: (...args: any[]) => Promise<unknown>;
   connect: () => Promise<void>;
   disconnect: (reconnect?: boolean) => void;
@@ -72,6 +76,7 @@ export class RedisConnection extends EventEmitter {
   private handleClientError: (e: Error) => void;
   private handleClientClose: () => void;
   private handleClientReady: () => void;
+  private patchedBlockingClusterClient?: BlockingClusterClient;
 
   constructor(
     opts: ConnectionOptions,
@@ -330,13 +335,12 @@ export class RedisConnection extends EventEmitter {
       return;
     }
 
-    const bzpopmin = blockingClient.bzpopmin.bind(blockingClient);
-    blockingClient[clusterPatchedForBlocking] = true;
-    blockingClient.bzpopmin = async (...args: any[]) => {
+    const bzpopmin = blockingClient.bzpopmin;
+    const wrappedBzpopmin = async (...args: any[]) => {
       await this.reconnectClusterIfNeeded(blockingClient);
 
       try {
-        return await bzpopmin(...args);
+        return await bzpopmin.apply(blockingClient, args);
       } catch (error) {
         const commandError = error as Error;
         if (
@@ -351,6 +355,31 @@ export class RedisConnection extends EventEmitter {
         throw commandError;
       }
     };
+
+    blockingClient[clusterOriginalBzpopmin] = bzpopmin;
+    blockingClient[clusterWrappedBzpopmin] = wrappedBzpopmin;
+    blockingClient[clusterPatchedForBlocking] = true;
+    blockingClient.bzpopmin = wrappedBzpopmin;
+    this.patchedBlockingClusterClient = blockingClient;
+  }
+
+  private restoreBlockingClusterClient(): void {
+    const client = this.patchedBlockingClusterClient;
+    if (!client) {
+      return;
+    }
+
+    if (
+      client[clusterOriginalBzpopmin] &&
+      client.bzpopmin === client[clusterWrappedBzpopmin]
+    ) {
+      client.bzpopmin = client[clusterOriginalBzpopmin];
+    }
+
+    delete client[clusterOriginalBzpopmin];
+    delete client[clusterWrappedBzpopmin];
+    delete client[clusterPatchedForBlocking];
+    this.patchedBlockingClusterClient = undefined;
   }
 
   private isClusterWithEmptyNodes(client: BlockingClusterClient): boolean {
@@ -477,6 +506,7 @@ export class RedisConnection extends EventEmitter {
           throw error;
         }
       } finally {
+        this.restoreBlockingClusterClient();
         this._client.off('error', this.handleClientError);
         this._client.off('close', this.handleClientClose);
         this._client.off('ready', this.handleClientReady);

--- a/tests/connection.test.ts
+++ b/tests/connection.test.ts
@@ -121,6 +121,29 @@ describe('RedisConnection', () => {
       await connection.close(true);
     });
 
+    it('restores patched bzpopmin when a shared blocking cluster connection closes', async () => {
+      const bzpopmin = sinon.stub().resolves(['marker', '0', '1']);
+      const cluster = createMockClusterClient({ bzpopmin });
+      const originalBzpopmin = cluster.bzpopmin;
+      const connection = new RedisConnection(cluster as any, {
+        shared: true,
+        blocking: true,
+        skipVersionCheck: true,
+        skipWaitingForReady: true,
+      });
+
+      const client = await connection.client;
+      expect((client as any).bzpopmin).not.toBe(originalBzpopmin);
+
+      await connection.close();
+
+      expect(cluster.bzpopmin).toBe(originalBzpopmin);
+      await (cluster as any).bzpopmin('marker', 1);
+      expect(cluster.disconnect.called).toBe(false);
+      expect(cluster.connect.called).toBe(false);
+      expect(bzpopmin.calledOnceWith('marker', 1)).toBe(true);
+    });
+
     it('does not reconnect an empty-node blocking cluster while closing', async () => {
       const bzpopmin = sinon.stub().resolves(['marker', '0', '1']);
       const cluster = createMockClusterClient({

--- a/tests/connection.test.ts
+++ b/tests/connection.test.ts
@@ -121,6 +121,34 @@ describe('RedisConnection', () => {
       await connection.close(true);
     });
 
+    it('does not reconnect an empty-node blocking cluster while closing', async () => {
+      const bzpopmin = sinon.stub().resolves(['marker', '0', '1']);
+      const cluster = createMockClusterClient({
+        nodes: sinon.stub().returns([]),
+        bzpopmin,
+      });
+      const connection = new RedisConnection(cluster as any, {
+        blocking: true,
+        skipVersionCheck: true,
+        skipWaitingForReady: true,
+      });
+
+      const client = await connection.client;
+      (connection as any).closing = true;
+      (connection as any).status = 'closing';
+
+      const result = await (client as any).bzpopmin('marker', 1);
+
+      expect(cluster.disconnect.called).toBe(false);
+      expect(cluster.connect.called).toBe(false);
+      expect(bzpopmin.calledOnceWith('marker', 1)).toBe(true);
+      expect(result).toEqual(['marker', '0', '1']);
+
+      (connection as any).closing = false;
+      (connection as any).status = 'ready';
+      await connection.close(true);
+    });
+
     it('reconnects an ioredis cluster after bzpopmin command timeout', async () => {
       const error = new Error('Command timed out');
       const bzpopmin = sinon.stub().rejects(error);
@@ -136,6 +164,62 @@ describe('RedisConnection', () => {
       await expect((client as any).bzpopmin('marker', 1)).rejects.toThrow(
         'Command timed out',
       );
+      expect(cluster.disconnect.calledOnceWith(false)).toBe(true);
+      expect(cluster.connect.calledOnce).toBe(true);
+      expect(bzpopmin.calledOnceWith('marker', 1)).toBe(true);
+
+      await connection.close(true);
+    });
+
+    it('does not reconnect after bzpopmin command timeout while closing', async () => {
+      const error = new Error('Command timed out');
+      const bzpopmin = sinon.stub().rejects(error);
+      const cluster = createMockClusterClient({ bzpopmin });
+      const connection = new RedisConnection(cluster as any, {
+        blocking: true,
+        skipVersionCheck: true,
+        skipWaitingForReady: true,
+      });
+
+      const client = await connection.client;
+      (connection as any).closing = true;
+      (connection as any).status = 'closing';
+
+      await expect((client as any).bzpopmin('marker', 1)).rejects.toThrow(
+        'Command timed out',
+      );
+      expect(cluster.disconnect.called).toBe(false);
+      expect(cluster.connect.called).toBe(false);
+      expect(bzpopmin.calledOnceWith('marker', 1)).toBe(true);
+
+      (connection as any).closing = false;
+      (connection as any).status = 'ready';
+      await connection.close(true);
+    });
+
+    it('preserves the bzpopmin error when reconnect after command timeout fails', async () => {
+      const commandError = new Error('Command timed out');
+      const bzpopmin = sinon.stub().rejects(commandError);
+      const cluster = createMockClusterClient({
+        bzpopmin,
+        connect: sinon.stub().rejects(new Error('Cluster reconnect failed')),
+      });
+      const connection = new RedisConnection(cluster as any, {
+        blocking: true,
+        skipVersionCheck: true,
+        skipWaitingForReady: true,
+      });
+
+      const client = await connection.client;
+      let thrownError: unknown;
+
+      try {
+        await (client as any).bzpopmin('marker', 1);
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBe(commandError);
       expect(cluster.disconnect.calledOnceWith(false)).toBe(true);
       expect(cluster.connect.calledOnce).toBe(true);
       expect(bzpopmin.calledOnceWith('marker', 1)).toBe(true);

--- a/tests/connection.test.ts
+++ b/tests/connection.test.ts
@@ -23,6 +23,29 @@ import { removeAllQueueData } from '../src/utils';
 import * as sinon from 'sinon';
 
 describe('RedisConnection', () => {
+  function createMockClusterClient(overrides: Record<string, any> = {}) {
+    return {
+      isCluster: true,
+      status: 'ready',
+      options: { redisOptions: {} },
+      on: sinon.stub(),
+      once: sinon.stub(),
+      off: sinon.stub(),
+      removeListener: sinon.stub(),
+      getMaxListeners: sinon.stub().returns(10),
+      setMaxListeners: sinon.stub(),
+      connect: sinon.stub().resolves(),
+      disconnect: sinon.stub(),
+      duplicate: sinon.stub(),
+      quit: sinon.stub().resolves('OK'),
+      defineCommand: sinon.stub(),
+      info: sinon.stub().resolves('redis_version:7.0.0'),
+      nodes: sinon.stub().returns([{}]),
+      bzpopmin: sinon.stub().resolves(null),
+      ...overrides,
+    };
+  }
+
   describe('constructor', () => {
     it('initializes with default extraOptions when none provided', () => {
       const connection = new RedisConnection({});
@@ -69,6 +92,79 @@ describe('RedisConnection', () => {
         { blocking: false },
       );
       expect((connection as any).opts.maxRetriesPerRequest).toBe(10);
+    });
+
+    it('reconnects an ioredis cluster with an empty node pool before bzpopmin', async () => {
+      let hasNodes = false;
+      const bzpopmin = sinon.stub().resolves(['marker', '0', '1']);
+      const cluster = createMockClusterClient({
+        connect: sinon.stub().callsFake(async () => {
+          hasNodes = true;
+        }),
+        nodes: sinon.stub().callsFake(() => (hasNodes ? [{}] : [])),
+        bzpopmin,
+      });
+      const connection = new RedisConnection(cluster as any, {
+        blocking: true,
+        skipVersionCheck: true,
+        skipWaitingForReady: true,
+      });
+
+      const client = await connection.client;
+      const result = await (client as any).bzpopmin('marker', 1);
+
+      expect(cluster.disconnect.calledOnceWith(false)).toBe(true);
+      expect(cluster.connect.calledOnce).toBe(true);
+      expect(bzpopmin.calledOnceWith('marker', 1)).toBe(true);
+      expect(result).toEqual(['marker', '0', '1']);
+
+      await connection.close(true);
+    });
+
+    it('reconnects an ioredis cluster after bzpopmin command timeout', async () => {
+      const error = new Error('Command timed out');
+      const bzpopmin = sinon.stub().rejects(error);
+      const cluster = createMockClusterClient({ bzpopmin });
+      const connection = new RedisConnection(cluster as any, {
+        blocking: true,
+        skipVersionCheck: true,
+        skipWaitingForReady: true,
+      });
+
+      const client = await connection.client;
+
+      await expect((client as any).bzpopmin('marker', 1)).rejects.toThrow(
+        'Command timed out',
+      );
+      expect(cluster.disconnect.calledOnceWith(false)).toBe(true);
+      expect(cluster.connect.calledOnce).toBe(true);
+      expect(bzpopmin.calledOnceWith('marker', 1)).toBe(true);
+
+      await connection.close(true);
+    });
+
+    it('reconnects an ioredis cluster after slots refresh timeout', async () => {
+      const error = Object.assign(new Error('Failed to refresh slots cache.'), {
+        lastNodeError: new Error('Command timed out'),
+      });
+      const bzpopmin = sinon.stub().rejects(error);
+      const cluster = createMockClusterClient({ bzpopmin });
+      const connection = new RedisConnection(cluster as any, {
+        blocking: true,
+        skipVersionCheck: true,
+        skipWaitingForReady: true,
+      });
+
+      const client = await connection.client;
+
+      await expect((client as any).bzpopmin('marker', 1)).rejects.toThrow(
+        'Failed to refresh slots cache.',
+      );
+      expect(cluster.disconnect.calledOnceWith(false)).toBe(true);
+      expect(cluster.connect.calledOnce).toBe(true);
+      expect(bzpopmin.calledOnceWith('marker', 1)).toBe(true);
+
+      await connection.close(true);
     });
   });
 

--- a/tests/connection.test.ts
+++ b/tests/connection.test.ts
@@ -144,9 +144,45 @@ describe('RedisConnection', () => {
       expect(bzpopmin.calledOnceWith('marker', 1)).toBe(true);
     });
 
-    it('does not reconnect an empty-node blocking cluster while closing', async () => {
+    it('keeps patched bzpopmin until all shared blocking cluster connections close', async () => {
+      const bzpopmin = sinon.stub().resolves(['marker', '0', '1']);
+      const cluster = createMockClusterClient({ bzpopmin });
+      const originalBzpopmin = cluster.bzpopmin;
+      const connectionA = new RedisConnection(cluster as any, {
+        shared: true,
+        blocking: true,
+        skipVersionCheck: true,
+        skipWaitingForReady: true,
+      });
+
+      await connectionA.client;
+      const patchedBzpopmin = cluster.bzpopmin;
+      expect(patchedBzpopmin).not.toBe(originalBzpopmin);
+
+      const connectionB = new RedisConnection(cluster as any, {
+        shared: true,
+        blocking: true,
+        skipVersionCheck: true,
+        skipWaitingForReady: true,
+      });
+
+      await connectionB.client;
+      expect(cluster.bzpopmin).toBe(patchedBzpopmin);
+
+      await connectionA.close();
+      expect(cluster.bzpopmin).toBe(patchedBzpopmin);
+
+      await (cluster as any).bzpopmin('marker', 1);
+      expect(bzpopmin.calledOnceWith('marker', 1)).toBe(true);
+
+      await connectionB.close();
+      expect(cluster.bzpopmin).toBe(originalBzpopmin);
+    });
+
+    it('does not reconnect an empty-node blocking cluster while the client is closing', async () => {
       const bzpopmin = sinon.stub().resolves(['marker', '0', '1']);
       const cluster = createMockClusterClient({
+        status: 'closing',
         nodes: sinon.stub().returns([]),
         bzpopmin,
       });
@@ -157,8 +193,6 @@ describe('RedisConnection', () => {
       });
 
       const client = await connection.client;
-      (connection as any).closing = true;
-      (connection as any).status = 'closing';
 
       const result = await (client as any).bzpopmin('marker', 1);
 
@@ -167,8 +201,7 @@ describe('RedisConnection', () => {
       expect(bzpopmin.calledOnceWith('marker', 1)).toBe(true);
       expect(result).toEqual(['marker', '0', '1']);
 
-      (connection as any).closing = false;
-      (connection as any).status = 'ready';
+      cluster.status = 'ready';
       await connection.close(true);
     });
 
@@ -196,28 +229,27 @@ describe('RedisConnection', () => {
 
     it('does not reconnect after bzpopmin command timeout while closing', async () => {
       const error = new Error('Command timed out');
-      const bzpopmin = sinon.stub().rejects(error);
+      let connection!: RedisConnection;
+      const bzpopmin = sinon.stub().callsFake(async () => {
+        await connection.close(true);
+        throw error;
+      });
       const cluster = createMockClusterClient({ bzpopmin });
-      const connection = new RedisConnection(cluster as any, {
+      connection = new RedisConnection(cluster as any, {
         blocking: true,
         skipVersionCheck: true,
         skipWaitingForReady: true,
       });
 
       const client = await connection.client;
-      (connection as any).closing = true;
-      (connection as any).status = 'closing';
 
       await expect((client as any).bzpopmin('marker', 1)).rejects.toThrow(
         'Command timed out',
       );
-      expect(cluster.disconnect.called).toBe(false);
+      expect(cluster.disconnect.calledOnce).toBe(true);
+      expect(cluster.disconnect.calledWith(false)).toBe(false);
       expect(cluster.connect.called).toBe(false);
       expect(bzpopmin.calledOnceWith('marker', 1)).toBe(true);
-
-      (connection as any).closing = false;
-      (connection as any).status = 'ready';
-      await connection.close(true);
     });
 
     it('preserves the bzpopmin error when reconnect after command timeout fails', async () => {


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.

  PR TITLE FORMAT
  ───────────────
  We use Conventional Commits: <type>(<scope>): <description>

  If your change affects one or more ports, append a tag at the end of the
  PR title (outside the conventional-commit part) to indicate their status:

    [python] / [elixir] / [php]
      → The change is ONLY relevant to that port (Node.js is NOT affected).
        Multiple ports can be listed: [python][elixir]

    (python) / (elixir) / (php)
      → The change affects that port AND Node.js.
        Multiple ports can be listed: (python)(php)

  Examples:
    fix(worker): handle stalled jobs correctly (python)(elixir)
    docs: update rate-limiting guide [python]
    feat(queue): add group priority support

  Please check all three ports below before setting your title.
-->

### Port Impact Checklist
<!--
  Review each port and tick every box that applies.
  If a port is not affected at all, leave its box unchecked.
-->

- [ ] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
There seems to be an issue in IORedis when handling Cluster disconnects that is affecting workers in the sense that they stop consuming jobs. This PR provides a workaround that hopefully eliminates this issue.

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
We patch ioredis to force a reconnection in the case of errors.

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
Hopefully fixes this issue: https://github.com/taskforcesh/bullmq-pro-support/issues/136