### PR TITLE
fix(deduplication): preserve custom jobId when requeuing keepLastIfActive proto-jobs (#4179)

### DIFF
--- a/src/commands/includes/requeueDeduplicatedJob.lua
+++ b/src/commands/includes/requeueDeduplicatedJob.lua
@@ -17,9 +17,17 @@ local function requeueDeduplicatedJob(prefix, deduplicationId, eventStreamKey,
   local deduplicationNextKey = prefix .. "dn:" .. deduplicationId
   if rcall("EXISTS", deduplicationNextKey) == 1 then
     local nextData = rcall("HMGET", deduplicationNextKey,
-        "name", "data", "opts", "pk", "pd", "pdk", "rjk")
+        "name", "data", "opts", "pk", "pd", "pdk", "rjk", "jid")
 
-    local newJobId = rcall("INCR", prefix .. "id") .. ""
+    -- Always increment the counter to keep it monotonic
+    local nextId = rcall("INCR", prefix .. "id") .. ""
+    local storedJobId = nextData[8] -- index 8 = "jid" (8th field in the HMGET call above)
+    local newJobId
+    if storedJobId then
+      newJobId = storedJobId
+    else
+      newJobId = nextId
+    end
     local newJobIdKey = prefix .. newJobId
     local newOpts = cjson.decode(nextData[3])
     local deduplicationKey = prefix .. "de:" .. deduplicationId

--- a/src/commands/includes/storeDeduplicatedNextJob.lua
+++ b/src/commands/includes/storeDeduplicatedNextJob.lua
@@ -14,7 +14,8 @@ local function storeDeduplicatedNextJob(deduplicationOpts, currentDebounceJobId,
         local activeItems = rcall('LRANGE', activeKey, 0, -1)
         if checkItemInList(activeItems, currentDebounceJobId) then
             local deduplicationNextKey = prefix .. "dn:" .. deduplicationId
-            local fields = {'name', jobName, 'data', jobData, 'opts', cjson.encode(fullOpts)}
+            local fields = {'name', jobName, 'data', jobData, 'opts', cjson.encode(fullOpts),
+                'jid', jobId}
 
             if parentKey then
                 fields[#fields+1] = 'pk'

--- a/src/commands/includes/storeDeduplicatedNextJob.lua
+++ b/src/commands/includes/storeDeduplicatedNextJob.lua
@@ -37,6 +37,7 @@ local function storeDeduplicatedNextJob(deduplicationOpts, currentDebounceJobId,
                 fields[#fields+1] = repeatJobKey
             end
 
+            rcall('DEL', deduplicationNextKey)
             rcall('HSET', deduplicationNextKey, unpack(fields))
 
             -- Ensure the dedup key does not expire while the job is active,

--- a/tests/deduplication.test.ts
+++ b/tests/deduplication.test.ts
@@ -2099,5 +2099,79 @@ describe('deduplication', () => {
 
       await worker.close();
     });
+
+    it('should preserve custom jobId when requeuing proto-job', async () => {
+      const testName = 'test';
+      const deduplicationId = 'dedup-custom-id-1';
+      const processedJobs: { id: string | undefined; data: any }[] = [];
+
+      let resolveFirstProcessing: () => void;
+      const firstProcessingStarted = new Promise<void>(resolve => {
+        resolveFirstProcessing = resolve;
+      });
+
+      const worker = new Worker(
+        queueName,
+        async job => {
+          if (processedJobs.length === 0) {
+            resolveFirstProcessing();
+            await delay(500);
+          }
+          processedJobs.push({ id: job.id, data: job.data });
+        },
+        { autorun: false, connection, prefix },
+      );
+      await worker.waitUntilReady();
+
+      const allCompleted = new Promise<void>(resolve => {
+        let count = 0;
+        worker.on('completed', () => {
+          count++;
+          if (count === 2) {
+            resolve();
+          }
+        });
+      });
+
+      worker.run();
+
+      // Add first job with a custom jobId
+      await queue.add(
+        testName,
+        { seq: 1 },
+        {
+          jobId: 'my-custom-uuid-1',
+          deduplication: {
+            id: deduplicationId,
+            keepLastIfActive: true,
+          },
+        },
+      );
+
+      await firstProcessingStarted;
+
+      // Add second job with a different custom jobId while first is active
+      await queue.add(
+        testName,
+        { seq: 2 },
+        {
+          jobId: 'my-custom-uuid-2',
+          deduplication: {
+            id: deduplicationId,
+            keepLastIfActive: true,
+          },
+        },
+      );
+
+      await allCompleted;
+
+      expect(processedJobs).toHaveLength(2);
+      expect(processedJobs[0].id).toBe('my-custom-uuid-1');
+      expect(processedJobs[0].data).toEqual({ seq: 1 });
+      expect(processedJobs[1].id).toBe('my-custom-uuid-2');
+      expect(processedJobs[1].data).toEqual({ seq: 2 });
+
+      await worker.close();
+    });
   });
 });


### PR DESCRIPTION
### Port Impact Checklist

- [ ] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?

### Why

`requeueDeduplicatedJob` always generated a new sequential ID via `INCR` when promoting a proto-job, ignoring any custom `jobId` supplied in the original `queue.add()` call. This was a separate fix isolated from #4170 per reviewer request.

### How

- **`storeDeduplicatedNextJob.lua`** — stores the `jobId` as a `jid` field in the dedup-next hash (`dn:<deduplicationId>`) alongside the other proto-job fields, so it is available when the active job completes.
- **`requeueDeduplicatedJob.lua`** — reads `jid` (8th field in `HMGET`) and uses it as the requeued job's ID. Always calls `INCR` to keep the counter monotonic; the incremented value is only used as fallback for proto-jobs created before this field existed.

```lua
-- Always increment the counter to keep it monotonic
local nextId = rcall("INCR", prefix .. "id") .. ""
local storedJobId = nextData[8] -- index 8 = "jid"
local newJobId
if storedJobId then
  newJobId = storedJobId
else
  newJobId = nextId
end
```

- **`tests/deduplication.test.ts`** — adds `should preserve custom jobId when requeuing proto-job`, which verifies end-to-end that both custom `jobId` values are preserved through the full dedup-next cycle when `keepLastIfActive` is used.

### Additional Notes (Optional)

All 33 deduplication tests pass.