### PR TITLE
ci(release): consider slashes when ignoring commits

### DIFF
--- a/docs/gitbook/changelog.md
+++ b/docs/gitbook/changelog.md
@@ -1,5 +1,10 @@
 # [5.79.0](https://github.com/taskforcesh/bullmq/compare/v5.78.1...v5.79.0) (2026-06-18)
 
+
+### Features
+
+* Nothing changed, triggered by a rust version release
+
 ## [5.78.1](https://github.com/taskforcesh/bullmq/compare/v5.78.0...v5.78.1) (2026-06-13)
 
 

--- a/elixir/package.json
+++ b/elixir/package.json
@@ -35,7 +35,7 @@
         {
           "releaseRules": [
             {
-              "message": "!(*\\(elixir\\)*|*\\[elixir\\]*)",
+              "message": "!({*,**/*}\\(elixir\\)*|{*,**/*}\\[elixir\\]*)",
               "release": false
             }
           ]

--- a/package.json
+++ b/package.json
@@ -150,19 +150,19 @@
         {
           "releaseRules": [
             {
-              "message": "*\\[python\\]*",
+              "message": "**/*\\[python\\]*",
               "release": false
             },
             {
-              "message": "*\\[elixir\\]*",
+              "message": "**/*\\[elixir\\]*",
               "release": false
             },
             {
-              "message": "*\\[php\\]*",
+              "message": "**/*\\[php\\]*",
               "release": false
             },
             {
-              "message": "*\\[rust\\]*",
+              "message": "**/*\\[rust\\]*",
               "release": false
             }
           ]

--- a/php/package.json
+++ b/php/package.json
@@ -35,7 +35,7 @@
         {
           "releaseRules": [
             {
-              "message": "!(*\\(php\\)*|*\\[php\\]*)",
+              "message": "!({*,**/*}\\(php\\)*|{*,**/*}\\[php\\]*)",
               "release": false
             }
           ]

--- a/python/package.json
+++ b/python/package.json
@@ -39,7 +39,7 @@
         {
           "releaseRules": [
             {
-              "message": "!(*\\(python\\)*|*\\[python\\]*)",
+              "message": "!({*,**/*}\\(python\\)*|{*,**/*}\\[python\\]*)",
               "release": false
             }
           ]

--- a/rust/package.json
+++ b/rust/package.json
@@ -24,7 +24,7 @@
         {
           "releaseRules": [
             {
-              "message": "!(*\\(rust\\)*|*\\[rust\\]*)",
+              "message": "!({*,**/*}\\(rust\\)*|{*,**/*}\\[rust\\]*)",
               "release": false
             }
           ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3419,7 +3419,7 @@ js-tokens@^4.0.0:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.2.0, js-yaml@^4.1.1, js-yaml@^4.1.0:
+js-yaml@4.2.0, js-yaml@^4.1.0, js-yaml@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
   integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==


### PR DESCRIPTION
<!--
  Thank you for submitting a PR!
  Please fill out all sections below to help us understand your changes.

  PR TITLE FORMAT
  ───────────────
  We use Conventional Commits: <type>(<scope>): <description>

  If your change affects one or more ports, append a tag at the end of the
  PR title (outside the conventional-commit part) to indicate their status:

    [python] / [elixir] / [php] / [rust]
      → The change is ONLY relevant to that port (Node.js is NOT affected).
        Multiple ports can be listed: [python][elixir]

    (python) / (elixir) / (php) / (rust)
      → The change affects that port AND Node.js.
        Multiple ports can be listed: (python)(php)

  Examples:
    fix(worker): handle stalled jobs correctly (python)(elixir)
    docs: update rate-limiting guide [python]
    feat(queue): add group priority support

  Please check all three ports below before setting your title.
-->

### Port Impact Checklist

<!--
  Review each port and tick every box that applies.
  If a port is not affected at all, leave its box unchecked.
-->

- [ ] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?
- [ ] **Rust** – does this change need to be ported or documented in the Rust library?

### Why

<!--
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->

  1. Why is this change necessary? micromatch is a path glob matcher. It treats / in strings as path separators. The * wildcard only matches within a single path segment (won't cross /), and ** alone adjacent to non-/ characters doesn't work as expected either.

The fix uses **/*\\[python\\]* which means:

**/ — match zero or more leading path segments (the part before the last /)
*\\[python\\]* — match the last segment containing the literal [python]
This correctly handles commit messages both with slashes (like Queue/Job/Worker) and without.

### How

<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->

_Enter the implementation details here._

### Additional Notes (Optional)

<!--
  Use this space for additional considerations:
  - Potential side effects
  - Dependencies
  - Testing instructions
  - Anything else reviewers should know
-->

_Any extra info here._
