### PR TITLE
docs: update bullmq-pro changelog for version v7.46.0

### DIFF
--- a/docs/gitbook/bullmq-pro/changelog.md
+++ b/docs/gitbook/bullmq-pro/changelog.md
@@ -1,3 +1,10 @@
+# [7.46.0](https://github.com/taskforcesh/bullmq-pro/compare/v7.45.1...v7.46.0) (2026-05-21)
+
+
+### Features
+
+* add support for both group concurrency and group rate limit ([#428](https://github.com/taskforcesh/bullmq-pro/issues/428)) ([ede5aa3](https://github.com/taskforcesh/bullmq-pro/commit/ede5aa385f6c7df1edcfccb15e0e064a1798f604))
+
 ## [7.45.1](https://github.com/taskforcesh/bullmq-pro/compare/v7.45.0...v7.45.1) (2026-05-07)
 
 


### PR DESCRIPTION
Automated update of BullMQ Pro changelog for version v7.46.0

  This PR updates the BullMQ Pro changelog with the latest release notes.