### PR TITLE
fix: same flow producer params as NodeJs version [python]

### DIFF
--- a/python/bullmq/flow_producer.py
+++ b/python/bullmq/flow_producer.py
@@ -31,11 +31,11 @@ class FlowProducer:
     Instantiate a FlowProducer object
     """
 
-    #TODO: pass only queueOpts, no need 2 parameters in next breaking change
-    def __init__(self, redisOpts: Union[dict, str] = {}, opts: QueueBaseOptions = {}):
+    def __init__(self, opts: QueueBaseOptions = {}):
         """
         Initialize a connection
         """
+        redisOpts = opts.get("connection", {})
         self.redisConnection = RedisConnection(
             redisOpts,
             skipVersionCheck=opts.get("skipVersionCheck", False)

--- a/python/tests/flow_test.py
+++ b/python/tests/flow_test.py
@@ -55,7 +55,7 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         parent_worker = Worker(parent_queue_name, process2, {"prefix": prefix})
         children_worker = Worker(queue_name, process1, {"prefix": prefix})
 
-        flow = FlowProducer({}, {"prefix": prefix})
+        flow = FlowProducer({"prefix": prefix})
         await flow.add(
             {
                 "name": 'parent-job',
@@ -112,7 +112,7 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         parent_worker = Worker(parent_queue_name, process2, {"prefix": prefix})
         children_worker = Worker(queue_name, process1, {"prefix": prefix})
 
-        flow = FlowProducer({},{"prefix": prefix})
+        flow = FlowProducer({"prefix": prefix})
         await flow.addBulk([
             {
                 "name": 'parent-job-1',
@@ -173,7 +173,7 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         parent_worker = Worker(parent_queue_name, process2, {"prefix": prefix})
         children_worker = Worker(queue_name, process1, {"prefix": prefix})
 
-        flow = FlowProducer({},{"prefix": prefix})
+        flow = FlowProducer({"prefix": prefix})
         await flow.add(
             {
                 "name": 'parent-job',
@@ -233,7 +233,7 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         parent_worker = Worker(parent_queue_name, process_parent, {"prefix": prefix})
         child_worker = Worker(child_queue_name, process_child, {"prefix": prefix})
 
-        flow = FlowProducer({}, {"prefix": prefix})
+        flow = FlowProducer({"prefix": prefix})
         parent_tree = await flow.add(
             {
                 "name": 'parent-job',


### PR DESCRIPTION
<!--
  Thank you for submitting a PR!
  Please fill out all sections below to help us understand your changes.

  PR TITLE FORMAT
  ───────────────
  We use Conventional Commits: <type>(<scope>): <description>

  If your change affects one or more ports, append a tag at the end of the
  PR title (outside the conventional-commit part) to indicate their status:

    [python] / [elixir] / [php] / [rust]
      → The change is ONLY relevant to that port (Node.js is NOT affected).
        Multiple ports can be listed: [python][elixir]

    (python) / (elixir) / (php) / (rust)
      → The change affects that port AND Node.js.
        Multiple ports can be listed: (python)(php)

  Examples:
    fix(worker): handle stalled jobs correctly (python)(elixir)
    docs: update rate-limiting guide [python]
    feat(queue): add group priority support

  Please check all three ports below before setting your title.
-->

### Port Impact Checklist

<!--
  Review each port and tick every box that applies.
  If a port is not affected at all, leave its box unchecked.
-->

- [x] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?
- [ ] **Rust** – does this change need to be ported or documented in the Rust library?

### Why

<!--
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->

  1. Why is this change necessary? There is an extra parameter for connection in FlowProducer for our python port. This option is also present in queueOptions as in nodeJs version

### How

<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->

_Enter the implementation details here._

### Additional Notes (Optional)

<!--
  Use this space for additional considerations:
  - Potential side effects
  - Dependencies
  - Testing instructions
  - Anything else reviewers should know
-->

_Any extra info here._
