### PR TITLE
fix(connection): handle cluster reconnection with timeouts

### DIFF
--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -582,10 +582,11 @@ export class RedisConnection extends EventEmitter {
         new Promise<never>((_, reject) => {
           timeoutHandle = setTimeout(() => {
             reject(
-              new Error(
+              new ConnectionClosedError(
                 `BullMQ: cluster reconnect timed out after ${timeoutMs}ms`,
               ),
             );
+          }, timeoutMs);
           }, timeoutMs);
           // Don't keep the event loop alive solely for this timer.
           timeoutHandle.unref?.();

--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -587,7 +587,6 @@ export class RedisConnection extends EventEmitter {
               ),
             );
           }, timeoutMs);
-          }, timeoutMs);
           // Don't keep the event loop alive solely for this timer.
           timeoutHandle.unref?.();
         }),

--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -34,6 +34,14 @@ const clusterWrappedBzpopmin = Symbol('bullmqClusterWrappedBzpopmin');
 const clusterPatchRefCount = Symbol('bullmqClusterPatchRefCount');
 const clusterClosingRefCount = Symbol('bullmqClusterClosingRefCount');
 
+// Hard cap on a single cluster reconnect attempt. Without this, a hung
+// `client.connect()` (e.g. ioredis Cluster cannot recover and slot refresh
+// keeps retrying internally) leaves `clusterReconnectPromise` pinned forever
+// and every subsequent bzpopmin call awaits the same dead promise, deadlocking
+// the worker. 30s is comfortably above the default ioredis slotsRefreshTimeout
+// while bounded enough that wedged workers recover within one or two ticks.
+const DEFAULT_CLUSTER_RECONNECT_TIMEOUT_MS = 30_000;
+
 interface RedisCapabilities {
   canDoubleTimeout: boolean;
   canBlockFor1Ms: boolean;
@@ -117,6 +125,7 @@ export class RedisConnection extends EventEmitter {
       blocking?: boolean;
       skipVersionCheck?: boolean;
       skipWaitingForReady?: boolean;
+      clusterReconnectTimeoutMs?: number;
     },
   ) {
     super();
@@ -127,6 +136,7 @@ export class RedisConnection extends EventEmitter {
       blocking: true,
       skipVersionCheck: false,
       skipWaitingForReady: false,
+      clusterReconnectTimeoutMs: DEFAULT_CLUSTER_RECONNECT_TIMEOUT_MS,
       ...extraOptions,
     };
 
@@ -385,6 +395,10 @@ export class RedisConnection extends EventEmitter {
       return;
     }
 
+    const reconnectTimeoutMs =
+      this.extraOptions.clusterReconnectTimeoutMs ??
+      DEFAULT_CLUSTER_RECONNECT_TIMEOUT_MS;
+
     blockingClient[clusterPatchRefCount] =
       (blockingClient[clusterPatchRefCount] || 0) + 1;
     this.patchedBlockingClusterClient = blockingClient;
@@ -395,7 +409,10 @@ export class RedisConnection extends EventEmitter {
 
     const bzpopmin = blockingClient.bzpopmin;
     const wrappedBzpopmin = async (...args: any[]) => {
-      await RedisConnection.reconnectClusterIfNeeded(blockingClient);
+      await RedisConnection.reconnectClusterIfNeeded(
+        blockingClient,
+        reconnectTimeoutMs,
+      );
 
       try {
         return await bzpopmin.apply(blockingClient, args);
@@ -408,7 +425,10 @@ export class RedisConnection extends EventEmitter {
           )
         ) {
           try {
-            await RedisConnection.reconnectCluster(blockingClient);
+            await RedisConnection.reconnectCluster(
+              blockingClient,
+              reconnectTimeoutMs,
+            );
           } catch {
             // Preserve the original command failure if best-effort recovery fails.
           }
@@ -493,12 +513,13 @@ export class RedisConnection extends EventEmitter {
 
   private static async reconnectClusterIfNeeded(
     client: BlockingClusterClient,
+    timeoutMs: number,
   ): Promise<void> {
     if (
       !RedisConnection.isReconnectingDisabled(client) &&
       RedisConnection.isClusterWithEmptyNodes(client)
     ) {
-      await RedisConnection.reconnectCluster(client);
+      await RedisConnection.reconnectCluster(client, timeoutMs);
     }
   }
 
@@ -524,21 +545,57 @@ export class RedisConnection extends EventEmitter {
 
   private static async reconnectCluster(
     client: BlockingClusterClient,
+    timeoutMs: number,
   ): Promise<void> {
     if (RedisConnection.isReconnectingDisabled(client)) {
       return;
     }
 
     if (!client[clusterReconnectPromise]) {
-      client[clusterReconnectPromise] = (async () => {
-        client.disconnect(false);
-        await client.connect();
-      })().finally(() => {
-        client[clusterReconnectPromise] = null;
-      });
+      client[clusterReconnectPromise] =
+        RedisConnection.connectClusterWithTimeout(client, timeoutMs).finally(
+          () => {
+            client[clusterReconnectPromise] = null;
+          },
+        );
     }
 
     await client[clusterReconnectPromise];
+  }
+
+  // Disconnects and reconnects a cluster client, racing connect() against a
+  // hard cap so a hung reconnect cannot pin `clusterReconnectPromise`
+  // indefinitely. On timeout, the underlying connect() is left running
+  // (ioredis Cluster handles its own retry/state); we simply stop awaiting it.
+  // The next bzpopmin call's `reconnectClusterIfNeeded` check will trigger a
+  // fresh reconnect if the pool is still empty.
+  private static async connectClusterWithTimeout(
+    client: BlockingClusterClient,
+    timeoutMs: number,
+  ): Promise<void> {
+    client.disconnect(false);
+
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        client.connect(),
+        new Promise<never>((_, reject) => {
+          timeoutHandle = setTimeout(() => {
+            reject(
+              new Error(
+                `BullMQ: cluster reconnect timed out after ${timeoutMs}ms`,
+              ),
+            );
+          }, timeoutMs);
+          // Don't keep the event loop alive solely for this timer.
+          timeoutHandle.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+    }
   }
 
   async disconnect(wait = true): Promise<void> {

--- a/tests/connection.test.ts
+++ b/tests/connection.test.ts
@@ -62,6 +62,7 @@ describe('RedisConnection', () => {
         blocking: true,
         skipVersionCheck: false,
         skipWaitingForReady: false,
+        clusterReconnectTimeoutMs: 30_000,
       });
     });
 
@@ -310,6 +311,73 @@ describe('RedisConnection', () => {
       expect(cluster.disconnect.calledOnceWith(false)).toBe(true);
       expect(cluster.connect.calledOnce).toBe(true);
       expect(bzpopmin.calledOnceWith('marker', 1)).toBe(true);
+
+      await connection.close(true);
+    });
+
+    // Regression for a deadlock observed in production after upgrading to
+    // bullmq 5.76.6: when ioredis Cluster cannot recover (slot refresh keeps
+    // retrying internally) `client.connect()` never resolves, the cached
+    // `clusterReconnectPromise` stays pinned, and every subsequent bzpopmin
+    // call awaits the same dead promise — leaving the worker permanently
+    // wedged with `isRunning: true`.
+    it('throws a timeout error when cluster reconnect hangs longer than clusterReconnectTimeoutMs', async () => {
+      const bzpopmin = sinon.stub().resolves(['marker', '0', '1']);
+      const cluster = createMockClusterClient({
+        // connect() never resolves: simulates ioredis Cluster stuck retrying
+        // slot refresh internally.
+        connect: sinon.stub().returns(new Promise<void>(() => {})),
+        nodes: sinon.stub().returns([]), // empty pool triggers pre-call reconnect
+        bzpopmin,
+      });
+      const connection = new RedisConnection(cluster as any, {
+        blocking: true,
+        skipVersionCheck: true,
+        skipWaitingForReady: true,
+        clusterReconnectTimeoutMs: 50,
+      });
+
+      const client = await connection.client;
+
+      await expect((client as any).bzpopmin('marker', 1)).rejects.toThrow(
+        /cluster reconnect timed out after 50ms/i,
+      );
+      expect(cluster.disconnect.calledOnceWith(false)).toBe(true);
+      expect(cluster.connect.calledOnce).toBe(true);
+      // bzpopmin must NOT be invoked when the pre-call reconnect times out;
+      // otherwise it would block on the same dead cluster state.
+      expect(bzpopmin.called).toBe(false);
+
+      await connection.close(true);
+    });
+
+    it('clears the cached reconnect promise after a timeout so subsequent calls can retry', async () => {
+      const bzpopmin = sinon.stub().resolves(['marker', '0', '1']);
+      const cluster = createMockClusterClient({
+        connect: sinon.stub().returns(new Promise<void>(() => {})),
+        nodes: sinon.stub().returns([]),
+        bzpopmin,
+      });
+      const connection = new RedisConnection(cluster as any, {
+        blocking: true,
+        skipVersionCheck: true,
+        skipWaitingForReady: true,
+        clusterReconnectTimeoutMs: 50,
+      });
+
+      const client = await connection.client;
+
+      await expect((client as any).bzpopmin('marker', 1)).rejects.toThrow(
+        /cluster reconnect timed out/i,
+      );
+      await expect((client as any).bzpopmin('marker', 1)).rejects.toThrow(
+        /cluster reconnect timed out/i,
+      );
+
+      // The second bzpopmin must trigger a fresh disconnect + connect rather
+      // than awaiting the dead promise from the first attempt.
+      expect(cluster.disconnect.callCount).toBe(2);
+      expect(cluster.connect.callCount).toBe(2);
 
       await connection.close(true);
     });


### PR DESCRIPTION
<!--
  Thank you for submitting a PR!
  Please fill out all sections below to help us understand your changes.

  PR TITLE FORMAT
  ───────────────
  We use Conventional Commits: <type>(<scope>): <description>

  If your change affects one or more ports, append a tag at the end of the
  PR title (outside the conventional-commit part) to indicate their status:

    [python] / [elixir] / [php]
      → The change is ONLY relevant to that port (Node.js is NOT affected).
        Multiple ports can be listed: [python][elixir]

    (python) / (elixir) / (php)
      → The change affects that port AND Node.js.
        Multiple ports can be listed: (python)(php)

  Examples:
    fix(worker): handle stalled jobs correctly (python)(elixir)
    docs: update rate-limiting guide [python]
    feat(queue): add group priority support

  Please check all three ports below before setting your title.
-->

### Port Impact Checklist

<!--
  Review each port and tick every box that applies.
  If a port is not affected at all, leave its box unchecked.
-->

- [ ] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?

### Why

<!--
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->

_Enter your explanation here._

### How

<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->

_Enter the implementation details here._

### Additional Notes (Optional)

<!--
  Use this space for additional considerations:
  - Potential side effects
  - Dependencies
  - Testing instructions
  - Anything else reviewers should know
-->

fixes https://github.com/taskforcesh/bullmq-pro-support/issues/136