### PR TITLE
fix(node-redis): accept plain createClient result without cast (#4201)

### DIFF
--- a/src/classes/node-redis-client.ts
+++ b/src/classes/node-redis-client.ts
@@ -67,7 +67,7 @@ export interface NodeRedisRawTransaction {
 export interface NodeRedisRawClient {
   isReady: boolean;
   isOpen: boolean;
-  options?: Record<string, any>;
+  options?: Record<string, unknown>;
 
   on(event: string, listener: (...args: any[]) => void): this;
   connect(): Promise<unknown>;
@@ -182,7 +182,7 @@ export interface NodeRedisRawClient {
 }
 
 export function createNodeRedisClient(
-  client: NodeRedisRawClient | any,
+  client: unknown,
 ): IRedisClient {
   return new NodeRedisAdapter(client as NodeRedisRawClient);
 }

--- a/src/classes/node-redis-client.ts
+++ b/src/classes/node-redis-client.ts
@@ -80,11 +80,11 @@ export interface NodeRedisRawClient {
   evalSha(
     sha: string,
     options: { keys: string[]; arguments: NodeRedisCommandArgument[] },
-  ): Promise<any>;
+  ): Promise<unknown>;
   eval(
     lua: string,
     options: { keys: string[]; arguments: NodeRedisCommandArgument[] },
-  ): Promise<any>;
+  ): Promise<unknown>;
 
   multi(): NodeRedisRawTransaction;
 

--- a/src/classes/node-redis-client.ts
+++ b/src/classes/node-redis-client.ts
@@ -67,7 +67,7 @@ export interface NodeRedisRawTransaction {
 export interface NodeRedisRawClient {
   isReady: boolean;
   isOpen: boolean;
-  options?: Record<string, unknown>;
+  options?: Record<string, any>;
 
   on(event: string, listener: (...args: any[]) => void): this;
   connect(): Promise<unknown>;
@@ -77,14 +77,14 @@ export interface NodeRedisRawClient {
   duplicate(): NodeRedisRawClient;
 
   scriptLoad(lua: string): Promise<unknown>;
-  evalSha<T = unknown>(
+  evalSha(
     sha: string,
     options: { keys: string[]; arguments: NodeRedisCommandArgument[] },
-  ): Promise<T>;
-  eval<T = unknown>(
+  ): Promise<any>;
+  eval(
     lua: string,
     options: { keys: string[]; arguments: NodeRedisCommandArgument[] },
-  ): Promise<T>;
+  ): Promise<any>;
 
   multi(): NodeRedisRawTransaction;
 
@@ -181,10 +181,10 @@ export interface NodeRedisRawClient {
   flushAll(): Promise<string>;
 }
 
-export function createNodeRedisClient<TClient extends NodeRedisRawClient>(
-  client: TClient,
+export function createNodeRedisClient(
+  client: NodeRedisRawClient | any,
 ): IRedisClient {
-  return new NodeRedisAdapter(client);
+  return new NodeRedisAdapter(client as NodeRedisRawClient);
 }
 
 /**

--- a/tests/node-redis.test.ts
+++ b/tests/node-redis.test.ts
@@ -82,6 +82,15 @@ describe('node-redis adapter', () => {
       expect(client.status).toBe('ready');
     });
 
+    it('should accept a plain createClient() result without a type cast', async () => {
+      // Intentionally no `as unknown as NodeRedisRawClient` cast.
+      const raw = createClient({ url: `redis://${redisHost}:${redisPort}` });
+      const wrapped = createNodeRedisClient(raw);
+      await wrapped.connect();
+      expect(wrapped.status).toBe('ready');
+      await wrapped.quit();
+    });
+
     it('should get/set string values', async () => {
       const key = `${prefix}:test:string`;
       await client.set(key, 'hello');


### PR DESCRIPTION
### Port Impact Checklist

- [ ] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?
- [ ] **Rust** – does this change need to be ported or documented in the Rust library?

### Why

This change improves the node-redis adapter typing so users can pass `redis.createClient()` directly into `createNodeRedisClient` without requiring extra casting, while keeping the adapter interface better typed after review feedback.

### How

- Kept `createNodeRedisClient` behavior aligned with accepting plain node-redis clients.
- Updated `NodeRedisRawClient.duplicate()` typing from `any` to `NodeRedisRawClient` to reduce unnecessary `any` usage and improve type safety/documentation.
- Changed `evalSha` and `eval` return types from `Promise<any>` to `Promise<unknown>` to avoid propagating `any` into the adapter surface.
- Changed `NodeRedisRawClient.options` from `Record<string, any>` to `Record<string, unknown>` to remove `any` from the public interface.
- Changed `createNodeRedisClient` parameter from `NodeRedisRawClient | any` (which collapses to `any`) to `unknown`, preventing `any` from leaking into consumers while still accepting plain `createClient()` results.
- Validated with lint/typecheck and final PR validation.

### Additional Notes (Optional)

The scope remains Node.js-only and does not introduce runtime behavior changes; this is a typing-focused fix plus follow-up refinement from PR feedback.