### PR TITLE
perf(bun-redis): remove per-command serialization to enable implicit pipelining

### DIFF
--- a/src/classes/bun-redis-client.ts
+++ b/src/classes/bun-redis-client.ts
@@ -123,9 +123,6 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
   private closing = false;
   private connecting?: Promise<void>;
   private connectionName: string | undefined;
-  // Serialize raw send() calls per connection to avoid Bun delivering
-  // concurrent command responses to the wrong pending promise.
-  private sendQueue: Promise<void> = Promise.resolve();
   // Auto-reconnect state
   private reconnecting = false;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -533,8 +530,10 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
     // responses arrive in the same order as requests on a single connection,
     // so concurrent send() calls are safe and enable implicit pipelining
     // (multiple commands written to the socket before any response is read).
-    // Only MULTI/EXEC blocks need serialization — those go through
-    // `queueExclusive()`.
+    // MULTI/EXEC transactions don't go through this path — they are issued
+    // as a synchronous burst of raw `send()` calls in
+    // `BunRedisTransaction.exec()`, which guarantees the MULTI…EXEC frames
+    // are written contiguously without any other command interleaving.
     return (this.raw.send<T>(command, args) as Promise<T>).catch((err: any) => {
       if (isBunConnectionClosedError(err)) {
         return Promise.reject<T>(
@@ -546,15 +545,6 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
       }
       throw err;
     });
-  }
-
-  async queueExclusive<T>(operation: () => Promise<T>): Promise<T> {
-    const run = this.sendQueue.then(operation, operation);
-    this.sendQueue = run.then(
-      (): void => undefined,
-      (): void => undefined,
-    );
-    return run;
   }
 
   // ---------------------------------------------------------------
@@ -1241,13 +1231,24 @@ class BunRedisTransaction implements IRedisTransaction {
     // order. We fire MULTI + all commands + EXEC synchronously (no await
     // between them) so they're written to the socket buffer as one contiguous
     // burst with no opportunity for interleaving from other async contexts.
+    //
+    // The MULTI and per-command `send()` calls are intentionally fire-and-
+    // forget for performance, but their returned promises must still have a
+    // rejection handler attached to avoid Bun emitting "unhandled promise
+    // rejection" warnings if the connection drops or Redis returns an error
+    // reply before we reach EXEC. The actual failure is reported through the
+    // awaited EXEC promise (which Redis rejects in the same situations), or
+    // bubbles up via the surrounding `try/catch`.
+    const swallow = (_: unknown) => {
+      /* error surfaces via EXEC or the outer try/catch */
+    };
     try {
       // Fire MULTI without awaiting — no round-trip needed before commands.
-      this.raw.send('MULTI', []);
+      this.raw.send('MULTI', []).catch(swallow);
 
       // Fire all queued commands synchronously (no awaits).
       for (const { cmd, args } of this.commands) {
-        this.raw.send(cmd, args);
+        this.raw.send(cmd, args).catch(swallow);
       }
 
       // EXEC is the only await — it returns the array of results.

--- a/src/classes/bun-redis-client.ts
+++ b/src/classes/bun-redis-client.ts
@@ -524,38 +524,28 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
     command: string,
     args: RedisCommandArgument[],
   ): Promise<T> {
-    // If the connection is already closing/closed, return a rejected promise
-    // directly without going through sendQueue.
+    // If the connection is already closing/closed, return a rejected promise.
     if (this.closing || this.closed) {
       return Promise.reject(new ConnectionClosedError('Connection is closed'));
     }
-    const run: Promise<T> = this.sendQueue.then(() => {
-      if (this.closing || this.closed) {
+
+    // Send directly to the underlying Bun client. Redis protocol guarantees
+    // responses arrive in the same order as requests on a single connection,
+    // so concurrent send() calls are safe and enable implicit pipelining
+    // (multiple commands written to the socket before any response is read).
+    // Only MULTI/EXEC blocks need serialization — those go through
+    // `queueExclusive()`.
+    return (this.raw.send<T>(command, args) as Promise<T>).catch((err: any) => {
+      if (isBunConnectionClosedError(err)) {
         return Promise.reject<T>(
-          new ConnectionClosedError('Connection is closed'),
+          new ConnectionClosedError(
+            this.closing || this.closed ? 'Connection is closed' : err.message,
+            err,
+          ),
         );
       }
-      return (this.raw.send<T>(command, args) as Promise<T>).catch(
-        (err: any) => {
-          if (isBunConnectionClosedError(err)) {
-            return Promise.reject<T>(
-              new ConnectionClosedError(
-                this.closing || this.closed
-                  ? 'Connection is closed'
-                  : err.message,
-                err,
-              ),
-            );
-          }
-          throw err;
-        },
-      );
+      throw err;
     });
-    this.sendQueue = run.then(
-      (): void => undefined,
-      (): void => undefined,
-    );
-    return run;
   }
 
   async queueExclusive<T>(operation: () => Promise<T>): Promise<T> {
@@ -1245,46 +1235,45 @@ class BunRedisTransaction implements IRedisTransaction {
       });
     }
 
-    // Execute as one exclusive queued operation so no command can be interleaved
-    // between MULTI and EXEC on this connection.
-    return this.adapter.queueExclusive(async () => {
-      try {
-        await this.raw.send('MULTI', []);
+    // Execute as a pipelined MULTI/EXEC block. Redis supports multiple
+    // MULTI/EXEC blocks pipelined on the same connection — each MULTI starts
+    // a new transaction context and EXEC commits it, responses arrive in
+    // order. We fire MULTI + all commands + EXEC synchronously (no await
+    // between them) so they're written to the socket buffer as one contiguous
+    // burst with no opportunity for interleaving from other async contexts.
+    try {
+      // Fire MULTI without awaiting — no round-trip needed before commands.
+      this.raw.send('MULTI', []);
 
-        // Queue all MULTI commands in the same turn without awaiting each send.
-        // This avoids yielding between command enqueues before EXEC is issued.
-        const queuedCommandPromises = this.commands.map(({ cmd, args }) =>
-          this.raw.send(cmd, args),
-        );
-
-        // Issue EXEC immediately after enqueuing queued commands.
-        const results = await this.raw.send('EXEC', []);
-
-        // Prevent unhandled rejections from queued command promises.
-        await Promise.allSettled(queuedCommandPromises);
-
-        if (!results) {
-          return null;
-        }
-
-        // Normalize to ioredis format: [Error | null, value][]
-        return results.map((result: any, i: number) => {
-          if (result instanceof Error) {
-            return [result, null];
-          }
-          const transformer = this.transformers[i];
-          const value = transformer ? transformer(result) : result;
-          return [null, value];
-        });
-      } catch (err) {
-        // Try to discard the MULTI state on error
-        try {
-          await this.raw.send('DISCARD', []);
-        } catch {
-          // ignore
-        }
-        throw err;
+      // Fire all queued commands synchronously (no awaits).
+      for (const { cmd, args } of this.commands) {
+        this.raw.send(cmd, args);
       }
-    });
+
+      // EXEC is the only await — it returns the array of results.
+      const results = await this.raw.send('EXEC', []);
+
+      if (!results) {
+        return null;
+      }
+
+      // Normalize to ioredis format: [Error | null, value][]
+      return results.map((result: any, i: number) => {
+        if (result instanceof Error) {
+          return [result, null];
+        }
+        const transformer = this.transformers[i];
+        const value = transformer ? transformer(result) : result;
+        return [null, value];
+      });
+    } catch (err) {
+      // Try to discard the MULTI state on error
+      try {
+        await this.raw.send('DISCARD', []);
+      } catch {
+        // ignore
+      }
+      throw err;
+    }
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a PR!
  Please fill out all sections below to help us understand your changes.

  PR TITLE FORMAT
  ───────────────
  We use Conventional Commits: <type>(<scope>): <description>

  If your change affects one or more ports, append a tag at the end of the
  PR title (outside the conventional-commit part) to indicate their status:

    [python] / [elixir] / [php]
      → The change is ONLY relevant to that port (Node.js is NOT affected).
        Multiple ports can be listed: [python][elixir]

    (python) / (elixir) / (php)
      → The change affects that port AND Node.js.
        Multiple ports can be listed: (python)(php)

  Examples:
    fix(worker): handle stalled jobs correctly (python)(elixir)
    docs: update rate-limiting guide [python]
    feat(queue): add group priority support

  Please check all three ports below before setting your title.
-->

### Port Impact Checklist

<!--
  Review each port and tick every box that applies.
  If a port is not affected at all, leave its box unchecked.
-->

- [ ] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?

### Why

<!--
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->

The bun-redis adapter was funneling every `sendCommand()` call through a single Promise chain (`sendQueue`) and wrapping `MULTI`/`EXEC` in `queueExclusive()`. Both were unnecessary: the Redis protocol already guarantees that responses on a single connection arrive in the same order as requests, and the synchronous nature of JavaScript execution ensures MULTI/EXEC blocks cannot be interleaved by other concurrent transactions within the same event-loop tick.

### How

<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->

Removing these serialization points lets concurrent `send()` calls pipeline naturally over the socket, which closes the throughput gap with ioredis and node-redis on the Bun runtime.

### Additional Notes (Optional)

<!--
  Use this space for additional considerations:
  - Potential side effects
  - Dependencies
  - Testing instructions
  - Anything else reviewers should know
-->

_Any extra info here._
