### PR TITLE
fix(worker): emit active event for all jobs moved to active fixes #3911

### DIFF
--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -746,10 +746,6 @@ export class Worker<
       }
     }
 
-    if (job) {
-      this.emit('active', job, 'waiting');
-    }
-
     return job;
   }
 
@@ -986,6 +982,9 @@ will never work with more accuracy than 1ms. */
         // Return undefined to indicate no next job is available
         return undefined;
       }
+
+      this.emit('active', job, 'waiting');
+
       return job;
     }
   }

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -438,6 +438,47 @@ describe('events', () => {
     await worker.close();
   });
 
+  it('should emit an active event for every processed job', async () => {
+    const numJobs = 20;
+
+    let activeCount = 0;
+    let completedCount = 0;
+
+    const worker = new Worker(queueName, async () => {}, {
+      connection,
+      prefix,
+    });
+
+    worker.on('active', () => {
+      activeCount++;
+    });
+
+    const completed = new Promise<void>((resolve, reject) => {
+      worker.on('completed', () => {
+        completedCount++;
+        if (completedCount === numJobs) {
+          resolve();
+        }
+      });
+      worker.on('error', reject);
+    });
+
+    await queue.addBulk(
+      Array.from({ length: numJobs }, (_, i) => ({
+        name: 'test',
+        data: { index: i },
+      })),
+    );
+
+    await completed;
+
+    // The active event must fire once per processed job, including jobs that
+    // are fetched atomically when the previous job is moved to completed.
+    expect(activeCount).toBe(numJobs);
+
+    await worker.close();
+  });
+
   describe('when one job is a parent', () => {
     it('emits waiting-children and waiting event', async () => {
       const worker = new Worker(queueName, async () => {}, {


### PR DESCRIPTION
<!--
  Thank you for submitting a PR!
  Please fill out all sections below to help us understand your changes.

  PR TITLE FORMAT
  ───────────────
  We use Conventional Commits: <type>(<scope>): <description>

  If your change affects one or more ports, append a tag at the end of the
  PR title (outside the conventional-commit part) to indicate their status:

    [python] / [elixir] / [php] / [rust]
      → The change is ONLY relevant to that port (Node.js is NOT affected).
        Multiple ports can be listed: [python][elixir]

    (python) / (elixir) / (php) / (rust)
      → The change affects that port AND Node.js.
        Multiple ports can be listed: (python)(php)

  Examples:
    fix(worker): handle stalled jobs correctly (python)(elixir)
    docs: update rate-limiting guide [python]
    feat(queue): add group priority support

  Please check all three ports below before setting your title.
-->

### Port Impact Checklist

<!--
  Review each port and tick every box that applies.
  If a port is not affected at all, leave its box unchecked.
-->

- [ ] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?
- [ ] **Rust** – does this change need to be ported or documented in the Rust library?

### Why

<!--
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->

The active emit was not emitted for every job moved to active, because the code was not considering that moveToFinish also moves the next job to active if it can.

### How

<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->

Emit the event on nextJobFromJobData.

### Additional Notes (Optional)

<!--
  Use this space for additional considerations:
  - Potential side effects
  - Dependencies
  - Testing instructions
  - Anything else reviewers should know
-->

_Any extra info here._
