### PR TITLE
fix(postgres): drop redundant bullmq_ prefix from schema objects

### DIFF
--- a/elixir/docs/transactional-jobs-design.md
+++ b/elixir/docs/transactional-jobs-design.md
@@ -1,0 +1,111 @@
+# Design: Transactional Jobs (Postgres backend)
+
+**Status:** Proposal / feasibility note
+**Applies to:** `BullMQ.Backends.Postgres` only (not Redis)
+
+## Goal
+
+Let a job's processor run its own database work **inside the same transaction
+that BullMQ uses to complete the job**, so that the business-logic writes and the
+job completion commit atomically together. If either fails, both roll back —
+which removes the classic at-least-once double-write window and makes idempotent
+processors unnecessary.
+
+## Why this is possible with Postgres (and impossible with Redis)
+
+The completion protocol on the Postgres backend is already a single SQL function,
+`move_to_completed(...)`, invoked from the adapter's `run/3` helper. That
+function is **transaction-agnostic**: it works the same whether it runs on a
+pooled connection or inside a caller-supplied `BEGIN … COMMIT`. That is the only
+hook required.
+
+Redis cannot do this: arbitrary user SQL can't be enrolled into a `MULTI/EXEC`.
+
+## The problem today: two commits
+
+Processing currently spans **two separate transactions**:
+
+1. `move_to_active` → commit (job becomes locked and visible as `active`)
+2. processor runs (user side effects, in the user's _own_ transaction)
+3. `move_to_completed` → separate commit
+
+The gap between (2) and (3) is the at-least-once window: if the worker crashes
+after the user's writes commit but before completion commits, the lock expires →
+the job is treated as stalled → it is reclaimed and reprocessed → **double side
+effects**. This is why processors must be idempotent.
+
+## The design: share only _process + complete_
+
+You must **not** fold the _claim_ (`move_to_active`) into the shared transaction.
+An uncommitted "active" state is invisible to other transactions, so two workers
+could claim the same job. Locking depends on the claim being committed.
+
+Instead, fold only **process + complete** into one transaction. The lock acquired
+at claim time provides mutual exclusion; the shared transaction provides
+atomicity of side-effects + completion:
+
+```elixir
+# 1. Claim stays a separate commit → job is locked and visible as active.
+move_to_active(backend, token, opts)
+
+# 2. Process + complete share ONE transaction → single COMMIT.
+Postgrex.transaction(pool, fn conn ->
+  result = processor.(job, conn)      # user's queries run on THIS conn
+  Postgrex.query!(conn, move_to_completed_sql, params)  # same tx
+  result
+end)
+```
+
+### Guarantees
+
+- **Crash mid-processing (before COMMIT):** the user's writes roll back; the job
+  stays `active` and locked → reclaimed → clean retry. No partial side effects,
+  so **no idempotence needed**.
+- **Lock expired mid-processing (slow job):** `move_to_completed` detects the
+  token mismatch and fails, so the _entire_ transaction — including the user's
+  writes — rolls back. This is exactly the "never double-write" property: a
+  worker whose lease expired can never commit its side effects.
+
+## What would change in the code
+
+| Piece                      | Change                                                                                                                                                 | Effort   |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
+| SQL                        | none — `move_to_completed` already runs in any transaction                                                                                             | none     |
+| Backend adapter            | add a connection-scoped variant of the completion path (`run/3` currently hardcodes the pool) + an optional callback, e.g. `complete_in_transaction/3` | Moderate |
+| Worker                     | wrap processor + completion in `Postgrex.transaction`, thread `conn` into the processor                                                                | Moderate |
+| Processor API              | give the processor the transaction handle (`processor.(job, tx)` or `job.tx`)                                                                          | Small    |
+| `BullMQ.Backend` behaviour | mark it an **optional, backend-specific capability** (Redis returns "unsupported")                                                                     | Small    |
+
+## The hard / careful parts
+
+1. **Pool sizing.** A transactional job holds a dedicated connection for its
+   entire duration; concurrency is then bounded by `pool_size` and long jobs pin
+   connections. Requires `pool_size ≥ in-flight transactional jobs`. This is the
+   main operational trade-off vs Redis (which releases connections between ops).
+2. **Ecto integration.** Trivial if the processor uses the raw Postgrex `conn` we
+   hand it; harder if users want their **Ecto Repo** calls to join the
+   transaction (Ecto doesn't cleanly adopt an external Postgrex connection). This
+   is the biggest integration question and dictates the public API shape.
+3. **`move_to_failed`.** Usually you want the opposite: roll back the user's work
+   but still **persist** the failure. So failures can't share the commit — roll
+   back the user transaction, then record the failure separately.
+4. **`fetch_next` fast path.** The fused claim-next-job optimization must be
+   disabled for transactional jobs (the next claim would be uncommitted until the
+   outer commit) or handled specially.
+5. **Lock renewal.** Fine as-is: `extend_lock` runs on a separate connection and
+   the completion transaction only touches the job row at the very end, so there
+   is no lock contention during the long user work.
+
+## Verdict
+
+**Very feasible — moderate effort for raw-Postgrex processors, more for Ecto
+integration.** The core is roughly a few hundred lines plus one optional
+behaviour callback, because the SQL already supports it. It is essentially the
+"transactional job" / exactly-once-via-shared-transaction pattern offered by
+Oban Pro and River (Go), and it is a real differentiator the Redis backend can
+never match.
+
+Two things to settle before committing to it:
+
+- the **Ecto story** (it determines the public API), and
+- an explicit **pool-sizing contract** so long jobs don't starve the pool.

--- a/elixir/lib/bullmq/backends/postgres.ex
+++ b/elixir/lib/bullmq/backends/postgres.ex
@@ -95,7 +95,7 @@ defmodule BullMQ.Backends.Postgres do
     Enum.map(rows, fn row -> cols |> Enum.zip(row) |> Map.new() end)
   end
 
-  # Maps a `bullmq_job` row into the Redis-hash-shaped string-keyed map that
+  # Maps a `job` row into the Redis-hash-shaped string-keyed map that
   # `BullMQ.Job.from_redis/4` consumes.
   defp row_to_job_map(row) do
     %{
@@ -319,12 +319,12 @@ defmodule BullMQ.Backends.Postgres do
   @impl true
   def add_flow(%__MODULE__{} = b, commands, _opts) do
     # `commands` is the pre-built, roots-first list of batch entries for every
-    # node of the flow tree (from `build_add_*_command`). `bullmq_add_flow`
+    # node of the flow tree (from `build_add_*_command`). `add_flow`
     # inserts the whole tree in one atomic statement.
     {:ok, Enum.map(run_add_flow(b, commands), &flow_result/1)}
   end
 
-  # Runs `bullmq_add_flow` with the ordered (roots-first) entry array and
+  # Runs `add_flow` with the ordered (roots-first) entry array and
   # returns the resulting ids in input order. The list is passed as an Elixir
   # term so Postgrex encodes it to a jsonb array (a JSON string would be wrapped
   # as a jsonb scalar and `jsonb_array_elements` would reject it).
@@ -345,7 +345,7 @@ defmodule BullMQ.Backends.Postgres do
     end
   end
 
-  # Builds one entry of the JSONB batch consumed by `bullmq_add_flow`. `job` is
+  # Builds one entry of the JSONB batch consumed by `add_flow`. `job` is
   # either a `%BullMQ.Job{}` (Queue.add_bulk) or a flow job map (FlowProducer);
   # both expose id/name/data/opts/timestamp/parent as atom keys.
   defp batch_entry(queue, job, encoded_opts, add_to_waiting_children) do
@@ -372,7 +372,7 @@ defmodule BullMQ.Backends.Postgres do
     }
   end
 
-  # `bullmq_add_flow` links a child to its parent by `(parentQueue, parentId)`
+  # `add_flow` links a child to its parent by `(parentQueue, parentId)`
   # matched against the parent's `queue` column — the plain queue name (no
   # prefix), which the flow job map exposes as `parent.queue`.
   defp batch_parent_queue(nil), do: nil
@@ -677,7 +677,7 @@ defmodule BullMQ.Backends.Postgres do
       Postgrex.query!(
         pool,
         "SELECT lock_token IS NOT NULL AND locked_until_ms > $3 AS locked " <>
-          "FROM bullmq_job WHERE queue = $1 AND id = $2",
+          "FROM job WHERE queue = $1 AND id = $2",
         [q, job_id, now_ms()]
       )
 
@@ -968,7 +968,7 @@ defmodule BullMQ.Backends.Postgres do
     Enum.each(values, fn {field, value} ->
       Postgrex.query!(
         pool,
-        "INSERT INTO bullmq_meta (queue, field, value) VALUES ($1, $2, $3) " <>
+        "INSERT INTO meta (queue, field, value) VALUES ($1, $2, $3) " <>
           "ON CONFLICT (queue, field) DO UPDATE SET value = EXCLUDED.value",
         [b.queue_name, to_string(field), to_string(value)]
       )
@@ -1289,7 +1289,7 @@ defmodule BullMQ.Backends.Postgres do
 
   def wait_for_job(%__MODULE__{notifications: notif} = b, block_timeout) do
     # Producers `NOTIFY bullmq_jobs` with the queue name as payload (in
-    # `bullmq_add_job`), so a producer in any process wakes a blocked worker
+    # `add_job`), so a producer in any process wakes a blocked worker
     # immediately. This mirrors the Redis backend's `BZPOPMIN`.
     {:ok, ref} = Postgrex.Notifications.listen(notif, "bullmq_jobs")
 

--- a/elixir/lib/bullmq/backends/postgres/migrator.ex
+++ b/elixir/lib/bullmq/backends/postgres/migrator.ex
@@ -139,7 +139,7 @@ defmodule BullMQ.Backends.Postgres.Migrator do
   defp ensure_ledger_table(conn) do
     Postgrex.query!(
       conn,
-      "CREATE TABLE IF NOT EXISTS bullmq_migration (" <>
+      "CREATE TABLE IF NOT EXISTS migration (" <>
         "version integer PRIMARY KEY, name text NOT NULL, " <>
         "applied_at timestamptz NOT NULL DEFAULT now())",
       []
@@ -150,7 +150,7 @@ defmodule BullMQ.Backends.Postgres.Migrator do
     %{rows: [[version]]} =
       Postgrex.query!(
         conn,
-        "SELECT COALESCE(MAX(version), 0)::int AS version FROM bullmq_migration",
+        "SELECT COALESCE(MAX(version), 0)::int AS version FROM migration",
         []
       )
 
@@ -172,7 +172,7 @@ defmodule BullMQ.Backends.Postgres.Migrator do
 
     Postgrex.query!(
       conn,
-      "INSERT INTO bullmq_migration (version, name) VALUES ($1, $2)",
+      "INSERT INTO migration (version, name) VALUES ($1, $2)",
       [version, name]
     )
   end

--- a/python/bullmq/backends/postgres_backend.py
+++ b/python/bullmq/backends/postgres_backend.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 minimum_block_timeout = 0.001
 
-# Job states stored as the enum value in bullmq_job.state; the high-level
+# Job states stored as the enum value in job.state; the high-level
 # classes sometimes use Redis list names ("wait", "paused") that map here.
 _STATE_ALIASES = {"wait": "waiting", "paused": "waiting"}
 
@@ -116,7 +116,7 @@ def _to_int(value: Any) -> int:
 
 
 def _row_to_job_map(row: dict) -> dict:
-    """Map a ``bullmq_job`` row into the Redis-hash-shaped dict ``Job.fromJSON``
+    """Map a ``job`` row into the Redis-hash-shaped dict ``Job.fromJSON``
     consumes (JSON-string values for the object fields, string values for the
     rest; ``None`` fields are dropped)."""
     parent_id = row.get("parent_id")

--- a/python/bullmq/backends/postgres_connection.py
+++ b/python/bullmq/backends/postgres_connection.py
@@ -119,11 +119,11 @@ async def run_migrations(
         await cur.execute(f"CREATE SCHEMA IF NOT EXISTS {quoted}")
         await cur.execute(f"SET LOCAL search_path TO {quoted}")
         await cur.execute(
-            "CREATE TABLE IF NOT EXISTS bullmq_migration ("
+            "CREATE TABLE IF NOT EXISTS migration ("
             "version integer PRIMARY KEY, name text NOT NULL, "
             "applied_at timestamptz NOT NULL DEFAULT now())"
         )
-        await cur.execute("SELECT COALESCE(MAX(version), 0)::int FROM bullmq_migration")
+        await cur.execute("SELECT COALESCE(MAX(version), 0)::int FROM migration")
         current = (await cur.fetchone())[0]
 
         for filename in sql_loader.migration_files():
@@ -131,7 +131,7 @@ async def run_migrations(
             if version > current:
                 await cur.execute(sql_loader.load_migration(filename))
                 await cur.execute(
-                    "INSERT INTO bullmq_migration (version, name) VALUES (%s, %s)",
+                    "INSERT INTO migration (version, name) VALUES (%s, %s)",
                     (version, filename),
                 )
                 current = version

--- a/src/postgres/commands/add_flow.sql
+++ b/src/postgres/commands/add_flow.sql
@@ -1,3 +1,3 @@
 -- Insert a flow (tree) of jobs atomically. Param: $1 entries (jsonb array,
 -- ordered roots-first). Returns the job ids in input order.
-SELECT id FROM bullmq_add_flow($1::jsonb) AS t(id);
+SELECT id FROM add_flow($1::jsonb) AS t(id);

--- a/src/postgres/commands/add_job.sql
+++ b/src/postgres/commands/add_job.sql
@@ -1,5 +1,5 @@
 -- Insert a single job, routing it to waiting or delayed; returns its id.
-SELECT bullmq_add_job(
+SELECT add_job(
   $1, $2, $3, $4::jsonb, $5::jsonb, $6, $7, $8, $9,
   $10, $11, $12, $13, $14, $15
 ) AS id;

--- a/src/postgres/commands/add_job_scheduler.sql
+++ b/src/postgres/commands/add_job_scheduler.sql
@@ -3,4 +3,4 @@
 -- $3 next_millis, $4 template_data (jsonb), $5 template_opts (jsonb),
 -- $6 opts (jsonb), $7 delayed_opts (jsonb), $8 now, $9 producer_id.
 SELECT job_id, delay
-  FROM bullmq_add_job_scheduler($1, $2, $3, $4, $5, $6, $7, $8, $9);
+  FROM add_job_scheduler($1, $2, $3, $4, $5, $6, $7, $8, $9);

--- a/src/postgres/commands/add_jobs_bulk.sql
+++ b/src/postgres/commands/add_jobs_bulk.sql
@@ -1,3 +1,3 @@
 -- Fast set-based bulk insert of INDEPENDENT jobs (no parents, no dedup).
 -- Param: $1 queue, $2 entries (jsonb array). Returns the job ids in input order.
-SELECT id FROM bullmq_add_jobs_bulk($1, $2::jsonb) AS t(id);
+SELECT id FROM add_jobs_bulk($1, $2::jsonb) AS t(id);

--- a/src/postgres/commands/add_log.sql
+++ b/src/postgres/commands/add_log.sql
@@ -2,11 +2,11 @@
 -- Params: $1 queue, $2 job_id, $3 row.
 -- The unqualified table name resolves in the configured BullMQ schema via
 -- search_path (default schema: bullmq).
-INSERT INTO bullmq_job_log (queue, job_id, idx, row)
+INSERT INTO job_log (queue, job_id, idx, row)
 VALUES (
   $1, $2,
   COALESCE(
-    (SELECT MAX(idx) + 1 FROM bullmq_job_log WHERE queue = $1 AND job_id = $2),
+    (SELECT MAX(idx) + 1 FROM job_log WHERE queue = $1 AND job_id = $2),
     0
   ),
   $3

--- a/src/postgres/commands/change_delay.sql
+++ b/src/postgres/commands/change_delay.sql
@@ -1,3 +1,3 @@
 -- Reschedule a delayed job. Params: $1 queue, $2 id, $3 delay, $4 now.
 -- Returns 0 ok, -1 missing, -3 not delayed.
-SELECT bullmq_change_delay($1, $2, $3, $4) AS code;
+SELECT change_delay($1, $2, $3, $4) AS code;

--- a/src/postgres/commands/change_priority.sql
+++ b/src/postgres/commands/change_priority.sql
@@ -1,3 +1,3 @@
 -- Change a job's priority (and reposition via lifo). Params: $1 queue, $2 id,
 -- $3 priority, $4 lifo. Returns 0 ok, -1 missing.
-SELECT bullmq_change_priority($1, $2, $3, $4) AS code;
+SELECT change_priority($1, $2, $3, $4) AS code;

--- a/src/postgres/commands/clean.sql
+++ b/src/postgres/commands/clean.sql
@@ -1,3 +1,3 @@
 -- Remove jobs of a state older than a timestamp, up to a limit (0 = all);
 -- returns removed ids. Params: $1 queue, $2 type, $3 timestamp, $4 limit.
-SELECT id FROM bullmq_clean($1, $2, $3, $4) AS t(id);
+SELECT id FROM clean($1, $2, $3, $4) AS t(id);

--- a/src/postgres/commands/clear_logs.sql
+++ b/src/postgres/commands/clear_logs.sql
@@ -1,9 +1,9 @@
 -- Clear a job's logs, keeping the latest $3 entries (NULL/0 → remove all).
 -- Params: $1 queue, $2 job_id, $3 keepLogs.
-DELETE FROM bullmq_job_log
+DELETE FROM job_log
  WHERE queue = $1 AND job_id = $2
    AND idx < COALESCE(
-     (SELECT MAX(idx) FROM bullmq_job_log WHERE queue = $1 AND job_id = $2)
+     (SELECT MAX(idx) FROM job_log WHERE queue = $1 AND job_id = $2)
        - $3 + 1,
      idx + 1
    );

--- a/src/postgres/commands/collect_metrics.sql
+++ b/src/postgres/commands/collect_metrics.sql
@@ -1,4 +1,4 @@
 -- Record one finished job into the queue/kind metrics (per-minute deltas).
 -- Params: $1 queue, $2 kind ('completed' | 'failed'), $3 maxDataPoints,
 -- $4 finish timestamp (epoch ms).
-SELECT bullmq_collect_metrics($1, $2, $3, $4);
+SELECT collect_metrics($1, $2, $3, $4);

--- a/src/postgres/commands/delete_deduplication_key.sql
+++ b/src/postgres/commands/delete_deduplication_key.sql
@@ -1,6 +1,6 @@
 -- Unconditionally remove a deduplication key (Queue.removeDeduplicationKey /
 -- the deprecated removeDebounceKey). Params: $1 queue, $2 dedup_id. Returns the
 -- removed key (0 or 1 row).
-DELETE FROM bullmq_dedup
+DELETE FROM dedup
 WHERE queue = $1 AND dedup_id = $2
 RETURNING dedup_id;

--- a/src/postgres/commands/drain.sql
+++ b/src/postgres/commands/drain.sql
@@ -1,2 +1,2 @@
 -- Remove waiting (and optionally delayed) jobs. Params: $1 queue, $2 delayed.
-SELECT bullmq_drain($1, $2);
+SELECT drain($1, $2);

--- a/src/postgres/commands/extend_lock.sql
+++ b/src/postgres/commands/extend_lock.sql
@@ -1,3 +1,3 @@
 -- Refresh an active job's lock; returns 1 on success, 0 if the lock was lost.
 -- Params: $1 queue, $2 id, $3 token, $4 lock_ms, $5 now_ms.
-SELECT bullmq_extend_lock($1, $2, $3, $4, $5) AS n;
+SELECT extend_lock($1, $2, $3, $4, $5) AS n;

--- a/src/postgres/commands/extend_locks.sql
+++ b/src/postgres/commands/extend_locks.sql
@@ -8,7 +8,7 @@ WITH input AS (
       USING (ord)
 ),
 updated AS (
-  UPDATE bullmq_job
+  UPDATE job
      SET locked_until_ms = $5::bigint + $4::bigint
     FROM input
    WHERE queue = $1

--- a/src/postgres/commands/get_counts.sql
+++ b/src/postgres/commands/get_counts.sql
@@ -8,6 +8,6 @@ SELECT
   COUNT(*) FILTER (WHERE state = 'waiting' AND priority = 0) AS waiting,
   COUNT(*) FILTER (WHERE state = 'waiting' AND priority > 0) AS prioritized,
   COUNT(*) FILTER (WHERE state = 'waiting-children')         AS "waiting-children",
-  (SELECT value FROM bullmq_meta WHERE queue = $1 AND field = 'paused') AS paused
-FROM bullmq_job
+  (SELECT value FROM meta WHERE queue = $1 AND field = 'paused') AS paused
+FROM job
 WHERE queue = $1;

--- a/src/postgres/commands/get_counts_per_priority.sql
+++ b/src/postgres/commands/get_counts_per_priority.sql
@@ -6,7 +6,7 @@
 -- wait/prioritized sets).
 SELECT COUNT(j.id) AS cnt
 FROM unnest($2::bigint[]) WITH ORDINALITY AS pr(priority, ord)
-LEFT JOIN bullmq_job j
+LEFT JOIN job j
   ON j.queue = $1
  AND j.state = 'waiting'
  AND j.priority = pr.priority

--- a/src/postgres/commands/get_deduplication_job_id.sql
+++ b/src/postgres/commands/get_deduplication_job_id.sql
@@ -1,7 +1,7 @@
 -- The current "winner" job id for a deduplication key, or none when absent or
 -- expired. Params: $1 queue, $2 dedup_id, $3 now (ms).
 SELECT job_id
-FROM bullmq_dedup
+FROM dedup
 WHERE queue = $1
   AND dedup_id = $2
   AND (expire_at_ms IS NULL OR expire_at_ms > $3);

--- a/src/postgres/commands/get_dependencies.sql
+++ b/src/postgres/commands/get_dependencies.sql
@@ -3,6 +3,6 @@
 -- processed → processed (value = return value), pending → unprocessed,
 -- ignored → ignored (value = reason), failed → failed.
 SELECT status::text AS status, child_key, value
-FROM bullmq_job_dependency
+FROM job_dependency
 WHERE parent_queue = $1 AND parent_id = $2
 ORDER BY child_id;

--- a/src/postgres/commands/get_dependencies_page.sql
+++ b/src/postgres/commands/get_dependencies_page.sql
@@ -1,7 +1,7 @@
 -- One page of a parent's child dependencies in a single status category.
 -- Params: $1 parent_queue, $2 parent_id, $3 status, $4 offset, $5 count.
 SELECT child_key, value
-FROM bullmq_job_dependency
-WHERE parent_queue = $1 AND parent_id = $2 AND status = $3::bullmq_dep_status
+FROM job_dependency
+WHERE parent_queue = $1 AND parent_id = $2 AND status = $3::dep_status
 ORDER BY child_id
 OFFSET $4 LIMIT $5;

--- a/src/postgres/commands/get_dependency_counts.sql
+++ b/src/postgres/commands/get_dependency_counts.sql
@@ -5,5 +5,5 @@ SELECT
   COUNT(*) FILTER (WHERE status = 'pending')   AS unprocessed,
   COUNT(*) FILTER (WHERE status = 'ignored')   AS ignored,
   COUNT(*) FILTER (WHERE status = 'failed')    AS failed
-FROM bullmq_job_dependency
+FROM job_dependency
 WHERE parent_queue = $1 AND parent_id = $2;

--- a/src/postgres/commands/get_ignored_children_failures.sql
+++ b/src/postgres/commands/get_ignored_children_failures.sql
@@ -2,6 +2,6 @@
 -- is stored as a JSON scalar string, so `#>> '{}'` extracts the raw text
 -- (mirrors the Redis `<jobId>:failed` hash). Params: $1 parent_queue, $2 parent_id.
 SELECT child_key, COALESCE(value #>> '{}', value::text) AS reason
-FROM bullmq_job_dependency
+FROM job_dependency
 WHERE parent_queue = $1 AND parent_id = $2 AND status = 'ignored'
 ORDER BY child_id;

--- a/src/postgres/commands/get_job_data.sql
+++ b/src/postgres/commands/get_job_data.sql
@@ -1,2 +1,2 @@
 -- A job's full row. Params: $1 queue, $2 id.
-SELECT * FROM bullmq_job WHERE queue = $1 AND id = $2;
+SELECT * FROM job WHERE queue = $1 AND id = $2;

--- a/src/postgres/commands/get_job_logs_asc.sql
+++ b/src/postgres/commands/get_job_logs_asc.sql
@@ -1,6 +1,6 @@
 -- A page of a job's logs, oldest first.
 -- Params: $1 queue, $2 job_id, $3 offset, $4 limit.
-SELECT row FROM bullmq_job_log
+SELECT row FROM job_log
  WHERE queue = $1 AND job_id = $2
  ORDER BY idx ASC
  OFFSET $3 LIMIT $4;

--- a/src/postgres/commands/get_job_logs_count.sql
+++ b/src/postgres/commands/get_job_logs_count.sql
@@ -1,2 +1,2 @@
 -- Total number of log lines for a job. Params: $1 queue, $2 job_id.
-SELECT COUNT(*) AS count FROM bullmq_job_log WHERE queue = $1 AND job_id = $2;
+SELECT COUNT(*) AS count FROM job_log WHERE queue = $1 AND job_id = $2;

--- a/src/postgres/commands/get_job_logs_desc.sql
+++ b/src/postgres/commands/get_job_logs_desc.sql
@@ -1,6 +1,6 @@
 -- A page of a job's logs, newest first.
 -- Params: $1 queue, $2 job_id, $3 offset, $4 limit.
-SELECT row FROM bullmq_job_log
+SELECT row FROM job_log
  WHERE queue = $1 AND job_id = $2
  ORDER BY idx DESC
  OFFSET $3 LIMIT $4;

--- a/src/postgres/commands/get_job_scheduler.sql
+++ b/src/postgres/commands/get_job_scheduler.sql
@@ -2,5 +2,5 @@
 -- Params: $1 queue, $2 scheduler_id.
 SELECT name, iteration_count, limit_count, start_date_ms, end_date_ms, tz,
        pattern, every_ms, offset_ms, template_data, template_opts, next_run_ms
-  FROM bullmq_scheduler
+  FROM scheduler
  WHERE queue = $1 AND scheduler_id = $2;

--- a/src/postgres/commands/get_job_schedulers_count.sql
+++ b/src/postgres/commands/get_job_schedulers_count.sql
@@ -1,2 +1,2 @@
 -- Number of registered schedulers in a queue. Param: $1 queue.
-SELECT count(*)::int AS count FROM bullmq_scheduler WHERE queue = $1;
+SELECT count(*)::int AS count FROM scheduler WHERE queue = $1;

--- a/src/postgres/commands/get_job_schedulers_range.sql
+++ b/src/postgres/commands/get_job_schedulers_range.sql
@@ -1,7 +1,7 @@
 -- Fetch a page of schedulers ordered by next-run time. Params: $1 queue,
 -- $2 asc (boolean), $3 offset, $4 count (NULL = all remaining).
 SELECT scheduler_id, next_run_ms
-  FROM bullmq_scheduler
+  FROM scheduler
  WHERE queue = $1
  ORDER BY CASE WHEN $2 THEN next_run_ms END ASC,
           CASE WHEN NOT $2 THEN next_run_ms END DESC,

--- a/src/postgres/commands/get_metrics.sql
+++ b/src/postgres/commands/get_metrics.sql
@@ -3,12 +3,12 @@
 -- (index 0 is the newest point; a negative end means "to the oldest").
 -- Params: $1 queue, $2 kind ('completed' | 'failed'), $3 start, $4 end.
 SELECT
-  COALESCE((SELECT count FROM bullmq_metrics
+  COALESCE((SELECT count FROM metrics
              WHERE queue = $1 AND kind = $2), 0)::bigint AS total,
   COALESCE((
     SELECT CASE
              WHEN $4 < 0 THEN data[($3 + 1) : ]
              ELSE data[($3 + 1) : ($4 + 1)]
            END
-      FROM bullmq_metrics WHERE queue = $1 AND kind = $2
+      FROM metrics WHERE queue = $1 AND kind = $2
   ), ARRAY[]::bigint[]) AS data;

--- a/src/postgres/commands/get_processed_children_values.sql
+++ b/src/postgres/commands/get_processed_children_values.sql
@@ -3,6 +3,6 @@
 -- Redis `<jobId>:processed` hash of stringified values). Params: $1 parent_queue,
 -- $2 parent_id.
 SELECT child_key, value::text AS value
-FROM bullmq_job_dependency
+FROM job_dependency
 WHERE parent_queue = $1 AND parent_id = $2 AND status = 'processed'
 ORDER BY child_id;

--- a/src/postgres/commands/get_queue_meta.sql
+++ b/src/postgres/commands/get_queue_meta.sql
@@ -1,2 +1,2 @@
 -- The full queue metadata hash. Param: $1 queue.
-SELECT field, value FROM bullmq_meta WHERE queue = $1;
+SELECT field, value FROM meta WHERE queue = $1;

--- a/src/postgres/commands/get_queue_meta_field.sql
+++ b/src/postgres/commands/get_queue_meta_field.sql
@@ -1,2 +1,2 @@
 -- A single queue metadata field's value. Params: $1 queue, $2 field.
-SELECT value FROM bullmq_meta WHERE queue = $1 AND field = $2;
+SELECT value FROM meta WHERE queue = $1 AND field = $2;

--- a/src/postgres/commands/get_queue_meta_fields.sql
+++ b/src/postgres/commands/get_queue_meta_fields.sql
@@ -1,3 +1,3 @@
 -- Several queue metadata fields. Params: $1 queue, $2 fields (text[]).
-SELECT field, value FROM bullmq_meta
+SELECT field, value FROM meta
  WHERE queue = $1 AND field = ANY($2::text[]);

--- a/src/postgres/commands/get_range.sql
+++ b/src/postgres/commands/get_range.sql
@@ -1,3 +1,3 @@
 -- Job ids in a state, sliced by [start, end]. Params: $1 queue, $2 type,
 -- $3 start, $4 end, $5 asc.
-SELECT id FROM bullmq_get_range($1, $2, $3, $4, $5) AS t(id);
+SELECT id FROM get_range($1, $2, $3, $4, $5) AS t(id);

--- a/src/postgres/commands/get_rate_limit_ttl.sql
+++ b/src/postgres/commands/get_rate_limit_ttl.sql
@@ -1,3 +1,3 @@
 -- Current rate-limit ttl in ms (Redis getRateLimitTtl semantics). Params:
 -- $1 queue, $2 maxJobs (0 = unspecified → meta `max` / raw window), $3 now_ms.
-SELECT bullmq_rate_limit_ttl($1, $2, $3) AS ttl;
+SELECT rate_limit_ttl($1, $2, $3) AS ttl;

--- a/src/postgres/commands/get_state.sql
+++ b/src/postgres/commands/get_state.sql
@@ -1,2 +1,2 @@
 -- A job's state and priority. Params: $1 queue, $2 id.
-SELECT state, priority FROM bullmq_job WHERE queue = $1 AND id = $2;
+SELECT state, priority FROM job WHERE queue = $1 AND id = $2;

--- a/src/postgres/commands/has_queue_meta_field.sql
+++ b/src/postgres/commands/has_queue_meta_field.sql
@@ -1,4 +1,4 @@
 -- Whether a queue metadata field exists. Params: $1 queue, $2 field.
 SELECT EXISTS(
-  SELECT 1 FROM bullmq_meta WHERE queue = $1 AND field = $2
+  SELECT 1 FROM meta WHERE queue = $1 AND field = $2
 ) AS exists;

--- a/src/postgres/commands/has_waiting_job.sql
+++ b/src/postgres/commands/has_waiting_job.sql
@@ -3,9 +3,9 @@
 -- established (mirrors the atomicity of Redis's blocking pop). Param: $1 queue.
 SELECT
   EXISTS(
-    SELECT 1 FROM bullmq_job WHERE queue = $1 AND state = 'waiting'
+    SELECT 1 FROM job WHERE queue = $1 AND state = 'waiting'
   )
   AND NOT EXISTS(
-    SELECT 1 FROM bullmq_meta
+    SELECT 1 FROM meta
      WHERE queue = $1 AND field = 'paused' AND value = '1'
   ) AS present;

--- a/src/postgres/commands/is_finished.sql
+++ b/src/postgres/commands/is_finished.sql
@@ -1,4 +1,4 @@
 -- A job's finished state and result/reason (for waitUntilFinished / isFinished).
 -- Params: $1 queue, $2 id.
 SELECT state, return_value, failed_reason
-  FROM bullmq_job WHERE queue = $1 AND id = $2;
+  FROM job WHERE queue = $1 AND id = $2;

--- a/src/postgres/commands/is_job_in_state.sql
+++ b/src/postgres/commands/is_job_in_state.sql
@@ -1,6 +1,6 @@
 -- Whether a job is currently in the given state. Params: $1 queue, $2 id,
 -- $3 state.
 SELECT EXISTS(
-  SELECT 1 FROM bullmq_job
-   WHERE queue = $1 AND id = $2 AND state = $3::bullmq_job_state
+  SELECT 1 FROM job
+   WHERE queue = $1 AND id = $2 AND state = $3::job_state
 ) AS present;

--- a/src/postgres/commands/is_job_in_wait.sql
+++ b/src/postgres/commands/is_job_in_wait.sql
@@ -3,12 +3,12 @@
 -- when the queue is paused, and to the wait list otherwise. $3 selects which
 -- list to test (true = paused, false = wait). Params: $1 queue, $2 id, $3 paused.
 SELECT EXISTS(
-  SELECT 1 FROM bullmq_job j
+  SELECT 1 FROM job j
    WHERE j.queue = $1 AND j.id = $2
      AND j.state = 'waiting' AND j.priority = 0
      AND (
        EXISTS(
-         SELECT 1 FROM bullmq_meta m
+         SELECT 1 FROM meta m
           WHERE m.queue = $1 AND m.field = 'paused' AND m.value = '1'
        )
      ) = $3

--- a/src/postgres/commands/is_job_prioritized.sql
+++ b/src/postgres/commands/is_job_prioritized.sql
@@ -1,6 +1,6 @@
 -- Whether a job is prioritized (waiting with a non-zero priority).
 -- Params: $1 queue, $2 id.
 SELECT EXISTS(
-  SELECT 1 FROM bullmq_job
+  SELECT 1 FROM job
    WHERE queue = $1 AND id = $2 AND state = 'waiting' AND priority > 0
 ) AS present;

--- a/src/postgres/commands/is_job_scheduler.sql
+++ b/src/postgres/commands/is_job_scheduler.sql
@@ -1,4 +1,4 @@
 -- Whether an id corresponds to a registered scheduler. Params: $1 queue, $2 id.
 SELECT EXISTS (
-  SELECT 1 FROM bullmq_scheduler WHERE queue = $1 AND scheduler_id = $2
+  SELECT 1 FROM scheduler WHERE queue = $1 AND scheduler_id = $2
 ) AS exists;

--- a/src/postgres/commands/is_maxed.sql
+++ b/src/postgres/commands/is_maxed.sql
@@ -3,8 +3,8 @@
 -- when no concurrency limit is configured.
 -- Params: $1 queue.
 SELECT COALESCE(
-  (SELECT count(*) FROM bullmq_job WHERE queue = $1 AND state = 'active')
-    >= (SELECT value::integer FROM bullmq_meta
+  (SELECT count(*) FROM job WHERE queue = $1 AND state = 'active')
+    >= (SELECT value::integer FROM meta
          WHERE queue = $1 AND field = 'concurrency'),
   false
 ) AS maxed;

--- a/src/postgres/commands/move_active_to_wait.sql
+++ b/src/postgres/commands/move_active_to_wait.sql
@@ -1,4 +1,4 @@
 -- Move an active job back to wait (Job.moveToWait / dynamic rate limit).
 -- Params: $1 queue, $2 id, $3 token ('0' bypasses the lock check), $4 now_ms.
 -- Returns the limiter window ms (>=0), or -1 when the job no longer exists.
-SELECT bullmq_move_active_to_wait($1, $2, $3, $4) AS n;
+SELECT move_active_to_wait($1, $2, $3, $4) AS n;

--- a/src/postgres/commands/move_stalled_jobs_to_wait.sql
+++ b/src/postgres/commands/move_stalled_jobs_to_wait.sql
@@ -1,4 +1,4 @@
 -- Two-phase stalled-job recovery (mark on one pass, reclaim on the next);
 -- returns the reclaimed ids. Params: $1 queue, $2 max_stalled_count,
 -- $3 now_ms, $4 max_check_time_ms (stalledInterval).
-SELECT id FROM bullmq_move_stalled_jobs_to_wait($1, $2, $3, $4) AS t(id);
+SELECT id FROM move_stalled_jobs_to_wait($1, $2, $3, $4) AS t(id);

--- a/src/postgres/commands/move_to_active.sql
+++ b/src/postgres/commands/move_to_active.sql
@@ -1,4 +1,4 @@
 -- Claim the next ready job for a worker (0 or 1 rows), honouring the limiter.
 -- Params: $1 queue, $2 token, $3 lock_ms, $4 now_ms, $5 worker name,
 -- $6 limiter max (worker option, NULL if none), $7 limiter duration ms.
-SELECT * FROM bullmq_move_to_active($1, $2, $3, $4, $5, $6, $7);
+SELECT * FROM move_to_active($1, $2, $3, $4, $5, $6, $7);

--- a/src/postgres/commands/move_to_completed.sql
+++ b/src/postgres/commands/move_to_completed.sql
@@ -1,4 +1,4 @@
 -- Finish an active job successfully; returns the finished-at timestamp.
 -- Params: $1 queue, $2 id, $3 token, $4 return_value (jsonb), $5 finished_on,
 --         $6 remove_all, $7 keep_age (s), $8 keep_count.
-SELECT bullmq_move_to_completed($1, $2, $3, $4::jsonb, $5, $6, $7, $8) AS finished_on;
+SELECT move_to_completed($1, $2, $3, $4::jsonb, $5, $6, $7, $8) AS finished_on;

--- a/src/postgres/commands/move_to_completed_fetch.sql
+++ b/src/postgres/commands/move_to_completed_fetch.sql
@@ -5,5 +5,5 @@
 --         $6 remove_all, $7 keep_age (s), $8 keep_count,
 --         $9 lock_ms, $10 now_ms, $11 worker name,
 --         $12 limiter max (worker option, NULL if none), $13 limiter duration ms.
-SELECT * FROM bullmq_move_to_completed_fetch(
+SELECT * FROM move_to_completed_fetch(
   $1, $2, $3, $4::jsonb, $5, $6, $7, $8, $9, $10, $11, $12, $13);

--- a/src/postgres/commands/move_to_delayed.sql
+++ b/src/postgres/commands/move_to_delayed.sql
@@ -1,4 +1,4 @@
 -- Re-queue an active job to the delayed state (retry-with-delay / manual delay).
 -- Params: $1 queue, $2 id, $3 token, $4 process_at, $5 delay,
 --         $6 skip_attempt, $7 failed_reason, $8 stacktrace (jsonb).
-SELECT bullmq_move_to_delayed($1, $2, $3, $4, $5, $6, $7, $8::jsonb) AS n;
+SELECT move_to_delayed($1, $2, $3, $4, $5, $6, $7, $8::jsonb) AS n;

--- a/src/postgres/commands/move_to_failed.sql
+++ b/src/postgres/commands/move_to_failed.sql
@@ -1,4 +1,4 @@
 -- Mark an active job failed; returns the finished-at timestamp.
 -- Params: $1 queue, $2 id, $3 token, $4 failed_reason, $5 stacktrace (jsonb),
 --         $6 finished_on, $7 remove_all, $8 keep_age (s), $9 keep_count.
-SELECT bullmq_move_to_failed($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9) AS finished_on;
+SELECT move_to_failed($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9) AS finished_on;

--- a/src/postgres/commands/move_to_failed_fetch.sql
+++ b/src/postgres/commands/move_to_failed_fetch.sql
@@ -5,5 +5,5 @@
 --         $6 finished_on, $7 remove_all, $8 keep_age (s), $9 keep_count,
 --         $10 lock_ms, $11 now_ms, $12 worker name,
 --         $13 limiter max (worker option, NULL if none), $14 limiter duration ms.
-SELECT * FROM bullmq_move_to_failed_fetch(
+SELECT * FROM move_to_failed_fetch(
   $1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12, $13, $14);

--- a/src/postgres/commands/move_to_waiting_children.sql
+++ b/src/postgres/commands/move_to_waiting_children.sql
@@ -1,3 +1,3 @@
 -- Move an active parent to waiting-children if it has pending children.
 -- Params: $1 queue, $2 id, $3 token. Returns 1 (should wait), 0 (proceed).
-SELECT bullmq_move_to_waiting_children($1, $2, $3) AS code;
+SELECT move_to_waiting_children($1, $2, $3) AS code;

--- a/src/postgres/commands/next_delay.sql
+++ b/src/postgres/commands/next_delay.sql
@@ -1,2 +1,2 @@
 -- The timestamp of the next delayed job, or NULL if there are none.
-SELECT bullmq_next_delay($1) AS next_delay;
+SELECT next_delay($1) AS next_delay;

--- a/src/postgres/commands/next_signal.sql
+++ b/src/postgres/commands/next_signal.sql
@@ -1,3 +1,3 @@
 -- The worker "no job" signal: effective rate-limit ttl + next delayed-job time.
 -- Params: $1 queue, $2 limiter max (worker option, NULL if none), $3 now_ms.
-SELECT rate_limit_ttl, next_delay FROM bullmq_next_signal($1, $2, $3);
+SELECT rate_limit_ttl, next_delay FROM next_signal($1, $2, $3);

--- a/src/postgres/commands/obliterate.sql
+++ b/src/postgres/commands/obliterate.sql
@@ -1,4 +1,4 @@
 -- Obliterate a queue: delete up to $2 jobs; returns -1 (not paused), -2 (active
 -- jobs without force), 1 (more to delete), or 0 (done). Params: $1 queue,
 -- $2 count, $3 force.
-SELECT bullmq_obliterate($1, $2, $3) AS cursor;
+SELECT obliterate($1, $2, $3) AS cursor;

--- a/src/postgres/commands/paginate_dependencies.sql
+++ b/src/postgres/commands/paginate_dependencies.sql
@@ -4,16 +4,16 @@
 -- (NULL = no limit). `total` is the full number of matching dependencies
 -- (COUNT(*) OVER(), computed before the slice). `dep_value` is the stored
 -- result for processed children. The remaining columns are the child
--- `bullmq_job` row consumed by rowToJobJson.
+-- `job` row consumed by rowToJobJson.
 SELECT
   d.child_key,
   d.value AS dep_value,
   COUNT(*) OVER() AS total,
   j.*
-FROM bullmq_job_dependency d
-LEFT JOIN bullmq_job j
+FROM job_dependency d
+LEFT JOIN job j
   ON j.queue = d.child_queue AND j.id = d.child_id
-WHERE d.parent_queue = $1 AND d.parent_id = $2 AND d.status = $3::bullmq_dep_status
+WHERE d.parent_queue = $1 AND d.parent_id = $2 AND d.status = $3::dep_status
 ORDER BY d.child_key
 OFFSET $4
 LIMIT $5;

--- a/src/postgres/commands/pause.sql
+++ b/src/postgres/commands/pause.sql
@@ -1,2 +1,2 @@
 -- Pause/resume the queue. Params: $1 queue, $2 paused.
-SELECT bullmq_pause($1, $2);
+SELECT pause($1, $2);

--- a/src/postgres/commands/promote.sql
+++ b/src/postgres/commands/promote.sql
@@ -1,3 +1,3 @@
 -- Promote a delayed job to waiting. Params: $1 queue, $2 id.
 -- Returns 0 ok, -1 missing, -3 not delayed.
-SELECT bullmq_promote($1, $2) AS code;
+SELECT promote($1, $2) AS code;

--- a/src/postgres/commands/promote_jobs.sql
+++ b/src/postgres/commands/promote_jobs.sql
@@ -1,3 +1,3 @@
 -- Move up to `count` delayed jobs to waiting; returns the number moved.
 -- Params: $1 queue, $2 count.
-SELECT bullmq_promote_jobs($1, $2) AS n;
+SELECT promote_jobs($1, $2) AS n;

--- a/src/postgres/commands/publish_event.sql
+++ b/src/postgres/commands/publish_event.sql
@@ -1,3 +1,3 @@
 -- Append a custom event to the stream; returns the event id.
 -- Params: $1 queue, $2 event, $3 data (jsonb).
-SELECT bullmq_publish_event($1, $2, $3::jsonb) AS id;
+SELECT publish_event($1, $2, $3::jsonb) AS id;

--- a/src/postgres/commands/read_events.sql
+++ b/src/postgres/commands/read_events.sql
@@ -1,6 +1,6 @@
 -- A page of events newer than a cursor, oldest first.
 -- Params: $1 queue, $2 cursor (exclusive), $3 limit.
-SELECT id, event, data FROM bullmq_event
+SELECT id, event, data FROM event
  WHERE queue = $1 AND id > $2
  ORDER BY id ASC
  LIMIT $3;

--- a/src/postgres/commands/read_events_max.sql
+++ b/src/postgres/commands/read_events_max.sql
@@ -1,3 +1,3 @@
 -- The current max event id for a queue (used to resolve the '$' cursor).
 -- Param: $1 queue.
-SELECT COALESCE(MAX(id), 0)::bigint AS max FROM bullmq_event WHERE queue = $1;
+SELECT COALESCE(MAX(id), 0)::bigint AS max FROM event WHERE queue = $1;

--- a/src/postgres/commands/remove.sql
+++ b/src/postgres/commands/remove.sql
@@ -1,3 +1,3 @@
 -- Remove a job (and optionally its children). Returns 1 if removed, else 0.
 -- Params: $1 queue, $2 id, $3 remove_children.
-SELECT bullmq_remove($1, $2, $3) AS n;
+SELECT remove($1, $2, $3) AS n;

--- a/src/postgres/commands/remove_child_dependency.sql
+++ b/src/postgres/commands/remove_child_dependency.sql
@@ -1,4 +1,4 @@
 -- Break a child's dependency link to its parent. Params: $1 queue, $2 job_id,
 -- $3 parent_key, $4 now. Returns 0 (removed) or 1 (no relationship); raises on
 -- missing job (-1) / missing parent (-5).
-SELECT bullmq_remove_child_dependency($1, $2, $3, $4) AS n;
+SELECT remove_child_dependency($1, $2, $3, $4) AS n;

--- a/src/postgres/commands/remove_deduplication_key.sql
+++ b/src/postgres/commands/remove_deduplication_key.sql
@@ -3,7 +3,7 @@
 -- job-instance Job.removeDeduplicationKey, where Redis GET returns nil for an
 -- expired key). Params: $1 queue, $2 dedup_id, $3 job_id, $4 now (ms). Returns
 -- the removed key (0 or 1 row).
-DELETE FROM bullmq_dedup
+DELETE FROM dedup
 WHERE queue = $1 AND dedup_id = $2 AND job_id = $3
   AND (expire_at_ms IS NULL OR expire_at_ms > $4)
 RETURNING dedup_id;

--- a/src/postgres/commands/remove_job_scheduler.sql
+++ b/src/postgres/commands/remove_job_scheduler.sql
@@ -1,3 +1,3 @@
 -- Remove a scheduler and its still-pending job (emitting `removed` events);
 -- returns 1 if the scheduler existed, 0 otherwise. Params: $1 queue, $2 id.
-SELECT bullmq_remove_job_scheduler($1, $2) AS removed;
+SELECT remove_job_scheduler($1, $2) AS removed;

--- a/src/postgres/commands/remove_queue_meta_fields.sql
+++ b/src/postgres/commands/remove_queue_meta_fields.sql
@@ -1,2 +1,2 @@
 -- Remove queue metadata fields. Params: $1 queue, $2 fields (text[]).
-DELETE FROM bullmq_meta WHERE queue = $1 AND field = ANY($2::text[]);
+DELETE FROM meta WHERE queue = $1 AND field = ANY($2::text[]);

--- a/src/postgres/commands/remove_rate_limit.sql
+++ b/src/postgres/commands/remove_rate_limit.sql
@@ -1,6 +1,6 @@
 -- Clear the limiter window; returns the number of rows removed (0 or 1).
 -- Param: $1 queue.
 WITH d AS (
-  DELETE FROM bullmq_rate_limit WHERE queue = $1 RETURNING 1
+  DELETE FROM rate_limit WHERE queue = $1 RETURNING 1
 )
 SELECT count(*)::int AS n FROM d;

--- a/src/postgres/commands/remove_unprocessed_children.sql
+++ b/src/postgres/commands/remove_unprocessed_children.sql
@@ -1,3 +1,3 @@
 -- Recursively remove a parent's still-pending children. Params: $1 queue,
 -- $2 job_id.
-SELECT bullmq_remove_unprocessed_children($1, $2);
+SELECT remove_unprocessed_children($1, $2);

--- a/src/postgres/commands/reprocess_job.sql
+++ b/src/postgres/commands/reprocess_job.sql
@@ -1,4 +1,4 @@
 -- Re-queue a finished job (failed/completed) back to wait. Params: $1 queue,
 -- $2 id, $3 state, $4 lifo, $5 reset_attempts_made, $6 reset_attempts_started.
 -- Returns 1 ok, -1 missing, -3 not in the expected state.
-SELECT bullmq_reprocess_job($1, $2, $3, $4, $5, $6) AS code;
+SELECT reprocess_job($1, $2, $3, $4, $5, $6) AS code;

--- a/src/postgres/commands/retry_job.sql
+++ b/src/postgres/commands/retry_job.sql
@@ -1,3 +1,3 @@
 -- Re-queue an active job back to waiting immediately (retry now).
 -- Params: $1 queue, $2 id, $3 token, $4 lifo, $5 failed_reason, $6 stacktrace (jsonb).
-SELECT bullmq_retry_job($1, $2, $3, $4, $5, $6::jsonb) AS n;
+SELECT retry_job($1, $2, $3, $4, $5, $6::jsonb) AS n;

--- a/src/postgres/commands/retry_jobs.sql
+++ b/src/postgres/commands/retry_jobs.sql
@@ -1,3 +1,3 @@
 -- Move up to `count` finished jobs back to waiting; returns the number moved.
 -- Params: $1 queue, $2 state, $3 count, $4 timestamp.
-SELECT bullmq_retry_jobs($1, $2, $3, $4) AS n;
+SELECT retry_jobs($1, $2, $3, $4) AS n;

--- a/src/postgres/commands/set_queue_meta.sql
+++ b/src/postgres/commands/set_queue_meta.sql
@@ -1,4 +1,4 @@
 -- Upsert queue metadata fields. Params: $1 queue, $2 fields (text[]), $3 values (text[]).
-INSERT INTO bullmq_meta (queue, field, value)
+INSERT INTO meta (queue, field, value)
 SELECT $1, f, v FROM unnest($2::text[], $3::text[]) AS t(f, v)
 ON CONFLICT (queue, field) DO UPDATE SET value = EXCLUDED.value;

--- a/src/postgres/commands/set_rate_limit.sql
+++ b/src/postgres/commands/set_rate_limit.sql
@@ -1,3 +1,3 @@
 -- Force the limiter window (dynamic / manual rate limit).
 -- Params: $1 queue, $2 expire ms, $3 now_ms.
-SELECT bullmq_set_rate_limit($1, $2, $3);
+SELECT set_rate_limit($1, $2, $3);

--- a/src/postgres/commands/trim_logs.sql
+++ b/src/postgres/commands/trim_logs.sql
@@ -1,3 +1,3 @@
 -- Trim a job's oldest logs. Params: $1 queue, $2 job_id, $3 min_idx_to_keep.
-DELETE FROM bullmq_job_log
+DELETE FROM job_log
  WHERE queue = $1 AND job_id = $2 AND idx < $3;

--- a/src/postgres/commands/update_data.sql
+++ b/src/postgres/commands/update_data.sql
@@ -1,3 +1,3 @@
 -- Replace a job's data payload. Params: $1 queue, $2 id, $3 data (jsonb).
-UPDATE bullmq_job SET data = $3::jsonb WHERE queue = $1 AND id = $2
+UPDATE job SET data = $3::jsonb WHERE queue = $1 AND id = $2
 RETURNING id;

--- a/src/postgres/commands/update_job_scheduler.sql
+++ b/src/postgres/commands/update_job_scheduler.sql
@@ -2,4 +2,4 @@
 -- returns the new delayed job id, or NULL if the scheduler is gone.
 -- Params: $1 queue, $2 scheduler_id, $3 next_millis, $4 template_data (jsonb),
 -- $5 delayed_opts (jsonb), $6 now, $7 producer_id.
-SELECT bullmq_update_job_scheduler_next_millis($1, $2, $3, $4, $5, $6, $7) AS job_id;
+SELECT update_job_scheduler_next_millis($1, $2, $3, $4, $5, $6, $7) AS job_id;

--- a/src/postgres/commands/update_progress.sql
+++ b/src/postgres/commands/update_progress.sql
@@ -1,3 +1,3 @@
 -- Update a job's progress and emit a 'progress' event. Returns the number of
 -- rows updated (0 = missing job). Params: $1 queue, $2 id, $3 progress (jsonb).
-SELECT bullmq_update_progress($1, $2, $3::jsonb) AS updated;
+SELECT update_progress($1, $2, $3::jsonb) AS updated;

--- a/src/postgres/migrations/0001_schema.sql
+++ b/src/postgres/migrations/0001_schema.sql
@@ -16,7 +16,7 @@
 -- `prefix` namespaces every key — SQL uses the schema as the single namespace
 -- for the whole connection, so there is no per-row/per-queue prefix.
 --
--- The migration ledger table (`bullmq_migration`) is bootstrapped by the
+-- The migration ledger table (`migration`) is bootstrapped by the
 -- migration runner itself, so it is intentionally not created here.
 --
 -- v1 only establishes the foundation that is independent of the job-storage
@@ -26,7 +26,7 @@
 -- Per-queue metadata. Mirrors the Redis `<prefix>:<queue>:meta` hash: a small
 -- key/value store keyed by (queue, field). Used for the queue version, global
 -- concurrency, global rate limit, paused flag, etc.
-CREATE TABLE IF NOT EXISTS bullmq_meta (
+CREATE TABLE IF NOT EXISTS meta (
   queue text NOT NULL,
   field text NOT NULL,
   value text,
@@ -53,7 +53,7 @@ CREATE TABLE IF NOT EXISTS bullmq_meta (
 --   independent BullMQ namespace. So there is no per-row/per-queue prefix — the
 --   `queue` column alone discriminates within the schema.
 --
--- * Single `bullmq_job` table keyed by (queue, id). The Redis adapter spreads a
+-- * Single `job` table keyed by (queue, id). The Redis adapter spreads a
 --   job's lifecycle across many keys (wait list, prioritized zset, delayed zset,
 --   active list, completed/failed zsets, locks, …); here a single `state`
 --   column plus a handful of promoted, indexable columns replaces all of them.
@@ -68,14 +68,14 @@ CREATE TABLE IF NOT EXISTS bullmq_meta (
 --   has a small index that only contains the rows in the relevant state.
 --
 -- * "paused" and "prioritized" are NOT physical states. Pausing is an O(1)
---   queue-level flag in `bullmq_meta`; a prioritized job is simply a waiting job
+--   queue-level flag in `meta`; a prioritized job is simply a waiting job
 --   with `priority > 0`. This avoids the bulk row rewrites Redis performs on
 --   pause and removes the need for a separate prioritized structure — full
 --   `ORDER BY (priority, seq)` does the job.
 -- ──────────────────────────────────────────────────────────────────────────
 
 -- Physical job states. (Pause = meta flag; prioritized = waiting + priority>0.)
-CREATE TYPE bullmq_job_state AS ENUM (
+CREATE TYPE job_state AS ENUM (
   'waiting',
   'active',
   'completed',
@@ -85,7 +85,7 @@ CREATE TYPE bullmq_job_state AS ENUM (
 );
 
 -- Status of a parent→child dependency (flows).
-CREATE TYPE bullmq_dep_status AS ENUM (
+CREATE TYPE dep_status AS ENUM (
   'pending',    -- child not finished yet
   'processed',  -- child completed; `value` holds its return value
   'ignored',    -- child failed but parent was told to ignore it; `value` = reason
@@ -97,21 +97,21 @@ CREATE TYPE bullmq_dep_status AS ENUM (
 -- with insertion. LIFO jobs are stored with a *negative* `seq` (from the same
 -- sequence, negated) so they sort ahead of all FIFO jobs and, among themselves,
 -- most-recently-added first — reproducing "last in, first out" with one column.
-CREATE SEQUENCE bullmq_job_seq;
+CREATE SEQUENCE job_seq;
 
 -- Global monotonic id for the event stream (the Postgres analogue of a Redis
 -- stream entry id). Consumers page forward with `id > cursor`.
-CREATE SEQUENCE bullmq_event_seq;
+CREATE SEQUENCE event_seq;
 
 -- ──────────────────────────────────────────────────────────────────────────
 -- Jobs
 -- ──────────────────────────────────────────────────────────────────────────
-CREATE TABLE bullmq_job (
+CREATE TABLE job (
   queue             text             NOT NULL,
   id                text             NOT NULL,  -- custom id, or numeric counter as text
   seq               bigint           NOT NULL,  -- FIFO order (negative = LIFO); see sequence above
   name              text             NOT NULL,
-  state             bullmq_job_state NOT NULL,
+  state             job_state NOT NULL,
 
   -- Payload / options. BullMQ serializes these as JSON strings; stored as jsonb
   -- (always valid JSON) so they are queryable and compact.
@@ -157,7 +157,7 @@ CREATE TABLE bullmq_job (
   parent_key        text,                         -- denormalized "<queue>:<id>" (Redis-compatible "<prefix>:<queue>:<id>")
   pending_deps      integer          NOT NULL DEFAULT 0,
   -- Two-phase stalled mark/sweep: set on the first stalled pass, reclaimed on
-  -- the next (see bullmq_move_stalled_jobs_to_wait in 0002_functions.sql).
+  -- the next (see move_stalled_jobs_to_wait in 0002_functions.sql).
   stalled_marked    boolean          NOT NULL DEFAULT false,
 
   PRIMARY KEY (queue, id)
@@ -166,52 +166,52 @@ CREATE TABLE bullmq_job (
 -- Claim next ready job: waiting jobs ordered by (priority, seq). Covers both the
 -- "wait" (priority = 0) and "prioritized" (priority > 0) views, and the FIFO/LIFO
 -- ordering via the signed `seq`. Used with FOR UPDATE SKIP LOCKED.
-CREATE INDEX bullmq_job_ready_idx
-  ON bullmq_job (queue, priority, seq)
+CREATE INDEX job_ready_idx
+  ON job (queue, priority, seq)
   WHERE state = 'waiting';
 
 -- Promote due delayed jobs (process_at_ms <= now) and find the next wake-up.
-CREATE INDEX bullmq_job_delayed_idx
-  ON bullmq_job (queue, process_at_ms)
+CREATE INDEX job_delayed_idx
+  ON job (queue, process_at_ms)
   WHERE state = 'delayed';
 
 -- Active jobs: stalled scan by lock expiry, and O(1)-ish concurrency counting
 -- (COUNT over the partial index for a queue).
-CREATE INDEX bullmq_job_active_idx
-  ON bullmq_job (queue, locked_until_ms)
+CREATE INDEX job_active_idx
+  ON job (queue, locked_until_ms)
   WHERE state = 'active';
 
 -- Finished jobs: range listing and age/count-based retention + cleaning.
-CREATE INDEX bullmq_job_finished_idx
-  ON bullmq_job (queue, state, finished_at_ms)
+CREATE INDEX job_finished_idx
+  ON job (queue, state, finished_at_ms)
   WHERE state IN ('completed', 'failed');
 
 -- Parents blocked on children.
-CREATE INDEX bullmq_job_waiting_children_idx
-  ON bullmq_job (queue, seq)
+CREATE INDEX job_waiting_children_idx
+  ON job (queue, seq)
   WHERE state = 'waiting-children';
 
 -- Reverse lookup from a child to its parent (e.g. orphan/repair scans).
-CREATE INDEX bullmq_job_parent_idx
-  ON bullmq_job (parent_queue, parent_id)
+CREATE INDEX job_parent_idx
+  ON job (parent_queue, parent_id)
   WHERE parent_id IS NOT NULL;
 
 -- Locate the job(s) produced by a given scheduler.
-CREATE INDEX bullmq_job_scheduler_idx
-  ON bullmq_job (queue, scheduler_id)
+CREATE INDEX job_scheduler_idx
+  ON job (queue, scheduler_id)
   WHERE scheduler_id IS NOT NULL;
 
 -- ──────────────────────────────────────────────────────────────────────────
 -- Job logs (append-only, per-job ordered lines)
 -- ──────────────────────────────────────────────────────────────────────────
-CREATE TABLE bullmq_job_log (
+CREATE TABLE job_log (
   queue   text   NOT NULL,
   job_id  text   NOT NULL,
   idx     bigint NOT NULL,   -- per-job ordinal (0-based); range reads + trimming
   row     text   NOT NULL,
   PRIMARY KEY (queue, job_id, idx),
   FOREIGN KEY (queue, job_id)
-    REFERENCES bullmq_job (queue, id) ON DELETE CASCADE
+    REFERENCES job (queue, id) ON DELETE CASCADE
 );
 
 -- ──────────────────────────────────────────────────────────────────────────
@@ -221,27 +221,27 @@ CREATE TABLE bullmq_job_log (
 -- child sets with a single `status` column, and stores each processed child's
 -- return value (or failure reason) in `value`. `pending_deps` on the parent job
 -- is the count of rows here still in 'pending'.
-CREATE TABLE bullmq_job_dependency (
+CREATE TABLE job_dependency (
   parent_queue text NOT NULL,
   parent_id    text NOT NULL,
   child_queue  text NOT NULL,
   child_id     text NOT NULL,
   child_key    text NOT NULL,  -- denormalized "<queue>:<id>" (Redis-compatible "<prefix>:<queue>:<id>")
-  status       bullmq_dep_status NOT NULL DEFAULT 'pending',
+  status       dep_status NOT NULL DEFAULT 'pending',
   value        jsonb,
   PRIMARY KEY (parent_queue, parent_id, child_key),
   FOREIGN KEY (parent_queue, parent_id)
-    REFERENCES bullmq_job (queue, id) ON DELETE CASCADE
+    REFERENCES job (queue, id) ON DELETE CASCADE
 );
 
 -- Paginate a parent's children by category (processed / pending / …).
-CREATE INDEX bullmq_dep_parent_status_idx
-  ON bullmq_job_dependency (parent_queue, parent_id, status);
+CREATE INDEX dep_parent_status_idx
+  ON job_dependency (parent_queue, parent_id, status);
 
 -- Resolve dependencies from the child side (when a child finishes, or when a
 -- child dependency is explicitly removed).
-CREATE INDEX bullmq_dep_child_idx
-  ON bullmq_job_dependency (child_queue, child_id);
+CREATE INDEX dep_child_idx
+  ON job_dependency (child_queue, child_id);
 
 -- ──────────────────────────────────────────────────────────────────────────
 -- Event stream (QueueEvents)
@@ -250,16 +250,16 @@ CREATE INDEX bullmq_dep_child_idx
 -- consumers page forward with `id > cursor`. Blocking reads are delivered via
 -- LISTEN/NOTIFY (the operation layer NOTIFYs on insert); trimming deletes the
 -- lowest ids beyond the configured max length.
-CREATE TABLE bullmq_event (
+CREATE TABLE event (
   queue         text   NOT NULL,
-  id            bigint NOT NULL DEFAULT nextval('bullmq_event_seq'),
+  id            bigint NOT NULL DEFAULT nextval('event_seq'),
   event         text   NOT NULL,
   data          jsonb  NOT NULL DEFAULT '{}'::jsonb,
   created_at_ms bigint NOT NULL,
   PRIMARY KEY (queue, id)
 );
 
-CREATE TABLE bullmq_metrics (
+CREATE TABLE metrics (
   queue      text     NOT NULL,
   kind       text     NOT NULL,  -- 'completed' | 'failed'
   count      bigint   NOT NULL DEFAULT 0,  -- cumulative finished jobs
@@ -277,7 +277,7 @@ CREATE TABLE bullmq_metrics (
 -- Redis `<prefix>:<queue>:limiter` counter key (with its PTTL). The global
 -- limiter is the only mode the open-source backend supports (per-group rate
 -- limiting was removed in BullMQ 3.0).
-CREATE TABLE bullmq_rate_limit (
+CREATE TABLE rate_limit (
   queue        text    NOT NULL,
   points       bigint  NOT NULL DEFAULT 0,
   expire_at_ms bigint  NOT NULL,
@@ -287,7 +287,7 @@ CREATE TABLE bullmq_rate_limit (
 -- ──────────────────────────────────────────────────────────────────────────
 -- Deduplication keys
 -- ──────────────────────────────────────────────────────────────────────────
-CREATE TABLE bullmq_dedup (
+CREATE TABLE dedup (
   queue        text   NOT NULL,
   dedup_id     text   NOT NULL,
   job_id       text   NOT NULL,
@@ -296,10 +296,10 @@ CREATE TABLE bullmq_dedup (
 );
 
 -- Expired dedup keys are reclaimed lazily by operation functions in
--- 0002_functions.sql (for example bullmq_deduplicate_job and
--- bullmq_dedup_finalize). This index keeps those lookups/deletes efficient.
-CREATE INDEX bullmq_dedup_expire_idx
-  ON bullmq_dedup (queue, expire_at_ms)
+-- 0002_functions.sql (for example deduplicate_job and
+-- dedup_finalize). This index keeps those lookups/deletes efficient.
+CREATE INDEX dedup_expire_idx
+  ON dedup (queue, expire_at_ms)
   WHERE expire_at_ms IS NOT NULL;
 
 -- ──────────────────────────────────────────────────────────────────────────
@@ -311,7 +311,7 @@ CREATE INDEX bullmq_dedup_expire_idx
 -- computes nextMillis (JS cron-parser); for `every` the backend computes it,
 -- honouring `offset_ms` (the phase offset from `start_date`).
 -- ──────────────────────────────────────────────────────────────────────────
-CREATE TABLE bullmq_scheduler (
+CREATE TABLE scheduler (
   queue           text   NOT NULL,
   scheduler_id    text   NOT NULL,
   name            text,
@@ -331,8 +331,8 @@ CREATE TABLE bullmq_scheduler (
 );
 
 -- Find schedulers whose next iteration is due, and order schedulers by next run.
-CREATE INDEX bullmq_scheduler_next_idx
-  ON bullmq_scheduler (queue, next_run_ms);
+CREATE INDEX scheduler_next_idx
+  ON scheduler (queue, next_run_ms);
 
 -- ── keepLastIfActive proto-next storage ──────────────────────────────────
 -- When a job is deduplicated while its winner is *active* and keepLastIfActive
@@ -340,7 +340,7 @@ CREATE INDEX bullmq_scheduler_next_idx
 -- dedup key is persisted (no expiry). When the active winner finishes, the
 -- stashed payload is turned into a real job (the new winner). At most one
 -- proto-next exists per id; a later add while active overwrites it.
-CREATE TABLE bullmq_dedup_next (
+CREATE TABLE dedup_next (
   queue    text  NOT NULL,
   dedup_id text  NOT NULL,
   payload  jsonb NOT NULL,  -- { name, data, opts, jobId }

--- a/src/postgres/migrations/0002_functions.sql
+++ b/src/postgres/migrations/0002_functions.sql
@@ -8,7 +8,7 @@
 -- Per-queue job-id allocator
 -- ──────────────────────────────────────────────────────────────────────────
 -- BullMQ hands auto-generated job ids from a per-queue counter (Redis: INCR
--- <prefix>:<queue>:id). Implementing that as a `bullmq_meta` row bumped with
+-- <prefix>:<queue>:id). Implementing that as a `meta` row bumped with
 -- `ON CONFLICT DO UPDATE` serializes *every* concurrent `add` on that row's
 -- lock (held until commit), so parallel producers cannot make progress — by far
 -- the biggest `add` bottleneck. A dedicated per-queue SEQUENCE hands out ids via
@@ -16,20 +16,20 @@
 -- parallel. Ids are still 1, 2, 3, … per queue (sequence starts at 1), matching
 -- Redis; a rolled-back add may leave a gap, exactly as a failed Redis add leaves
 -- its INCR in place. The sequence is created lazily on first use and dropped by
--- `bullmq_obliterate`. If we ever need user-facing immutable ids independent from
+-- `obliterate`. If we ever need user-facing immutable ids independent from
 -- this allocator, we can add a separate custom-id column/index without regressing
 -- the hot-path insert concurrency.
-CREATE FUNCTION bullmq_job_id_seq_name(p_queue text) RETURNS text
+CREATE FUNCTION job_id_seq_name(p_queue text) RETURNS text
 LANGUAGE sql IMMUTABLE AS $$
   SELECT 'bullmq_jid_' || md5(p_queue)
 $$;
 
-CREATE FUNCTION bullmq_next_job_id(p_queue text) RETURNS text
+CREATE FUNCTION next_job_id(p_queue text) RETURNS text
 LANGUAGE plpgsql
 SET search_path FROM CURRENT
 AS $$
 DECLARE
-  v_seq text := bullmq_job_id_seq_name(p_queue);
+  v_seq text := job_id_seq_name(p_queue);
 BEGIN
   -- Fast path once the sequence exists: a cached catalog lookup + a lock-free
   -- `nextval`. Only the first add(s) for a queue take the creation path; the
@@ -44,7 +44,7 @@ END;
 $$;
 
 -- ── Recreate add_job to run the deduplication decision before inserting.
-CREATE OR REPLACE FUNCTION bullmq_add_job(
+CREATE OR REPLACE FUNCTION add_job(
   p_queue        text,
   p_id           text,
   p_name         text,
@@ -67,7 +67,7 @@ AS $$
 DECLARE
   v_id    text := p_id;
   v_seq   bigint;
-  v_state bullmq_job_state;
+  v_state job_state;
   v_process_at bigint;
   v_inserted boolean;
   v_dedup    jsonb;
@@ -85,14 +85,14 @@ BEGIN
   END IF;
 
   IF v_id IS NULL OR v_id = '' THEN
-    v_id := bullmq_next_job_id(p_queue);
+    v_id := next_job_id(p_queue);
   END IF;
 
   -- Deduplication: if a live key wins, skip the insert and return its id.
   IF p_dedup_id IS NOT NULL AND p_dedup_id <> '' THEN
     v_dedup := COALESCE(p_opts->'deduplication', p_opts->'debounce',
                         jsonb_build_object('id', p_dedup_id));
-    v_existing := bullmq_deduplicate_job(p_queue, v_dedup, v_id, p_timestamp,
+    v_existing := deduplicate_job(p_queue, v_dedup, v_id, p_timestamp,
       p_name, COALESCE(p_data, '{}'::jsonb), COALESCE(p_opts, '{}'::jsonb));
     IF v_existing IS NOT NULL THEN
       RETURN v_existing;
@@ -102,14 +102,14 @@ BEGIN
   -- Verify the parent exists before inserting (atomic: a failure rolls back).
   IF p_parent_id IS NOT NULL AND p_parent_queue IS NOT NULL THEN
     IF NOT EXISTS (
-      SELECT 1 FROM bullmq_job WHERE queue = p_parent_queue AND id = p_parent_id
+      SELECT 1 FROM job WHERE queue = p_parent_queue AND id = p_parent_id
     ) THEN
       RAISE EXCEPTION 'bullmq: missing parent %', p_parent_key
         USING ERRCODE = 'BM001', DETAIL = '-5';
     END IF;
   END IF;
 
-  v_seq := nextval('bullmq_job_seq');
+  v_seq := nextval('job_seq');
   IF p_lifo THEN
     v_seq := -v_seq;
   END IF;
@@ -122,7 +122,7 @@ BEGIN
     v_process_at := NULL;
   END IF;
 
-  INSERT INTO bullmq_job (
+  INSERT INTO job (
     queue, id, seq, name, state,
     data, opts, priority, delay_ms, max_attempts,
     added_at_ms, process_at_ms,
@@ -141,7 +141,7 @@ BEGIN
   GET DIAGNOSTICS v_inserted = ROW_COUNT;
 
   IF v_inserted AND p_parent_id IS NOT NULL AND p_parent_queue IS NOT NULL THEN
-    INSERT INTO bullmq_job_dependency (
+    INSERT INTO job_dependency (
       parent_queue, parent_id, child_queue, child_id, child_key, status
     ) VALUES (
       p_parent_queue, p_parent_id, p_queue, v_id,
@@ -149,7 +149,7 @@ BEGIN
     )
     ON CONFLICT (parent_queue, parent_id, child_key) DO NOTHING;
 
-    UPDATE bullmq_job
+    UPDATE job
        SET pending_deps = pending_deps + 1
      WHERE queue = p_parent_queue AND id = p_parent_id;
   END IF;
@@ -157,7 +157,7 @@ BEGIN
   -- The job already existed: re-attach it to the new parent (or, with no
   -- parent, just announce the duplicate). -7 = it already has a different one.
   IF NOT v_inserted THEN
-    IF bullmq_handle_duplicated_job(p_queue, v_id, p_parent_queue,
+    IF handle_duplicated_job(p_queue, v_id, p_parent_queue,
          p_parent_id, p_parent_key, p_timestamp) = -7 THEN
       RAISE EXCEPTION 'bullmq: parent cannot be replaced'
         USING ERRCODE = 'BM001', DETAIL = '-7';
@@ -167,13 +167,13 @@ BEGIN
   IF v_inserted THEN
     PERFORM pg_notify('bullmq_jobs', p_queue);
     -- Every stored job announces itself (mirrors storeJob.lua's 'added').
-    PERFORM bullmq_publish_event(p_queue, 'added',
+    PERFORM publish_event(p_queue, 'added',
       jsonb_build_object('jobId', v_id, 'name', p_name));
     IF v_state = 'delayed' THEN
-      PERFORM bullmq_publish_event(p_queue, 'delayed',
+      PERFORM publish_event(p_queue, 'delayed',
         jsonb_build_object('jobId', v_id, 'delay', v_process_at));
     ELSE
-      PERFORM bullmq_publish_event(p_queue, 'waiting',
+      PERFORM publish_event(p_queue, 'waiting',
         jsonb_build_object('jobId', v_id));
     END IF;
   END IF;
@@ -184,9 +184,9 @@ $$;
 
 -- ── move_to_active with limiter enforcement ────────────────────────────────
 -- Adds the limiter: after promoting due delayed jobs, refuse to claim while
--- rate limited (the caller reads the ttl via bullmq_next_signal), and consume a
+-- rate limited (the caller reads the ttl via next_signal), and consume a
 -- token when a job is claimed. Otherwise identical to the v23 definition.
-CREATE OR REPLACE FUNCTION bullmq_move_to_active(
+CREATE OR REPLACE FUNCTION move_to_active(
   p_queue            text,
   p_token            text,
   p_lock_ms          bigint,
@@ -194,13 +194,13 @@ CREATE OR REPLACE FUNCTION bullmq_move_to_active(
   p_name             text,
   p_limiter_max      integer,
   p_limiter_duration bigint
-) RETURNS SETOF bullmq_job
+) RETURNS SETOF job
 LANGUAGE plpgsql
 SET search_path FROM CURRENT
 AS $$
 DECLARE
   v_id       text;
-  v_job      bullmq_job;
+  v_job      job;
   v_meta_max integer;
   v_max      integer;
   v_duration bigint;
@@ -214,7 +214,7 @@ BEGIN
   -- but the claim/activate below is skipped.
   FOR v_id IN
     WITH promoted AS (
-      UPDATE bullmq_job
+      UPDATE job
          SET state = 'waiting', delay_ms = 0
        WHERE queue = p_queue
          AND state = 'delayed'
@@ -223,12 +223,12 @@ BEGIN
     )
     SELECT id FROM promoted
   LOOP
-    PERFORM bullmq_publish_event(p_queue, 'waiting',
+    PERFORM publish_event(p_queue, 'waiting',
       jsonb_build_object('jobId', v_id, 'prev', 'delayed'));
   END LOOP;
 
   IF EXISTS (
-    SELECT 1 FROM bullmq_meta
+    SELECT 1 FROM meta
      WHERE queue = p_queue AND field = 'paused' AND value = '1'
   ) THEN
     RETURN;
@@ -239,11 +239,11 @@ BEGIN
   -- advisory lock so concurrent workers cannot all pass the check and overshoot;
   -- it releases at commit, once this claim is reflected in the active count.
   SELECT value::integer INTO v_concurrency
-    FROM bullmq_meta WHERE queue = p_queue AND field = 'concurrency';
+    FROM meta WHERE queue = p_queue AND field = 'concurrency';
   IF v_concurrency IS NOT NULL THEN
     PERFORM pg_advisory_xact_lock(hashtext('bullmq:concurrency:' || p_queue));
     IF (
-      SELECT count(*) FROM bullmq_job
+      SELECT count(*) FROM job
        WHERE queue = p_queue AND state = 'active'
     ) >= v_concurrency THEN
       RETURN;
@@ -252,7 +252,7 @@ BEGIN
 
   -- Rate limit: meta `max` wins, else the worker's `limiter.max`.
   SELECT value::integer INTO v_meta_max
-    FROM bullmq_meta WHERE queue = p_queue AND field = 'max';
+    FROM meta WHERE queue = p_queue AND field = 'max';
   v_max := COALESCE(v_meta_max, p_limiter_max);
 
   IF v_max IS NOT NULL THEN
@@ -268,13 +268,13 @@ BEGIN
     -- (this function is always called standalone) and is only taken when a
     -- limiter actually applies, so unlimited queues pay nothing.
     PERFORM pg_advisory_xact_lock(hashtext('bullmq:limiter:' || p_queue));
-    IF bullmq_rate_limit_effective(p_queue, p_limiter_max, p_now) > 0 THEN
+    IF rate_limit_effective(p_queue, p_limiter_max, p_now) > 0 THEN
       RETURN;
     END IF;
   END IF;
 
   SELECT id INTO v_id
-    FROM bullmq_job
+    FROM job
    WHERE queue = p_queue AND state = 'waiting'
    ORDER BY priority, seq
    FOR UPDATE SKIP LOCKED
@@ -288,14 +288,14 @@ BEGIN
   -- worker's `limiter.duration` wins, else meta `duration`.
   IF v_max IS NOT NULL THEN
     SELECT value::bigint INTO v_duration
-      FROM bullmq_meta WHERE queue = p_queue AND field = 'duration';
+      FROM meta WHERE queue = p_queue AND field = 'duration';
     v_duration := COALESCE(p_limiter_duration, v_duration);
     IF v_duration IS NOT NULL THEN
-      PERFORM bullmq_rate_limit_consume(p_queue, v_duration, p_now);
+      PERFORM rate_limit_consume(p_queue, v_duration, p_now);
     END IF;
   END IF;
 
-  UPDATE bullmq_job
+  UPDATE job
      SET state = 'active',
          lock_token = p_token,
          locked_until_ms = p_now + p_lock_ms,
@@ -305,7 +305,7 @@ BEGIN
    WHERE queue = p_queue AND id = v_id
   RETURNING * INTO v_job;
 
-  PERFORM bullmq_publish_event(p_queue, 'active',
+  PERFORM publish_event(p_queue, 'active',
     jsonb_build_object('jobId', v_id, 'prev', 'waiting'));
 
   RETURN NEXT v_job;
@@ -316,16 +316,16 @@ $$;
 -- next_delay: the timestamp of the next delayed job (for worker block timing),
 -- or NULL when there are none.
 -- ──────────────────────────────────────────────────────────────────────────
-CREATE FUNCTION bullmq_next_delay(p_queue text) RETURNS bigint
+CREATE FUNCTION next_delay(p_queue text) RETURNS bigint
 LANGUAGE sql
 SET search_path FROM CURRENT
 AS $$
   SELECT MIN(process_at_ms)
-    FROM bullmq_job
+    FROM job
    WHERE queue = p_queue AND state = 'delayed';
 $$;
 
-CREATE OR REPLACE FUNCTION bullmq_move_to_completed(
+CREATE OR REPLACE FUNCTION move_to_completed(
   p_queue        text,
   p_id           text,
   p_token        text,
@@ -339,7 +339,7 @@ LANGUAGE plpgsql
 SET search_path FROM CURRENT
 AS $$
 DECLARE
-  v_state    bullmq_job_state;
+  v_state    job_state;
   v_lock     text;
   v_pq       text;
   v_pid      text;
@@ -355,7 +355,7 @@ BEGIN
   -- serialize. Mirrors Redis's single-threaded atomicity; auto-releases at
   -- commit and is only ever taken on the direct parent (never nested).
   SELECT parent_queue, parent_id INTO v_pq, v_pid
-    FROM bullmq_job WHERE queue = p_queue AND id = p_id;
+    FROM job WHERE queue = p_queue AND id = p_id;
   IF v_pq IS NOT NULL AND v_pid IS NOT NULL THEN
     PERFORM pg_advisory_xact_lock(
       hashtext('bullmq:parent:' || v_pq || ':' || v_pid));
@@ -363,7 +363,7 @@ BEGIN
 
   SELECT state, lock_token, parent_queue, parent_id, dedup_id
     INTO v_state, v_lock, v_pq, v_pid, v_dedup_id
-    FROM bullmq_job WHERE queue = p_queue AND id = p_id FOR UPDATE;
+    FROM job WHERE queue = p_queue AND id = p_id FOR UPDATE;
   IF NOT FOUND THEN
     RAISE EXCEPTION 'bullmq: missing job %', p_id USING ERRCODE = 'BM001', DETAIL = '-1';
   END IF;
@@ -378,21 +378,21 @@ BEGIN
   -- children → -4, failed children → -9 (mirrors moveToFinished-14.lua, which
   -- only enforces this on the "completed" path).
   IF EXISTS (
-    SELECT 1 FROM bullmq_job_dependency
+    SELECT 1 FROM job_dependency
      WHERE parent_queue = p_queue AND parent_id = p_id AND status = 'pending'
   ) THEN
     RAISE EXCEPTION 'bullmq: job % has pending dependencies', p_id
       USING ERRCODE = 'BM001', DETAIL = '-4';
   END IF;
   IF EXISTS (
-    SELECT 1 FROM bullmq_job_dependency
+    SELECT 1 FROM job_dependency
      WHERE parent_queue = p_queue AND parent_id = p_id AND status = 'failed'
   ) THEN
     RAISE EXCEPTION 'bullmq: job % has failed dependencies', p_id
       USING ERRCODE = 'BM001', DETAIL = '-9';
   END IF;
 
-  UPDATE bullmq_job
+  UPDATE job
      SET state = 'completed',
          return_value = p_return_value,
          finished_at_ms = p_finished_on,
@@ -401,7 +401,7 @@ BEGIN
          attempts_made = attempts_made + 1
    WHERE queue = p_queue AND id = p_id;
 
-  PERFORM bullmq_publish_event(p_queue, 'completed',
+  PERFORM publish_event(p_queue, 'completed',
     jsonb_build_object('jobId', p_id, 'returnvalue',
       COALESCE(p_return_value, 'null'::jsonb)::text, 'prev', 'active'));
 
@@ -411,12 +411,12 @@ BEGIN
   -- these mutations with any sibling finish op and with a concurrent parent
   -- removal, so the decrement cannot deadlock on the parent row.
   IF v_pid IS NOT NULL AND v_pq IS NOT NULL THEN
-    UPDATE bullmq_job_dependency
+    UPDATE job_dependency
        SET status = 'processed', value = p_return_value
      WHERE parent_queue = v_pq AND parent_id = v_pid
        AND child_key = p_queue || ':' || p_id;
 
-    UPDATE bullmq_job
+    UPDATE job
        SET pending_deps = GREATEST(pending_deps - 1, 0)
      WHERE queue = v_pq AND id = v_pid
     RETURNING pending_deps INTO v_remaining;
@@ -424,11 +424,11 @@ BEGIN
     IF v_remaining = 0 THEN
       -- Release the parent (delay-aware: a parent carrying a delay goes to the
       -- delayed set, a prioritized parent keeps its priority).
-      PERFORM bullmq_move_parent_to_wait(v_pq, v_pid, p_finished_on);
+      PERFORM move_parent_to_wait(v_pq, v_pid, p_finished_on);
     END IF;
   END IF;
 
-  PERFORM bullmq_apply_retention(
+  PERFORM apply_retention(
     p_queue, p_id, 'completed', p_finished_on, p_remove_all, p_keep_age, p_keep_count
   );
 
@@ -439,27 +439,27 @@ BEGIN
       hashtext('bullmq:dedup:' || p_queue || ':' || v_dedup_id));
   END IF;
   -- Clear a no-ttl deduplication key now that its winner has finished.
-  PERFORM bullmq_dedup_finalize(p_queue, v_dedup_id, p_id, p_finished_on);
+  PERFORM dedup_finalize(p_queue, v_dedup_id, p_id, p_finished_on);
   -- keepLastIfActive: turn any stashed proto-next into the new winner job.
-  PERFORM bullmq_requeue_dedup_next(p_queue, v_dedup_id, p_finished_on);
+  PERFORM requeue_dedup_next(p_queue, v_dedup_id, p_finished_on);
 
   -- run, announce the queue is drained. Redis checks the physical wait + active
   -- + prioritized lists; when paused, jobs live in the paused list, so the wait
   -- list is empty and 'drained' still fires. Here that is: no active jobs and
   -- (the queue is paused OR there are no waiting/prioritized jobs).
   IF NOT EXISTS (
-       SELECT 1 FROM bullmq_job WHERE queue = p_queue AND state = 'active'
+       SELECT 1 FROM job WHERE queue = p_queue AND state = 'active'
      )
      AND (
        EXISTS (
-         SELECT 1 FROM bullmq_meta
+         SELECT 1 FROM meta
           WHERE queue = p_queue AND field = 'paused' AND value = '1'
        )
        OR NOT EXISTS (
-         SELECT 1 FROM bullmq_job WHERE queue = p_queue AND state = 'waiting'
+         SELECT 1 FROM job WHERE queue = p_queue AND state = 'waiting'
        )
      ) THEN
-    PERFORM bullmq_publish_event(p_queue, 'drained', '{}'::jsonb);
+    PERFORM publish_event(p_queue, 'drained', '{}'::jsonb);
   END IF;
 
   RETURN p_finished_on;
@@ -470,7 +470,7 @@ $$;
 --
 -- A permanent failure (no retries left) emits a 'retries-exhausted' event in
 -- addition to 'failed'. Recreate move_to_failed (from 0010) to publish it.
-CREATE OR REPLACE FUNCTION bullmq_move_to_failed(
+CREATE OR REPLACE FUNCTION move_to_failed(
   p_queue         text,
   p_id            text,
   p_token         text,
@@ -485,13 +485,13 @@ LANGUAGE plpgsql
 SET search_path FROM CURRENT
 AS $$
 DECLARE
-  v_state    bullmq_job_state;
+  v_state    job_state;
   v_lock     text;
   v_dedup_id text;
   v_attempts integer;
 BEGIN
-  -- If this job is itself a flow parent, `removeOnFail` (bullmq_apply_retention
-  -- below) DELETEs it and, via the `bullmq_job_dependency … ON DELETE CASCADE`
+  -- If this job is itself a flow parent, `removeOnFail` (apply_retention
+  -- below) DELETEs it and, via the `job_dependency … ON DELETE CASCADE`
   -- FK, its child-dependency rows. A child finishing concurrently locks that
   -- same dependency row and then this job's row — the opposite order — which
   -- deadlocks (SQLSTATE 40P01). Take the per-parent advisory lock (keyed on this
@@ -502,7 +502,7 @@ BEGIN
     hashtext('bullmq:parent:' || p_queue || ':' || p_id));
 
   SELECT state, lock_token, dedup_id INTO v_state, v_lock, v_dedup_id
-    FROM bullmq_job WHERE queue = p_queue AND id = p_id FOR UPDATE;
+    FROM job WHERE queue = p_queue AND id = p_id FOR UPDATE;
   IF NOT FOUND THEN
     RAISE EXCEPTION 'bullmq: missing job %', p_id USING ERRCODE = 'BM001', DETAIL = '-1';
   END IF;
@@ -513,7 +513,7 @@ BEGIN
     RAISE EXCEPTION 'bullmq: job % lock mismatch', p_id USING ERRCODE = 'BM001', DETAIL = '-6';
   END IF;
 
-  UPDATE bullmq_job
+  UPDATE job
      SET state = 'failed',
          failed_reason = p_failed_reason,
          stacktrace = COALESCE(p_stacktrace, stacktrace),
@@ -525,18 +525,18 @@ BEGIN
    WHERE queue = p_queue AND id = p_id
   RETURNING attempts_made INTO v_attempts;
 
-  PERFORM bullmq_publish_event(p_queue, 'failed',
+  PERFORM publish_event(p_queue, 'failed',
     jsonb_build_object('jobId', p_id, 'failedReason', p_failed_reason, 'prev', 'active'));
 
   -- A final failure (reached this function rather than retry/delay) exhausts
   -- the job's attempts.
-  PERFORM bullmq_publish_event(p_queue, 'retries-exhausted',
+  PERFORM publish_event(p_queue, 'retries-exhausted',
     jsonb_build_object('jobId', p_id, 'attemptsMade', v_attempts));
 
   -- Propagate the permanent failure to a parent flow job (fpof/cpof/idof/rdof).
-  PERFORM bullmq_handle_child_failure(p_queue, p_id, p_failed_reason, p_finished_on);
+  PERFORM handle_child_failure(p_queue, p_id, p_failed_reason, p_finished_on);
 
-  PERFORM bullmq_apply_retention(
+  PERFORM apply_retention(
     p_queue, p_id, 'failed', p_finished_on, p_remove_all, p_keep_age, p_keep_count
   );
 
@@ -547,25 +547,25 @@ BEGIN
       hashtext('bullmq:dedup:' || p_queue || ':' || v_dedup_id));
   END IF;
   -- Clear a no-ttl deduplication key now that its winner has finished.
-  PERFORM bullmq_dedup_finalize(p_queue, v_dedup_id, p_id, p_finished_on);
+  PERFORM dedup_finalize(p_queue, v_dedup_id, p_id, p_finished_on);
   -- keepLastIfActive: turn any stashed proto-next into the new winner job.
-  PERFORM bullmq_requeue_dedup_next(p_queue, v_dedup_id, p_finished_on);
+  PERFORM requeue_dedup_next(p_queue, v_dedup_id, p_finished_on);
 
   -- finishes and nothing is left to run (no active and either paused or no
-  -- waiting/prioritized jobs — see bullmq_move_to_completed).
+  -- waiting/prioritized jobs — see move_to_completed).
   IF NOT EXISTS (
-       SELECT 1 FROM bullmq_job WHERE queue = p_queue AND state = 'active'
+       SELECT 1 FROM job WHERE queue = p_queue AND state = 'active'
      )
      AND (
        EXISTS (
-         SELECT 1 FROM bullmq_meta
+         SELECT 1 FROM meta
           WHERE queue = p_queue AND field = 'paused' AND value = '1'
        )
        OR NOT EXISTS (
-         SELECT 1 FROM bullmq_job WHERE queue = p_queue AND state = 'waiting'
+         SELECT 1 FROM job WHERE queue = p_queue AND state = 'waiting'
        )
      ) THEN
-    PERFORM bullmq_publish_event(p_queue, 'drained', '{}'::jsonb);
+    PERFORM publish_event(p_queue, 'drained', '{}'::jsonb);
   END IF;
 
   RETURN p_finished_on;
@@ -576,7 +576,7 @@ $$;
 -- extend_lock: refresh an active job's lock if the token still holds it.
 -- Returns 1 on success, 0 if the lock was lost.
 -- ──────────────────────────────────────────────────────────────────────────
-CREATE FUNCTION bullmq_extend_lock(
+CREATE FUNCTION extend_lock(
   p_queue    text,
   p_id       text,
   p_token    text,
@@ -589,7 +589,7 @@ AS $$
 DECLARE
   v_updated integer;
 BEGIN
-  UPDATE bullmq_job
+  UPDATE job
      SET locked_until_ms = p_now + p_lock_ms
    WHERE queue = p_queue
      AND id = p_id
@@ -601,7 +601,7 @@ BEGIN
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION bullmq_move_to_delayed(
+CREATE OR REPLACE FUNCTION move_to_delayed(
   p_queue         text,
   p_id            text,
   p_token         text,
@@ -615,11 +615,11 @@ LANGUAGE plpgsql
 SET search_path FROM CURRENT
 AS $$
 DECLARE
-  v_state bullmq_job_state;
+  v_state job_state;
   v_lock  text;
 BEGIN
   SELECT state, lock_token INTO v_state, v_lock
-    FROM bullmq_job WHERE queue = p_queue AND id = p_id FOR UPDATE;
+    FROM job WHERE queue = p_queue AND id = p_id FOR UPDATE;
   IF NOT FOUND THEN
     RAISE EXCEPTION 'bullmq: missing job %', p_id USING ERRCODE = 'BM001', DETAIL = '-1';
   END IF;
@@ -630,7 +630,7 @@ BEGIN
     RAISE EXCEPTION 'bullmq: job % lock mismatch', p_id USING ERRCODE = 'BM001', DETAIL = '-6';
   END IF;
 
-  UPDATE bullmq_job
+  UPDATE job
      SET state = 'delayed',
          process_at_ms = p_process_at,
          delay_ms = p_delay,
@@ -644,7 +644,7 @@ BEGIN
   -- Announce the delay on the event stream (mirrors moveToDelayed's XADD
   -- 'delayed'); QueueEvents consumers rely on this. `delay` carries the
   -- absolute timestamp the job becomes due, matching the Redis payload.
-  PERFORM bullmq_publish_event(p_queue, 'delayed',
+  PERFORM publish_event(p_queue, 'delayed',
     jsonb_build_object('jobId', p_id, 'delay', p_process_at));
   PERFORM pg_notify('bullmq_jobs', p_queue);
   RETURN 1;
@@ -655,7 +655,7 @@ $$;
 --
 -- An immediately-retried job transitions active → waiting, so the 'waiting'
 -- event's `prev` is 'active' (not 'failed'). Recreate retry_job accordingly.
-CREATE OR REPLACE FUNCTION bullmq_retry_job(
+CREATE OR REPLACE FUNCTION retry_job(
   p_queue         text,
   p_id            text,
   p_token         text,
@@ -667,12 +667,12 @@ LANGUAGE plpgsql
 SET search_path FROM CURRENT
 AS $$
 DECLARE
-  v_state bullmq_job_state;
+  v_state job_state;
   v_lock  text;
   v_seq   bigint;
 BEGIN
   SELECT state, lock_token INTO v_state, v_lock
-    FROM bullmq_job WHERE queue = p_queue AND id = p_id FOR UPDATE;
+    FROM job WHERE queue = p_queue AND id = p_id FOR UPDATE;
   IF NOT FOUND THEN
     RAISE EXCEPTION 'bullmq: missing job %', p_id USING ERRCODE = 'BM001', DETAIL = '-1';
   END IF;
@@ -683,12 +683,12 @@ BEGIN
     RAISE EXCEPTION 'bullmq: job % lock mismatch', p_id USING ERRCODE = 'BM001', DETAIL = '-6';
   END IF;
 
-  v_seq := nextval('bullmq_job_seq');
+  v_seq := nextval('job_seq');
   IF p_lifo THEN
     v_seq := -v_seq;
   END IF;
 
-  UPDATE bullmq_job
+  UPDATE job
      SET state = 'waiting',
          seq = v_seq,
          process_at_ms = NULL,
@@ -700,7 +700,7 @@ BEGIN
    WHERE queue = p_queue AND id = p_id;
 
   PERFORM pg_notify('bullmq_jobs', p_queue);
-  PERFORM bullmq_publish_event(p_queue, 'waiting',
+  PERFORM publish_event(p_queue, 'waiting',
     jsonb_build_object('jobId', p_id, 'prev', 'active'));
   RETURN 1;
 END;
@@ -712,10 +712,10 @@ $$;
 -- a job exactly on the boundary (finished_at = now - age*1000) is removed, so
 -- the comparison is `<=`, not `<` (matches Redis: keep jobs with score above
 -- the cutoff). Otherwise an N-second window keeps N+1 jobs.
-CREATE OR REPLACE FUNCTION bullmq_apply_retention(
+CREATE OR REPLACE FUNCTION apply_retention(
   p_queue       text,
   p_id          text,
-  p_state       bullmq_job_state,
+  p_state       job_state,
   p_now         bigint,
   p_remove_all  boolean,
   p_keep_age    bigint,
@@ -735,28 +735,28 @@ BEGIN
     -- pending dependency (mirrors removeParentDependencyKey on removal). A
     -- processed/failed dependency is left untouched so the parent keeps it.
     SELECT parent_queue, parent_id INTO v_pq, v_pid
-      FROM bullmq_job WHERE queue = p_queue AND id = p_id;
+      FROM job WHERE queue = p_queue AND id = p_id;
     IF v_pq IS NOT NULL AND v_pid IS NOT NULL THEN
-      DELETE FROM bullmq_job_dependency
+      DELETE FROM job_dependency
        WHERE parent_queue = v_pq AND parent_id = v_pid
          AND child_key = p_queue || ':' || p_id
          AND status = 'pending';
       IF FOUND THEN
-        UPDATE bullmq_job SET pending_deps = GREATEST(pending_deps - 1, 0)
+        UPDATE job SET pending_deps = GREATEST(pending_deps - 1, 0)
          WHERE queue = v_pq AND id = v_pid
         RETURNING pending_deps INTO v_remaining;
         IF v_remaining = 0 THEN
-          PERFORM bullmq_move_parent_to_wait(v_pq, v_pid, p_now);
+          PERFORM move_parent_to_wait(v_pq, v_pid, p_now);
         END IF;
       END IF;
     END IF;
 
-    DELETE FROM bullmq_job WHERE queue = p_queue AND id = p_id;
+    DELETE FROM job WHERE queue = p_queue AND id = p_id;
     RETURN;
   END IF;
 
   IF p_keep_age IS NOT NULL AND p_keep_age >= 0 THEN
-    DELETE FROM bullmq_job
+    DELETE FROM job
      WHERE queue = p_queue
        AND state = p_state
        AND finished_at_ms <= p_now - p_keep_age * 1000;
@@ -766,11 +766,11 @@ BEGIN
   -- where -1 disables count-based trimming); skip it — a negative SQL LIMIT is
   -- a hard error.
   IF p_keep_count IS NOT NULL AND p_keep_count >= 0 THEN
-    DELETE FROM bullmq_job
+    DELETE FROM job
      WHERE queue = p_queue
        AND state = p_state
        AND id NOT IN (
-         SELECT id FROM bullmq_job
+         SELECT id FROM job
           WHERE queue = p_queue AND state = p_state
           ORDER BY finished_at_ms DESC, seq DESC
           LIMIT p_keep_count
@@ -782,7 +782,7 @@ $$;
 -- BullMQ PostgreSQL backend — event stream (schema version 6).
 --
 -- QueueEvents consumes an append-only event stream. In Redis this is an XADD
--- stream read with a blocking XREAD; here events live in `bullmq_event` (a
+-- stream read with a blocking XREAD; here events live in `event` (a
 -- globally-ordered id per insert) and blocking reads use LISTEN/NOTIFY on the
 -- shared `bullmq_events` channel. This migration adds the publish helper and
 -- weaves event emission into the lifecycle operations.
@@ -792,7 +792,7 @@ $$;
 -- stream to the queue's configured max length (`opts.maxLenEvents`, default
 -- 10000). Returns the new event id.
 -- ──────────────────────────────────────────────────────────────────────────
-CREATE FUNCTION bullmq_publish_event(
+CREATE FUNCTION publish_event(
   p_queue text,
   p_event text,
   p_data  jsonb
@@ -804,7 +804,7 @@ DECLARE
   v_id      bigint;
   v_max     integer;
 BEGIN
-  INSERT INTO bullmq_event (queue, event, data, created_at_ms)
+  INSERT INTO event (queue, event, data, created_at_ms)
   VALUES (
     p_queue, p_event, COALESCE(p_data, '{}'::jsonb),
     (extract(epoch FROM clock_timestamp()) * 1000)::bigint
@@ -831,13 +831,13 @@ BEGIN
   END IF;
 
   SELECT value::integer INTO v_max
-    FROM bullmq_meta
+    FROM meta
    WHERE queue = p_queue AND field = 'opts.maxLenEvents';
   IF v_max IS NULL THEN
     v_max := 10000;
   END IF;
 
-  -- Trim to (approximately) the most recent `v_max` events. `bullmq_event.id`
+  -- Trim to (approximately) the most recent `v_max` events. `event.id`
   -- comes from a monotonic sequence, so the cutoff is simply `id - v_max` — an
   -- O(number-of-deleted-rows) DELETE.
   --
@@ -845,14 +845,14 @@ BEGIN
   -- it. Redis's `XADD MAXLEN ~` likewise trims a whole macro-node at a time
   -- rather than on every add — trimming eagerly turns a bulk/concurrent insert
   -- into a stream of DELETEs that contend (and previously deadlocked) with the
-  -- concurrent INSERTs on `bullmq_event`. At 1/256 the table stays within
+  -- concurrent INSERTs on `event`. At 1/256 the table stays within
   -- `v_max + 256`, which is well inside the "approximate" contract. A
   -- non-blocking, per-queue advisory lock further ensures at most one trimmer
   -- per queue at a time; publishers that miss it simply skip (the next one
   -- covers the same rows).
   IF v_max > 0 AND v_id > v_max AND (v_id % 256) = 0 THEN
     IF pg_try_advisory_xact_lock(hashtext('bullmq:evtrim:' || p_queue)) THEN
-      DELETE FROM bullmq_event
+      DELETE FROM event
        WHERE queue = p_queue AND id <= v_id - v_max;
     END IF;
   END IF;
@@ -861,7 +861,7 @@ BEGIN
 END;
 $$;
 
-CREATE FUNCTION bullmq_update_progress(
+CREATE FUNCTION update_progress(
   p_queue    text,
   p_id       text,
   p_progress jsonb
@@ -872,12 +872,12 @@ AS $$
 DECLARE
   v_updated integer;
 BEGIN
-  UPDATE bullmq_job SET progress = p_progress
+  UPDATE job SET progress = p_progress
    WHERE queue = p_queue AND id = p_id;
   GET DIAGNOSTICS v_updated = ROW_COUNT;
 
   IF v_updated > 0 THEN
-    PERFORM bullmq_publish_event(p_queue, 'progress',
+    PERFORM publish_event(p_queue, 'progress',
       jsonb_build_object('jobId', p_id, 'data', p_progress::text));
   END IF;
 
@@ -893,20 +893,20 @@ $$;
 -- ──────────────────────────────────────────────────────────────────────────
 -- pause: set/clear the queue's paused flag (an O(1) meta flag — no bulk move).
 -- ──────────────────────────────────────────────────────────────────────────
-CREATE FUNCTION bullmq_pause(p_queue text, p_paused boolean) RETURNS void
+CREATE FUNCTION pause(p_queue text, p_paused boolean) RETURNS void
 LANGUAGE plpgsql
 SET search_path FROM CURRENT
 AS $$
 BEGIN
   IF p_paused THEN
-    INSERT INTO bullmq_meta (queue, field, value)
+    INSERT INTO meta (queue, field, value)
     VALUES (p_queue, 'paused', '1')
     ON CONFLICT (queue, field) DO UPDATE SET value = '1';
   ELSE
     -- Resume mirrors Redis `HDEL meta paused`: the field is removed entirely,
     -- so `isPaused` (hasQueueMetaField 'paused') reports false rather than
     -- finding a lingering '0'.
-    DELETE FROM bullmq_meta WHERE queue = p_queue AND field = 'paused';
+    DELETE FROM meta WHERE queue = p_queue AND field = 'paused';
 
     -- Wake any worker blocked in waitForJob (LISTEN bullmq_jobs): jobs that were
     -- unclaimable only because the queue was paused are now claimable, but no
@@ -916,14 +916,14 @@ BEGIN
     PERFORM pg_notify('bullmq_jobs', p_queue);
   END IF;
 
-  PERFORM bullmq_publish_event(
+  PERFORM publish_event(
     p_queue, CASE WHEN p_paused THEN 'paused' ELSE 'resumed' END, '{}'::jsonb
   );
 END;
 $$;
 
 -- drain: never remove scheduler jobs.
-CREATE OR REPLACE FUNCTION bullmq_drain(p_queue text, p_delayed boolean)
+CREATE OR REPLACE FUNCTION drain(p_queue text, p_delayed boolean)
 RETURNS void
 LANGUAGE plpgsql
 SET search_path FROM CURRENT
@@ -937,15 +937,15 @@ BEGIN
     INTO v_pq, v_pid
   FROM (
     SELECT DISTINCT parent_queue, parent_id
-      FROM bullmq_job
+      FROM job
      WHERE queue = p_queue
        AND parent_id IS NOT NULL
        AND scheduler_id IS NULL
        AND (state = 'waiting' OR (p_delayed AND state = 'delayed'))
   ) s;
 
-  DELETE FROM bullmq_job_dependency d
-   USING bullmq_job j
+  DELETE FROM job_dependency d
+   USING job j
    WHERE j.queue = p_queue
      AND (j.state = 'waiting' OR (p_delayed AND j.state = 'delayed'))
      AND j.parent_id IS NOT NULL
@@ -955,36 +955,36 @@ BEGIN
      AND d.child_queue = j.queue
      AND d.child_id = j.id;
 
-  DELETE FROM bullmq_job
+  DELETE FROM job
    WHERE queue = p_queue
      AND scheduler_id IS NULL
      AND (state = 'waiting' OR (p_delayed AND state = 'delayed'));
 
   IF v_pq IS NOT NULL THEN
     FOR i IN 1 .. array_length(v_pq, 1) LOOP
-      UPDATE bullmq_job p
+      UPDATE job p
          SET pending_deps = (
-           SELECT count(*) FROM bullmq_job_dependency d
+           SELECT count(*) FROM job_dependency d
             WHERE d.parent_queue = v_pq[i]
               AND d.parent_id = v_pid[i]
               AND d.status = 'pending'
          )
        WHERE p.queue = v_pq[i] AND p.id = v_pid[i];
 
-      PERFORM 1 FROM bullmq_job p
+      PERFORM 1 FROM job p
        WHERE p.queue = v_pq[i] AND p.id = v_pid[i]
          AND p.state = 'waiting-children'
          AND p.pending_deps = 0;
 
       IF FOUND THEN
         IF v_pq[i] = p_queue THEN
-          DELETE FROM bullmq_job WHERE queue = v_pq[i] AND id = v_pid[i];
+          DELETE FROM job WHERE queue = v_pq[i] AND id = v_pid[i];
         ELSE
-          UPDATE bullmq_job
-             SET state = 'waiting', seq = nextval('bullmq_job_seq')
+          UPDATE job
+             SET state = 'waiting', seq = nextval('job_seq')
            WHERE queue = v_pq[i] AND id = v_pid[i];
           PERFORM pg_notify('bullmq_jobs', v_pq[i]);
-          PERFORM bullmq_publish_event(v_pq[i], 'waiting',
+          PERFORM publish_event(v_pq[i], 'waiting',
             jsonb_build_object('jobId', v_pid[i], 'prev', 'waiting-children'));
         END IF;
       END IF;
@@ -1011,7 +1011,7 @@ $$;
 --     the parent to wait when that clears its last pending dependency;
 --   * recursively deletes the subtree (children linked via parent_queue/
 --     parent_id) and clears each removed job's deduplication key.
-CREATE OR REPLACE FUNCTION bullmq_remove(
+CREATE OR REPLACE FUNCTION remove(
   p_queue text, p_id text, p_remove_children boolean
 ) RETURNS integer
 LANGUAGE plpgsql
@@ -1030,7 +1030,7 @@ DECLARE
 BEGIN
   SELECT true, scheduler_id, parent_queue, parent_id
     INTO v_found, v_scheduler, v_pq, v_pid
-    FROM bullmq_job WHERE queue = p_queue AND id = p_id;
+    FROM job WHERE queue = p_queue AND id = p_id;
 
   IF NOT COALESCE(v_found, false) THEN
     RETURN 0;
@@ -1049,18 +1049,18 @@ BEGIN
       UNION
       SELECT d.child_queue, d.child_id
         FROM subtree s
-        JOIN bullmq_job_dependency d
+        JOIN job_dependency d
           ON d.parent_queue = s.q AND d.parent_id = s.id
          AND d.status = 'pending'
     )
     SELECT EXISTS (
       SELECT 1 FROM subtree s
-       JOIN bullmq_job j ON j.queue = s.q AND j.id = s.id
+       JOIN job j ON j.queue = s.q AND j.id = s.id
       WHERE j.lock_token IS NOT NULL AND j.locked_until_ms > v_now
     ) INTO v_locked;
   ELSE
     SELECT lock_token IS NOT NULL AND locked_until_ms > v_now INTO v_locked
-      FROM bullmq_job WHERE queue = p_queue AND id = p_id;
+      FROM job WHERE queue = p_queue AND id = p_id;
   END IF;
 
   IF v_locked THEN
@@ -1071,16 +1071,16 @@ BEGIN
   -- clears the parent's last pending dependency, promote it to wait. Only
   -- pending links matter (a processed/failed child was already accounted for).
   IF v_pq IS NOT NULL AND v_pid IS NOT NULL THEN
-    DELETE FROM bullmq_job_dependency
+    DELETE FROM job_dependency
      WHERE parent_queue = v_pq AND parent_id = v_pid
        AND child_key = p_queue || ':' || p_id
        AND status = 'pending';
     IF FOUND THEN
-      UPDATE bullmq_job SET pending_deps = GREATEST(pending_deps - 1, 0)
+      UPDATE job SET pending_deps = GREATEST(pending_deps - 1, 0)
        WHERE queue = v_pq AND id = v_pid
       RETURNING pending_deps INTO v_remaining;
       IF v_remaining = 0 THEN
-        PERFORM bullmq_move_parent_to_wait(v_pq, v_pid, v_now);
+        PERFORM move_parent_to_wait(v_pq, v_pid, v_now);
       END IF;
     END IF;
   END IF;
@@ -1090,23 +1090,23 @@ BEGIN
     FOR r IN
       WITH RECURSIVE subtree AS (
         SELECT p_queue AS q, p_id AS id, dedup_id AS dd
-          FROM bullmq_job WHERE queue = p_queue AND id = p_id
+          FROM job WHERE queue = p_queue AND id = p_id
         UNION
         SELECT j.queue, j.id, j.dedup_id
           FROM subtree s
-          JOIN bullmq_job j ON j.parent_queue = s.q AND j.parent_id = s.id
+          JOIN job j ON j.parent_queue = s.q AND j.parent_id = s.id
       )
       SELECT q, id, dd FROM subtree
     LOOP
-      PERFORM bullmq_dedup_on_removal(r.q, r.id, r.dd);
-      DELETE FROM bullmq_job WHERE queue = r.q AND id = r.id;
+      PERFORM dedup_on_removal(r.q, r.id, r.dd);
+      DELETE FROM job WHERE queue = r.q AND id = r.id;
       v_deleted := v_deleted + 1;
     END LOOP;
   ELSE
-    PERFORM bullmq_dedup_on_removal(
+    PERFORM dedup_on_removal(
       p_queue, p_id,
-      (SELECT dedup_id FROM bullmq_job WHERE queue = p_queue AND id = p_id));
-    DELETE FROM bullmq_job WHERE queue = p_queue AND id = p_id;
+      (SELECT dedup_id FROM job WHERE queue = p_queue AND id = p_id));
+    DELETE FROM job WHERE queue = p_queue AND id = p_id;
     GET DIAGNOSTICS v_deleted = ROW_COUNT;
   END IF;
 
@@ -1118,7 +1118,7 @@ $$;
 -- retry_jobs: move up to `count` finished jobs of a state back to waiting.
 -- Returns the number moved (the caller loops until it returns 0).
 -- ──────────────────────────────────────────────────────────────────────────
-CREATE FUNCTION bullmq_retry_jobs(
+CREATE FUNCTION retry_jobs(
   p_queue text, p_state text, p_count integer, p_timestamp bigint
 ) RETURNS integer
 LANGUAGE plpgsql
@@ -1128,16 +1128,16 @@ DECLARE
   v_moved integer;
 BEGIN
   WITH batch AS (
-    SELECT id FROM bullmq_job
+    SELECT id FROM job
      WHERE queue = p_queue
-       AND state = p_state::bullmq_job_state
+       AND state = p_state::job_state
        AND (p_timestamp IS NULL OR finished_at_ms <= p_timestamp)
      ORDER BY finished_at_ms
      LIMIT p_count
   )
-  UPDATE bullmq_job j
+  UPDATE job j
      SET state = 'waiting',
-         seq = nextval('bullmq_job_seq'),
+         seq = nextval('job_seq'),
          finished_at_ms = NULL,
          processed_at_ms = NULL,
          return_value = NULL,
@@ -1162,7 +1162,7 @@ $$;
 -- promote_jobs: move up to `count` delayed jobs to waiting (process now).
 -- Returns the number moved (the caller loops until it returns 0).
 -- ──────────────────────────────────────────────────────────────────────────
-CREATE FUNCTION bullmq_promote_jobs(p_queue text, p_count integer)
+CREATE FUNCTION promote_jobs(p_queue text, p_count integer)
 RETURNS integer
 LANGUAGE plpgsql
 SET search_path FROM CURRENT
@@ -1171,13 +1171,13 @@ DECLARE
   v_moved integer;
 BEGIN
   WITH batch AS (
-    SELECT id FROM bullmq_job
+    SELECT id FROM job
      WHERE queue = p_queue AND state = 'delayed'
      ORDER BY process_at_ms
      LIMIT p_count
   )
-  UPDATE bullmq_job j
-     SET state = 'waiting', process_at_ms = NULL, seq = nextval('bullmq_job_seq')
+  UPDATE job j
+     SET state = 'waiting', process_at_ms = NULL, seq = nextval('job_seq')
     FROM batch
    WHERE j.queue = p_queue AND j.id = batch.id;
 
@@ -1195,7 +1195,7 @@ $$;
 -- ascending seq order (the getter layer reverses them for `asc`); zset-like
 -- states honour the requested direction.
 -- ──────────────────────────────────────────────────────────────────────────
-CREATE FUNCTION bullmq_get_range(
+CREATE FUNCTION get_range(
   p_queue text, p_type text, p_start integer, p_end integer, p_asc boolean
 ) RETURNS SETOF text
 LANGUAGE plpgsql
@@ -1238,7 +1238,7 @@ BEGIN
   END IF;
 
   RETURN QUERY EXECUTE format(
-    'SELECT id FROM bullmq_job WHERE queue = %L AND %s ORDER BY %s %s OFFSET %s LIMIT %s',
+    'SELECT id FROM job WHERE queue = %L AND %s ORDER BY %s %s OFFSET %s LIMIT %s',
     p_queue, v_where, v_order, v_dir, v_offset, v_limit
   );
 END;
@@ -1246,7 +1246,7 @@ $$;
 
 -- BullMQ PostgreSQL backend — flows (schema version 8).
 --
--- `bullmq_add_flow` atomically inserts a whole tree of jobs (possibly spanning
+-- `add_flow` atomically inserts a whole tree of jobs (possibly spanning
 -- multiple queues) from a single JSONB array of entries, ordered roots-first so
 -- a parent always exists before its children register a dependency. `drain` is
 -- recreated to be flow-aware: when draining a queue's children resolves a
@@ -1275,7 +1275,7 @@ $$;
 --      model) for callers that do not use QueueEvents, removing the event
 --      insert entirely.
 -- ──────────────────────────────────────────────────────────────────────────
-CREATE FUNCTION bullmq_add_flow(p_entries jsonb) RETURNS SETOF text
+CREATE FUNCTION add_flow(p_entries jsonb) RETURNS SETOF text
 LANGUAGE plpgsql
 SET search_path FROM CURRENT
 AS $$
@@ -1283,7 +1283,7 @@ DECLARE
   e              jsonb;
   v_id           text;
   v_seq          bigint;
-  v_state        bullmq_job_state;
+  v_state        job_state;
   v_process_at   bigint;
   v_queue        text;
   v_delay        bigint;
@@ -1297,7 +1297,7 @@ DECLARE
   v_winner       text;
   v_inserted     boolean;
   v_code         integer;
-  -- Lifecycle-event accumulation. Rather than PERFORM bullmq_publish_event per
+  -- Lifecycle-event accumulation. Rather than PERFORM publish_event per
   -- job (which turns a 1000-job addBulk into ~2000 extra statement executions —
   -- the dominant cost of a single-connection bulk add), events are collected
   -- here and flushed in ONE set-based INSERT after the loop. Appending to a
@@ -1329,7 +1329,7 @@ BEGIN
     END IF;
 
     IF v_id IS NULL OR v_id = '' THEN
-      v_id := bullmq_next_job_id(v_queue);
+      v_id := next_job_id(v_queue);
     END IF;
 
     -- Root deduplication: if a live key already won, return its id and skip
@@ -1338,7 +1338,7 @@ BEGIN
       v_dedup := COALESCE(e -> 'opts' -> 'deduplication',
                           e -> 'opts' -> 'debounce',
                           jsonb_build_object('id', v_dedup_id));
-      v_winner := bullmq_deduplicate_job(v_queue, v_dedup, v_id, v_timestamp,
+      v_winner := deduplicate_job(v_queue, v_dedup, v_id, v_timestamp,
         e ->> 'name', COALESCE((e ->> 'data')::jsonb, '{}'::jsonb),
         COALESCE(e -> 'opts', '{}'::jsonb));
       IF v_winner IS NOT NULL THEN
@@ -1352,14 +1352,14 @@ BEGIN
     -- without aborting the rest of the flow.
     IF v_parent_id IS NOT NULL AND v_parent_queue IS NOT NULL
        AND NOT EXISTS (
-         SELECT 1 FROM bullmq_job
+         SELECT 1 FROM job
           WHERE queue = v_parent_queue AND id = v_parent_id
        ) THEN
       RETURN NEXT '-5';
       CONTINUE;
     END IF;
 
-    v_seq := nextval('bullmq_job_seq');
+    v_seq := nextval('job_seq');
     IF v_lifo THEN
       v_seq := -v_seq;
     END IF;
@@ -1375,7 +1375,7 @@ BEGIN
       v_process_at := NULL;
     END IF;
 
-    INSERT INTO bullmq_job (
+    INSERT INTO job (
       queue, id, seq, name, state,
       data, opts, priority, delay_ms, max_attempts,
       added_at_ms, process_at_ms,
@@ -1397,7 +1397,7 @@ BEGIN
     IF v_parent_id IS NOT NULL AND v_parent_queue IS NOT NULL THEN
       IF v_inserted THEN
         -- New job: register a pending dependency on its parent.
-        INSERT INTO bullmq_job_dependency (
+        INSERT INTO job_dependency (
           parent_queue, parent_id, child_queue, child_id, child_key, status
         ) VALUES (
           v_parent_queue, v_parent_id, v_queue, v_id,
@@ -1405,13 +1405,13 @@ BEGIN
         )
         ON CONFLICT (parent_queue, parent_id, child_key) DO NOTHING;
 
-        UPDATE bullmq_job
+        UPDATE job
            SET pending_deps = pending_deps + 1
          WHERE queue = v_parent_queue AND id = v_parent_id;
       ELSE
         -- The job already existed: re-attach it to this new parent (mirrors
         -- handleDuplicatedJob). -7 means it already has a different parent.
-        v_code := bullmq_handle_duplicated_job(v_queue, v_id,
+        v_code := handle_duplicated_job(v_queue, v_id,
           v_parent_queue, v_parent_id, e ->> 'parentKey', v_timestamp);
         IF v_code = -7 THEN
           RETURN NEXT '-7';
@@ -1455,10 +1455,10 @@ BEGIN
 
   -- ── Flush accumulated lifecycle events in one statement ──────────────────
   IF array_length(v_ev_queue, 1) > 0 THEN
-    -- Single set-based append. The id DEFAULT nextval('bullmq_event_seq') is
+    -- Single set-based append. The id DEFAULT nextval('event_seq') is
     -- assigned in ordinality order (the ORDER BY pins row-production order), so
     -- the stream keeps each job's 'added' → state-event ordering.
-    INSERT INTO bullmq_event (queue, event, data, created_at_ms)
+    INSERT INTO event (queue, event, data, created_at_ms)
     SELECT q, ev, dat, (extract(epoch FROM clock_timestamp()) * 1000)::bigint
       FROM unnest(v_ev_queue, v_ev_event, v_ev_data)
              WITH ORDINALITY AS t(q, ev, dat, ord)
@@ -1467,12 +1467,12 @@ BEGIN
     -- One 'bullmq_events' wakeup per distinct queue, then trim that queue's
     -- stream once (not per publish). A non-blocking advisory lock keeps at most
     -- one trimmer per queue; publishers that miss it skip (the next flush covers
-    -- the same rows). Matches bullmq_publish_event's approximate-MAXLEN trim.
+    -- the same rows). Matches publish_event's approximate-MAXLEN trim.
     FOR v_queue IN SELECT DISTINCT q FROM unnest(v_ev_queue) AS q LOOP
       PERFORM pg_notify('bullmq_events', v_queue);
 
       SELECT value::integer INTO v_max
-        FROM bullmq_meta
+        FROM meta
        WHERE queue = v_queue AND field = 'opts.maxLenEvents';
       IF v_max IS NULL THEN
         v_max := 10000;
@@ -1480,9 +1480,9 @@ BEGIN
       IF v_max > 0
          AND pg_try_advisory_xact_lock(hashtext('bullmq:evtrim:' || v_queue))
       THEN
-        DELETE FROM bullmq_event
+        DELETE FROM event
          WHERE queue = v_queue
-           AND id <= (SELECT max(id) FROM bullmq_event WHERE queue = v_queue)
+           AND id <= (SELECT max(id) FROM event WHERE queue = v_queue)
                      - v_max;
       END IF;
     END LOOP;
@@ -1505,14 +1505,14 @@ $$;
 -- promote: a delayed job → waiting (process ASAP, keeping its priority).
 -- Returns 0 ok, -1 missing (JobNotExist), -3 not delayed (JobNotInState).
 -- ──────────────────────────────────────────────────────────────────────────
-CREATE FUNCTION bullmq_promote(p_queue text, p_id text) RETURNS integer
+CREATE FUNCTION promote(p_queue text, p_id text) RETURNS integer
 LANGUAGE plpgsql
 SET search_path FROM CURRENT
 AS $$
 DECLARE
-  v_state bullmq_job_state;
+  v_state job_state;
 BEGIN
-  SELECT state INTO v_state FROM bullmq_job WHERE queue = p_queue AND id = p_id;
+  SELECT state INTO v_state FROM job WHERE queue = p_queue AND id = p_id;
   IF NOT FOUND THEN
     RETURN -1;
   END IF;
@@ -1520,15 +1520,15 @@ BEGIN
     RETURN -3;
   END IF;
 
-  UPDATE bullmq_job
+  UPDATE job
      SET state = 'waiting',
          process_at_ms = NULL,
          delay_ms = 0,
-         seq = nextval('bullmq_job_seq')
+         seq = nextval('job_seq')
    WHERE queue = p_queue AND id = p_id;
 
   PERFORM pg_notify('bullmq_jobs', p_queue);
-  PERFORM bullmq_publish_event(p_queue, 'waiting',
+  PERFORM publish_event(p_queue, 'waiting',
     jsonb_build_object('jobId', p_id, 'prev', 'delayed'));
   RETURN 0;
 END;
@@ -1538,16 +1538,16 @@ $$;
 -- change_delay: reschedule a delayed job to fire `p_delay` ms from now.
 -- Returns 0 ok, -1 missing, -3 not delayed.
 -- ──────────────────────────────────────────────────────────────────────────
-CREATE FUNCTION bullmq_change_delay(
+CREATE FUNCTION change_delay(
   p_queue text, p_id text, p_delay bigint, p_now bigint
 ) RETURNS integer
 LANGUAGE plpgsql
 SET search_path FROM CURRENT
 AS $$
 DECLARE
-  v_state bullmq_job_state;
+  v_state job_state;
 BEGIN
-  SELECT state INTO v_state FROM bullmq_job WHERE queue = p_queue AND id = p_id;
+  SELECT state INTO v_state FROM job WHERE queue = p_queue AND id = p_id;
   IF NOT FOUND THEN
     RETURN -1;
   END IF;
@@ -1555,7 +1555,7 @@ BEGIN
     RETURN -3;
   END IF;
 
-  UPDATE bullmq_job
+  UPDATE job
      SET delay_ms = p_delay,
          process_at_ms = p_now + p_delay
    WHERE queue = p_queue AND id = p_id;
@@ -1571,30 +1571,30 @@ $$;
 -- waiting/prioritized; otherwise just record the new priority. Returns 0 ok,
 -- -1 missing.
 -- ──────────────────────────────────────────────────────────────────────────
-CREATE FUNCTION bullmq_change_priority(
+CREATE FUNCTION change_priority(
   p_queue text, p_id text, p_priority integer, p_lifo boolean
 ) RETURNS integer
 LANGUAGE plpgsql
 SET search_path FROM CURRENT
 AS $$
 DECLARE
-  v_state bullmq_job_state;
+  v_state job_state;
 BEGIN
-  SELECT state INTO v_state FROM bullmq_job WHERE queue = p_queue AND id = p_id;
+  SELECT state INTO v_state FROM job WHERE queue = p_queue AND id = p_id;
   IF NOT FOUND THEN
     RETURN -1;
   END IF;
 
   IF v_state = 'waiting' THEN
     -- Reposition: lifo → head (negative seq), otherwise → tail (new seq).
-    UPDATE bullmq_job
+    UPDATE job
        SET priority = p_priority,
            seq = CASE WHEN p_lifo
-                      THEN -nextval('bullmq_job_seq')
-                      ELSE nextval('bullmq_job_seq') END
+                      THEN -nextval('job_seq')
+                      ELSE nextval('job_seq') END
      WHERE queue = p_queue AND id = p_id;
   ELSE
-    UPDATE bullmq_job
+    UPDATE job
        SET priority = p_priority
      WHERE queue = p_queue AND id = p_id;
   END IF;
@@ -1605,7 +1605,7 @@ $$;
 
 -- BullMQ PostgreSQL backend — rate-limit-aware active→wait move (schema v26).
 --
--- Recreates bullmq_move_active_to_wait (used by the dynamic/manual rate limit
+-- Recreates move_active_to_wait (used by the dynamic/manual rate limit
 -- and `Job.moveToWait`) to mirror moveJobFromActiveToWait-9.lua:
 --   * A missing job returns -1 (so the caller can raise the canonical
 --     "Missing key for job …" error).
@@ -1615,21 +1615,21 @@ $$;
 --     before the positive seqs of same-priority jobs), tail = `nextval`.
 --   * Returns the remaining limiter window in ms (Redis returns the limiter
 --     PTTL), which the worker uses to decide how long to back off.
-CREATE OR REPLACE FUNCTION bullmq_move_active_to_wait(
+CREATE OR REPLACE FUNCTION move_active_to_wait(
   p_queue text, p_id text, p_token text, p_now bigint
 ) RETURNS bigint
 LANGUAGE plpgsql
 SET search_path FROM CURRENT
 AS $$
 DECLARE
-  v_state    bullmq_job_state;
+  v_state    job_state;
   v_lock     text;
   v_priority integer;
   v_seq      bigint;
   v_expire   bigint;
 BEGIN
   SELECT state, lock_token, priority INTO v_state, v_lock, v_priority
-    FROM bullmq_job WHERE queue = p_queue AND id = p_id;
+    FROM job WHERE queue = p_queue AND id = p_id;
   IF NOT FOUND THEN
     RETURN -1;
   END IF;
@@ -1637,12 +1637,12 @@ BEGIN
   IF v_state = 'active'
      AND (p_token = '0' OR v_lock IS NOT DISTINCT FROM p_token) THEN
     IF v_priority > 0 THEN
-      v_seq := -nextval('bullmq_job_seq');
+      v_seq := -nextval('job_seq');
     ELSE
-      v_seq := nextval('bullmq_job_seq');
+      v_seq := nextval('job_seq');
     END IF;
 
-    UPDATE bullmq_job
+    UPDATE job
        SET state = 'waiting',
            seq = v_seq,
            lock_token = NULL,
@@ -1650,13 +1650,13 @@ BEGIN
      WHERE queue = p_queue AND id = p_id;
 
     PERFORM pg_notify('bullmq_jobs', p_queue);
-    PERFORM bullmq_publish_event(p_queue, 'waiting',
+    PERFORM publish_event(p_queue, 'waiting',
       jsonb_build_object('jobId', p_id, 'prev', 'active'));
   END IF;
 
   -- Remaining limiter window (mirrors Redis returning PTTL of the limiter key).
   SELECT expire_at_ms INTO v_expire
-    FROM bullmq_rate_limit WHERE queue = p_queue;
+    FROM rate_limit WHERE queue = p_queue;
   IF v_expire IS NOT NULL AND v_expire > p_now THEN
     RETURN v_expire - p_now;
   END IF;
@@ -1668,7 +1668,7 @@ $$;
 --
 -- Job.retry() must reset processedOn too: a re-queued job is "fresh", so
 -- processed_at_ms is cleared alongside finished/return/failed/stacktrace.
-CREATE OR REPLACE FUNCTION bullmq_reprocess_job(
+CREATE OR REPLACE FUNCTION reprocess_job(
   p_queue         text,
   p_id            text,
   p_state         text,
@@ -1680,26 +1680,26 @@ LANGUAGE plpgsql
 SET search_path FROM CURRENT
 AS $$
 DECLARE
-  v_state bullmq_job_state;
+  v_state job_state;
   v_seq   bigint;
   v_pq    text;
   v_pid   text;
 BEGIN
   SELECT state, parent_queue, parent_id INTO v_state, v_pq, v_pid
-    FROM bullmq_job WHERE queue = p_queue AND id = p_id FOR UPDATE;
+    FROM job WHERE queue = p_queue AND id = p_id FOR UPDATE;
   IF NOT FOUND THEN
     RETURN -1;
   END IF;
-  IF v_state <> p_state::bullmq_job_state THEN
+  IF v_state <> p_state::job_state THEN
     RETURN -3;
   END IF;
 
-  v_seq := nextval('bullmq_job_seq');
+  v_seq := nextval('job_seq');
   IF p_lifo THEN
     v_seq := -v_seq;
   END IF;
 
-  UPDATE bullmq_job
+  UPDATE job
      SET state = 'waiting',
          seq = v_seq,
          process_at_ms = NULL,
@@ -1717,21 +1717,21 @@ BEGIN
   -- back to pending and re-count it (mirrors reprocessJob-8.lua re-adding the
   -- job to the parent's :dependencies set).
   IF v_pq IS NOT NULL AND v_pid IS NOT NULL
-     AND EXISTS (SELECT 1 FROM bullmq_job WHERE queue = v_pq AND id = v_pid) THEN
-    UPDATE bullmq_job_dependency
+     AND EXISTS (SELECT 1 FROM job WHERE queue = v_pq AND id = v_pid) THEN
+    UPDATE job_dependency
        SET status = 'pending', value = NULL
      WHERE parent_queue = v_pq AND parent_id = v_pid
        AND child_key = p_queue || ':' || p_id
        AND status = (CASE WHEN p_state = 'failed' THEN 'failed'
-                          ELSE 'processed' END)::bullmq_dep_status;
+                          ELSE 'processed' END)::dep_status;
     IF FOUND THEN
-      UPDATE bullmq_job SET pending_deps = pending_deps + 1
+      UPDATE job SET pending_deps = pending_deps + 1
        WHERE queue = v_pq AND id = v_pid;
     END IF;
   END IF;
 
   PERFORM pg_notify('bullmq_jobs', p_queue);
-  PERFORM bullmq_publish_event(p_queue, 'waiting',
+  PERFORM publish_event(p_queue, 'waiting',
     jsonb_build_object('jobId', p_id, 'prev', p_state));
   RETURN 1;
 END;
@@ -1744,19 +1744,19 @@ $$;
 --   * move_to_completed also releases the parent: a completing child marks its
 --     dependency processed and, when the parent has no pending deps left and is
 --     waiting-children, promotes it back to waiting.
-CREATE FUNCTION bullmq_move_to_waiting_children(
+CREATE FUNCTION move_to_waiting_children(
   p_queue text, p_id text, p_token text
 ) RETURNS integer
 LANGUAGE plpgsql
 SET search_path FROM CURRENT
 AS $$
 DECLARE
-  v_state   bullmq_job_state;
+  v_state   job_state;
   v_lock    text;
   v_pending integer;
 BEGIN
   SELECT state, lock_token, pending_deps INTO v_state, v_lock, v_pending
-    FROM bullmq_job WHERE queue = p_queue AND id = p_id FOR UPDATE;
+    FROM job WHERE queue = p_queue AND id = p_id FOR UPDATE;
   IF NOT FOUND THEN
     RAISE EXCEPTION 'bullmq: missing job %', p_id USING ERRCODE = 'BM001', DETAIL = '-1';
   END IF;
@@ -1764,7 +1764,7 @@ BEGIN
   -- children step; surface it as an unrecoverable failure (mirrors the
   -- `:unsuccessful` set check in moveToWaitingChildren-7.lua).
   IF EXISTS (
-    SELECT 1 FROM bullmq_job_dependency
+    SELECT 1 FROM job_dependency
      WHERE parent_queue = p_queue AND parent_id = p_id AND status = 'failed'
   ) THEN
     RAISE EXCEPTION 'bullmq: job % has failed children', p_id
@@ -1786,7 +1786,7 @@ BEGIN
   END IF;
 
   IF v_pending > 0 THEN
-    UPDATE bullmq_job
+    UPDATE job
        SET state = 'waiting-children', lock_token = NULL, locked_until_ms = NULL
      WHERE queue = p_queue AND id = p_id;
     RETURN 1; -- should wait
@@ -1800,7 +1800,7 @@ $$;
 -- Flow-aware: when a cleaned job is a pending child, its parent's dependency
 -- count is updated and the parent released (removed if it lives in the cleaned
 -- queue, otherwise moved to wait) — mirrors removeJob → removeParentDependencyKey.
-CREATE OR REPLACE FUNCTION bullmq_clean(
+CREATE OR REPLACE FUNCTION clean(
   p_queue text, p_type text, p_ts bigint, p_limit integer
 ) RETURNS SETOF text
 LANGUAGE plpgsql
@@ -1833,7 +1833,7 @@ BEGIN
 
   -- Collect the ids to clean (respecting FIFO order + limit).
   EXECUTE format(
-    'SELECT array_agg(id) FROM (SELECT id FROM bullmq_job '
+    'SELECT array_agg(id) FROM (SELECT id FROM job '
     || 'WHERE queue = %L AND %s %s ORDER BY seq %s) s',
     p_queue, v_where, v_scheduler_filter,
     CASE WHEN p_limit > 0 THEN 'LIMIT ' || p_limit ELSE '' END
@@ -1846,38 +1846,38 @@ BEGIN
   -- Distinct parents of the cleaned jobs, for flow-aware release.
   SELECT array_agg(pq), array_agg(pid) INTO v_pq, v_pid FROM (
     SELECT DISTINCT parent_queue AS pq, parent_id AS pid
-      FROM bullmq_job
+      FROM job
      WHERE queue = p_queue AND id = ANY(v_ids)
        AND parent_queue IS NOT NULL AND parent_id IS NOT NULL
   ) s;
 
   -- Break the cleaned jobs' dependency links, then delete the jobs.
-  DELETE FROM bullmq_job_dependency
+  DELETE FROM job_dependency
    WHERE child_queue = p_queue AND child_id = ANY(v_ids);
-  DELETE FROM bullmq_job WHERE queue = p_queue AND id = ANY(v_ids);
+  DELETE FROM job WHERE queue = p_queue AND id = ANY(v_ids);
 
   -- Release affected parents: a parent with no remaining pending dependencies
   -- is removed when it lives in the cleaned queue, else moved to wait.
   IF v_pq IS NOT NULL THEN
     FOR i IN 1 .. array_length(v_pq, 1) LOOP
-      UPDATE bullmq_job p SET pending_deps = (
-        SELECT count(*) FROM bullmq_job_dependency d
+      UPDATE job p SET pending_deps = (
+        SELECT count(*) FROM job_dependency d
          WHERE d.parent_queue = v_pq[i] AND d.parent_id = v_pid[i]
            AND d.status = 'pending'
       ) WHERE p.queue = v_pq[i] AND p.id = v_pid[i];
 
-      PERFORM 1 FROM bullmq_job p
+      PERFORM 1 FROM job p
        WHERE p.queue = v_pq[i] AND p.id = v_pid[i]
          AND p.state = 'waiting-children' AND p.pending_deps = 0;
       IF FOUND THEN
         IF v_pq[i] = p_queue THEN
-          DELETE FROM bullmq_job WHERE queue = v_pq[i] AND id = v_pid[i];
+          DELETE FROM job WHERE queue = v_pq[i] AND id = v_pid[i];
         ELSE
-          UPDATE bullmq_job
-             SET state = 'waiting', seq = nextval('bullmq_job_seq')
+          UPDATE job
+             SET state = 'waiting', seq = nextval('job_seq')
            WHERE queue = v_pq[i] AND id = v_pid[i];
           PERFORM pg_notify('bullmq_jobs', v_pq[i]);
-          PERFORM bullmq_publish_event(v_pq[i], 'waiting',
+          PERFORM publish_event(v_pq[i], 'waiting',
             jsonb_build_object('jobId', v_pid[i], 'prev', 'waiting-children'));
         END IF;
       END IF;
@@ -1886,7 +1886,7 @@ BEGIN
 
   -- Announce how many jobs were cleaned (mirrors cleanJobsInSet-3.lua's
   -- `cleaned` event; count is a string, as on the Redis stream).
-  PERFORM bullmq_publish_event(p_queue, 'cleaned',
+  PERFORM publish_event(p_queue, 'cleaned',
     jsonb_build_object('count', array_length(v_ids, 1)::text));
 
   RETURN QUERY SELECT unnest(v_ids);
@@ -1895,7 +1895,7 @@ $$;
 
 -- Mirror of the Lua getJobSchedulerEveryNextMillis: returns the next due time
 -- for a fixed-interval scheduler and the aligned offset, as a 2-int array.
-CREATE FUNCTION bullmq_scheduler_every_next_millis(
+CREATE FUNCTION scheduler_every_next_millis(
   p_prev bigint, p_every bigint, p_now bigint, p_offset bigint, p_start bigint
 ) RETURNS bigint[]
 LANGUAGE plpgsql
@@ -1934,7 +1934,7 @@ $$;
 
 -- Registers/updates a scheduler and enqueues its next delayed job.
 -- Returns (job_id, delay).
-CREATE FUNCTION bullmq_add_job_scheduler(
+CREATE FUNCTION add_job_scheduler(
   p_queue         text,
   p_scheduler_id  text,
   p_next_millis   bigint,
@@ -1973,12 +1973,12 @@ DECLARE
   v_em      bigint[];
   v_jobid   text;
   v_delay   bigint;
-  v_state   bullmq_job_state;
+  v_state   job_state;
   v_seq     bigint;
 BEGIN
   SELECT next_run_ms, every_ms, iteration_count, offset_ms
     INTO v_prev, v_prev_every, v_ic, v_existing_offset
-    FROM bullmq_scheduler WHERE queue = p_queue AND scheduler_id = p_scheduler_id;
+    FROM scheduler WHERE queue = p_queue AND scheduler_id = p_scheduler_id;
 
   -- `v_prev` is the previous iteration (used for removal); `v_millis` seeds the
   -- `every` formula and is reset to NULL when the interval itself changed.
@@ -1988,7 +1988,7 @@ BEGIN
       v_millis := NULL;
       v_updated_every := true;
     END IF;
-    v_em := bullmq_scheduler_every_next_millis(v_millis, v_every, p_now, v_offset, v_start);
+    v_em := scheduler_every_next_millis(v_millis, v_every, p_now, v_offset, v_start);
     v_next := v_em[1];
     v_new_offset := v_em[2];
     -- Preserve the offset established at scheduler creation. On re-upsert of an
@@ -2003,7 +2003,7 @@ BEGIN
 
   -- Remove the previous iteration's (still-pending) job, if any.
   IF v_prev IS NOT NULL THEN
-    DELETE FROM bullmq_job
+    DELETE FROM job
      WHERE queue = p_queue
        AND id = 'repeat:' || p_scheduler_id || ':' || v_prev
        AND state IN ('delayed', 'waiting');
@@ -2020,11 +2020,11 @@ BEGIN
   -- (e.g. it is active). For `every` we try the following slot; for `pattern`
   -- we fail — unless we just removed the previous job (override replaces it).
   v_jobid := 'repeat:' || p_scheduler_id || ':' || v_next;
-  IF EXISTS (SELECT 1 FROM bullmq_job WHERE queue = p_queue AND id = v_jobid) THEN
+  IF EXISTS (SELECT 1 FROM job WHERE queue = p_queue AND id = v_jobid) THEN
     IF v_every IS NOT NULL THEN
       v_next := v_next + v_every;
       v_jobid := 'repeat:' || p_scheduler_id || ':' || v_next;
-      IF EXISTS (SELECT 1 FROM bullmq_job WHERE queue = p_queue AND id = v_jobid) THEN
+      IF EXISTS (SELECT 1 FROM job WHERE queue = p_queue AND id = v_jobid) THEN
         RAISE EXCEPTION 'scheduler job slots busy'
           USING ERRCODE = 'BM001', DETAIL = '-11';
       END IF;
@@ -2039,7 +2039,7 @@ BEGIN
   v_delay := GREATEST(v_next - p_now, 0);
 
   -- Upsert the scheduler row (iteration count preserved, or 1 the first time).
-  INSERT INTO bullmq_scheduler (
+  INSERT INTO scheduler (
     queue, scheduler_id, name, next_run_ms, pattern, every_ms, tz,
     start_date_ms, end_date_ms, limit_count, iteration_count, offset_ms,
     template_data, template_opts, producer_id
@@ -2064,14 +2064,14 @@ BEGIN
 
   -- Create the next delayed (or immediately-ready) job. When `v_collision` we
   -- are replacing an existing (removed-prev) row, so fully reset it.
-  v_seq := nextval('bullmq_job_seq');
+  v_seq := nextval('job_seq');
   IF v_delay > 0 THEN
     v_state := 'delayed';
   ELSE
     v_state := 'waiting';
   END IF;
 
-  INSERT INTO bullmq_job (
+  INSERT INTO job (
     queue, id, seq, name, state, data, opts, priority, delay_ms, max_attempts,
     added_at_ms, process_at_ms, scheduler_id
   ) VALUES (
@@ -2118,7 +2118,7 @@ $$;
 
 -- Advance an existing scheduler to its next iteration (no template change).
 -- Returns the new job id, or NULL if the scheduler no longer exists.
-CREATE FUNCTION bullmq_update_job_scheduler_next_millis(
+CREATE FUNCTION update_job_scheduler_next_millis(
   p_queue         text,
   p_scheduler_id  text,
   p_next_millis   bigint,
@@ -2143,12 +2143,12 @@ DECLARE
   v_jobid  text;
   v_current text;
   v_delay  bigint;
-  v_state  bullmq_job_state;
+  v_state  job_state;
   v_seq    bigint;
 BEGIN
   SELECT name, next_run_ms, every_ms, start_date_ms, offset_ms, template_data
     INTO v_name, v_prev, v_every, v_start, v_offset, v_data
-    FROM bullmq_scheduler WHERE queue = p_queue AND scheduler_id = p_scheduler_id;
+    FROM scheduler WHERE queue = p_queue AND scheduler_id = p_scheduler_id;
   IF NOT FOUND THEN
     RETURN NULL;
   END IF;
@@ -2159,7 +2159,7 @@ BEGIN
 
   IF v_every IS NOT NULL THEN
     v_offset := COALESCE(v_offset, (p_delayed_opts #>> '{repeat,offset}')::bigint, 0);
-    v_em := bullmq_scheduler_every_next_millis(v_prev, v_every, p_now, v_offset, v_start);
+    v_em := scheduler_every_next_millis(v_prev, v_every, p_now, v_offset, v_start);
     v_next := v_em[1];
     v_new_offset := v_em[2];
   END IF;
@@ -2174,15 +2174,15 @@ BEGIN
   v_jobid := 'repeat:' || p_scheduler_id || ':' || v_next;
 
   -- If the next iteration's job already exists, this is a duplicate.
-  IF EXISTS (SELECT 1 FROM bullmq_job WHERE queue = p_queue AND id = v_jobid) THEN
-    PERFORM bullmq_publish_event(p_queue, 'duplicated',
+  IF EXISTS (SELECT 1 FROM job WHERE queue = p_queue AND id = v_jobid) THEN
+    PERFORM publish_event(p_queue, 'duplicated',
       jsonb_build_object('jobId', v_jobid));
     RETURN NULL;
   END IF;
 
   v_delay := GREATEST(v_next - p_now, 0);
 
-  UPDATE bullmq_scheduler
+  UPDATE scheduler
      SET next_run_ms = v_next,
          iteration_count = iteration_count + 1,
          offset_ms = COALESCE(offset_ms, v_new_offset),
@@ -2193,10 +2193,10 @@ BEGIN
          END
    WHERE queue = p_queue AND scheduler_id = p_scheduler_id;
 
-  v_seq := nextval('bullmq_job_seq');
+  v_seq := nextval('job_seq');
   v_state := CASE WHEN v_delay > 0 THEN 'delayed' ELSE 'waiting' END;
 
-  INSERT INTO bullmq_job (
+  INSERT INTO job (
     queue, id, seq, name, state, data, opts, priority, delay_ms, max_attempts,
     added_at_ms, process_at_ms, scheduler_id
   ) VALUES (
@@ -2220,7 +2220,7 @@ $$;
 -- Remove a scheduler and its still-pending job, emitting a `removed` event for
 -- each deleted job. Returns 0 if the scheduler existed (removed), 1 otherwise
 -- (mirrors removeJobScheduler-3.lua: 0 = OK, 1 = missing).
-CREATE FUNCTION bullmq_remove_job_scheduler(
+CREATE FUNCTION remove_job_scheduler(
   p_queue text, p_scheduler_id text
 ) RETURNS integer
 LANGUAGE plpgsql
@@ -2239,20 +2239,20 @@ BEGIN
   -- 'duplicated'. Deleting every delayed/waiting job of the scheduler would
   -- wrongly reap the promoted job.
   SELECT next_run_ms INTO v_next
-    FROM bullmq_scheduler
+    FROM scheduler
    WHERE queue = p_queue AND scheduler_id = p_scheduler_id;
 
   IF v_next IS NOT NULL THEN
     v_jobid := 'repeat:' || p_scheduler_id || ':' || v_next;
-    DELETE FROM bullmq_job
+    DELETE FROM job
      WHERE queue = p_queue AND id = v_jobid AND state = 'delayed';
     IF FOUND THEN
-      PERFORM bullmq_publish_event(p_queue, 'removed',
+      PERFORM publish_event(p_queue, 'removed',
         jsonb_build_object('jobId', v_jobid, 'prev', 'delayed'));
     END IF;
   END IF;
 
-  DELETE FROM bullmq_scheduler
+  DELETE FROM scheduler
    WHERE queue = p_queue AND scheduler_id = p_scheduler_id;
   GET DIAGNOSTICS v_removed = ROW_COUNT;
   RETURN CASE WHEN v_removed > 0 THEN 0 ELSE 1 END;
@@ -2271,7 +2271,7 @@ $$;
 --     lock — so a job that completes or renews its lock between passes is never
 --     reclaimed.
 --   * Scheduler ("repeatable") jobs are recovered but never permanently failed.
-CREATE FUNCTION bullmq_move_stalled_jobs_to_wait(
+CREATE FUNCTION move_stalled_jobs_to_wait(
   p_queue          text,
   p_max_stalled    integer,
   p_now            bigint,
@@ -2290,11 +2290,11 @@ BEGIN
   -- Throttle: only run once per `max_check_time` window (mirrors the Redis
   -- `stalled-check` key with `PX maxCheckTime`).
   SELECT value::bigint INTO v_last
-    FROM bullmq_meta WHERE queue = p_queue AND field = 'stalled-check';
+    FROM meta WHERE queue = p_queue AND field = 'stalled-check';
   IF v_last IS NOT NULL AND p_now < v_last + p_max_check_time THEN
     RETURN;
   END IF;
-  INSERT INTO bullmq_meta (queue, field, value)
+  INSERT INTO meta (queue, field, value)
     VALUES (p_queue, 'stalled-check', p_now::text)
     ON CONFLICT (queue, field) DO UPDATE SET value = EXCLUDED.value;
 
@@ -2302,7 +2302,7 @@ BEGIN
   -- still active with an expired lock.
   FOR r IN
     SELECT id, scheduler_id, stalled_count
-      FROM bullmq_job
+      FROM job
      WHERE queue = p_queue
        AND state = 'active'
        AND stalled_marked
@@ -2314,17 +2314,17 @@ BEGIN
 
     -- Scheduler jobs are recovered but never permanently failed.
     v_repeatable := r.scheduler_id IS NOT NULL AND EXISTS (
-      SELECT 1 FROM bullmq_scheduler
+      SELECT 1 FROM scheduler
        WHERE queue = p_queue AND scheduler_id = r.scheduler_id
     );
 
-    UPDATE bullmq_job
+    UPDATE job
        SET state = 'waiting',
            lock_token = NULL,
            locked_until_ms = NULL,
            stalled_marked = false,
            stalled_count = v_count,
-           seq = nextval('bullmq_job_seq'),
+           seq = nextval('job_seq'),
            deferred_failure = CASE
              WHEN v_count > p_max_stalled AND NOT v_repeatable
                THEN 'job stalled more than allowable limit'
@@ -2332,20 +2332,20 @@ BEGIN
            END
      WHERE queue = p_queue AND id = r.id;
 
-    PERFORM bullmq_publish_event(p_queue, 'stalled',
+    PERFORM publish_event(p_queue, 'stalled',
       jsonb_build_object('jobId', r.id));
     v_reclaimed := true;
     RETURN NEXT r.id;
   END LOOP;
 
   -- Clear all old marks (mirrors `DEL stalledKey`) …
-  UPDATE bullmq_job SET stalled_marked = false
+  UPDATE job SET stalled_marked = false
    WHERE queue = p_queue AND stalled_marked;
 
   -- … then mark every currently-active job for the NEXT pass (mirrors
   -- `SADD stalledKey <active>`). Freshly-claimed jobs are therefore never
   -- reclaimed on the pass that first observes them.
-  UPDATE bullmq_job SET stalled_marked = true
+  UPDATE job SET stalled_marked = true
    WHERE queue = p_queue AND state = 'active';
 
   -- Wake a worker for any jobs pushed back to wait.
@@ -2362,7 +2362,7 @@ $$;
 -- counter key with a PTTL: a token is consumed (INCR + PEXPIRE-on-first) each
 -- time a job is moved to active, and `getRateLimitTTL` reports the remaining
 -- window once the counter reaches `max`. Here that key is one row of
--- `bullmq_rate_limit` (`points` ⇔ the counter, `expire_at_ms` ⇔ the PTTL
+-- `rate_limit` (`points` ⇔ the counter, `expire_at_ms` ⇔ the PTTL
 -- window). The limiter config comes from the queue meta (`max`/`duration`, set
 -- via `Queue.setGlobalRateLimit`) and/or the worker's `limiter` option.
 
@@ -2370,7 +2370,7 @@ $$;
 -- p_max_jobs > 0 → check against that; else fall back to meta `max`; else the
 -- raw remaining window (or -2 when there is none, like Redis PTTL on a missing
 -- key).
-CREATE FUNCTION bullmq_rate_limit_ttl(
+CREATE FUNCTION rate_limit_ttl(
   p_queue text, p_max_jobs integer, p_now bigint
 ) RETURNS bigint
 LANGUAGE plpgsql
@@ -2386,7 +2386,7 @@ DECLARE
   v_max     integer;
 BEGIN
   SELECT points, expire_at_ms INTO v_points, v_expire
-    FROM bullmq_rate_limit WHERE queue = p_queue;
+    FROM rate_limit WHERE queue = p_queue;
   v_active  := v_expire IS NOT NULL AND v_expire > p_now;
   v_counter := CASE WHEN v_active THEN v_points ELSE 0 END;
   v_pttl    := CASE WHEN v_active THEN v_expire - p_now ELSE -2 END;
@@ -2399,7 +2399,7 @@ BEGIN
   END IF;
 
   SELECT value::integer INTO v_max
-    FROM bullmq_meta WHERE queue = p_queue AND field = 'max';
+    FROM meta WHERE queue = p_queue AND field = 'max';
   IF v_max IS NOT NULL THEN
     IF v_max <= v_counter AND v_pttl > 0 THEN
       RETURN v_pttl;
@@ -2416,7 +2416,7 @@ $$;
 -- falling back to the worker's own `limiter.max`. Returns the remaining window
 -- when the counter has reached that limit, else 0 (and 0 when no limiter at
 -- all is configured).
-CREATE FUNCTION bullmq_rate_limit_effective(
+CREATE FUNCTION rate_limit_effective(
   p_queue text, p_limiter_max integer, p_now bigint
 ) RETURNS bigint
 LANGUAGE plpgsql
@@ -2430,14 +2430,14 @@ DECLARE
   v_expire   bigint;
 BEGIN
   SELECT value::integer INTO v_meta_max
-    FROM bullmq_meta WHERE queue = p_queue AND field = 'max';
+    FROM meta WHERE queue = p_queue AND field = 'max';
   v_max := COALESCE(v_meta_max, p_limiter_max);
   IF v_max IS NULL THEN
     RETURN 0;
   END IF;
 
   SELECT points, expire_at_ms INTO v_points, v_expire
-    FROM bullmq_rate_limit WHERE queue = p_queue;
+    FROM rate_limit WHERE queue = p_queue;
   IF v_expire IS NULL OR v_expire <= p_now THEN
     RETURN 0;
   END IF;
@@ -2449,31 +2449,31 @@ END;
 $$;
 
 -- Consume one token (INCR + PEXPIRE-on-first-of-window).
-CREATE FUNCTION bullmq_rate_limit_consume(
+CREATE FUNCTION rate_limit_consume(
   p_queue text, p_duration bigint, p_now bigint
 ) RETURNS void
 LANGUAGE sql
 SET search_path FROM CURRENT
 AS $$
-  INSERT INTO bullmq_rate_limit (queue, points, expire_at_ms)
+  INSERT INTO rate_limit (queue, points, expire_at_ms)
     VALUES (p_queue, 1, p_now + p_duration)
   ON CONFLICT (queue) DO UPDATE SET
-    points = CASE WHEN bullmq_rate_limit.expire_at_ms <= p_now
-                  THEN 1 ELSE bullmq_rate_limit.points + 1 END,
-    expire_at_ms = CASE WHEN bullmq_rate_limit.expire_at_ms <= p_now
+    points = CASE WHEN rate_limit.expire_at_ms <= p_now
+                  THEN 1 ELSE rate_limit.points + 1 END,
+    expire_at_ms = CASE WHEN rate_limit.expire_at_ms <= p_now
                         THEN p_now + p_duration
-                        ELSE bullmq_rate_limit.expire_at_ms END;
+                        ELSE rate_limit.expire_at_ms END;
 $$;
 
 -- Force the limiter for `p_expire_ms` (dynamic / manual rate limit). Mirrors
 -- Redis SET limiter = MAX_SAFE_INTEGER PX p_expire_ms.
-CREATE FUNCTION bullmq_set_rate_limit(
+CREATE FUNCTION set_rate_limit(
   p_queue text, p_expire_ms bigint, p_now bigint
 ) RETURNS void
 LANGUAGE sql
 SET search_path FROM CURRENT
 AS $$
-  INSERT INTO bullmq_rate_limit (queue, points, expire_at_ms)
+  INSERT INTO rate_limit (queue, points, expire_at_ms)
     VALUES (p_queue, 9007199254740991, p_now + p_expire_ms)
   ON CONFLICT (queue) DO UPDATE SET
     points = 9007199254740991,
@@ -2482,15 +2482,15 @@ $$;
 
 -- The "no job" signal: the worker-effective rate-limit ttl and the next delayed
 -- job's timestamp, in one round trip.
-CREATE FUNCTION bullmq_next_signal(
+CREATE FUNCTION next_signal(
   p_queue text, p_limiter_max integer, p_now bigint
 ) RETURNS TABLE (rate_limit_ttl bigint, next_delay bigint)
 LANGUAGE sql
 STABLE
 SET search_path FROM CURRENT
 AS $$
-  SELECT bullmq_rate_limit_effective(p_queue, p_limiter_max, p_now),
-         bullmq_next_delay(p_queue);
+  SELECT rate_limit_effective(p_queue, p_limiter_max, p_now),
+         next_delay(p_queue);
 $$;
 
 -- BullMQ PostgreSQL backend — obliterate (schema v27).
@@ -2503,9 +2503,9 @@ $$;
 --     caller loops), and once every job is gone delete the remaining
 --     per-queue data and return 0.
 --
--- `bullmq_job_log` and `bullmq_job_dependency` rows cascade from `bullmq_job`,
+-- `job_log` and `job_dependency` rows cascade from `job`,
 -- so deleting the jobs removes their logs and (parent-side) dependency links.
-CREATE FUNCTION bullmq_obliterate(
+CREATE FUNCTION obliterate(
   p_queue text, p_count integer, p_force boolean
 ) RETURNS integer
 LANGUAGE plpgsql
@@ -2515,22 +2515,22 @@ DECLARE
   v_deleted integer;
 BEGIN
   IF NOT EXISTS (
-    SELECT 1 FROM bullmq_meta
+    SELECT 1 FROM meta
      WHERE queue = p_queue AND field = 'paused' AND value = '1'
   ) THEN
     RETURN -1;  -- NotPaused
   END IF;
 
   IF NOT p_force AND EXISTS (
-    SELECT 1 FROM bullmq_job WHERE queue = p_queue AND state = 'active'
+    SELECT 1 FROM job WHERE queue = p_queue AND state = 'active'
   ) THEN
     RETURN -2;  -- ExistActiveJobs
   END IF;
 
   WITH batch AS (
-    SELECT id FROM bullmq_job WHERE queue = p_queue LIMIT p_count
+    SELECT id FROM job WHERE queue = p_queue LIMIT p_count
   )
-  DELETE FROM bullmq_job j
+  DELETE FROM job j
    USING batch
    WHERE j.queue = p_queue AND j.id = batch.id;
   GET DIAGNOSTICS v_deleted = ROW_COUNT;
@@ -2541,17 +2541,17 @@ BEGIN
   END IF;
 
   -- Every job is gone; remove the rest of the queue's footprint.
-  DELETE FROM bullmq_scheduler  WHERE queue = p_queue;
-  DELETE FROM bullmq_rate_limit WHERE queue = p_queue;
-  DELETE FROM bullmq_event      WHERE queue = p_queue;
-  DELETE FROM bullmq_metrics    WHERE queue = p_queue;
-  DELETE FROM bullmq_dedup      WHERE queue = p_queue;
-  DELETE FROM bullmq_dedup_next WHERE queue = p_queue;
-  DELETE FROM bullmq_meta       WHERE queue = p_queue;
+  DELETE FROM scheduler  WHERE queue = p_queue;
+  DELETE FROM rate_limit WHERE queue = p_queue;
+  DELETE FROM event      WHERE queue = p_queue;
+  DELETE FROM metrics    WHERE queue = p_queue;
+  DELETE FROM dedup      WHERE queue = p_queue;
+  DELETE FROM dedup_next WHERE queue = p_queue;
+  DELETE FROM meta       WHERE queue = p_queue;
   -- Drop the per-queue job-id sequence so a re-created queue restarts at 1
   -- (mirrors Redis obliterate deleting the `<queue>:id` counter key).
   EXECUTE format(
-    'DROP SEQUENCE IF EXISTS %I', bullmq_job_id_seq_name(p_queue));
+    'DROP SEQUENCE IF EXISTS %I', job_id_seq_name(p_queue));
   RETURN 0;
 END;
 $$;
@@ -2563,19 +2563,19 @@ $$;
 -- `{ id, ttl, extend, replace, keepLastIfActive }`. When a *live* key already
 -- exists for that id the new job is NOT added: the existing "winner" job id is
 -- returned and `deduplicated` events are emitted. The key is one
--- row of `bullmq_dedup` (`job_id` ⇔ the winner, `expire_at_ms` ⇔ the Redis
+-- row of `dedup` (`job_id` ⇔ the winner, `expire_at_ms` ⇔ the Redis
 -- PTTL window; NULL = no expiry). The full key lifecycle:
---   * add        — set / check the key (see bullmq_deduplicate_job),
+--   * add        — set / check the key (see deduplicate_job),
 --   * finalize   — when the winner completes/fails, a no-ttl key is cleared
---                  (bullmq_dedup_finalize),
+--                  (dedup_finalize),
 --   * removal    — when the winner is removed, its key is cleared
---                  (bullmq_dedup_on_removal).
+--                  (dedup_on_removal).
 -- NOTE: `keepLastIfActive`'s proto-job storage/requeue is added in a later
 -- migration; here keepLastIfActive only governs the key's expiry (no ttl).
 
 -- ── Finalize: clear a no-ttl key whose winner is finishing (PTTL == -1 path),
 --    and reap an already-expired key (PTTL == 0). ttl keys expire on their own.
-CREATE FUNCTION bullmq_dedup_finalize(
+CREATE FUNCTION dedup_finalize(
   p_queue text, p_dedup_id text, p_job_id text, p_now bigint
 ) RETURNS void
 LANGUAGE plpgsql
@@ -2589,25 +2589,25 @@ BEGIN
     RETURN;
   END IF;
   SELECT job_id, expire_at_ms INTO v_cur, v_exp
-    FROM bullmq_dedup WHERE queue = p_queue AND dedup_id = p_dedup_id;
+    FROM dedup WHERE queue = p_queue AND dedup_id = p_dedup_id;
   IF NOT FOUND THEN
     RETURN;
   END IF;
   IF v_exp IS NULL THEN
     -- No expiry: only the current winner clears its own key.
     IF v_cur = p_job_id THEN
-      DELETE FROM bullmq_dedup WHERE queue = p_queue AND dedup_id = p_dedup_id;
+      DELETE FROM dedup WHERE queue = p_queue AND dedup_id = p_dedup_id;
     END IF;
   ELSIF v_exp <= p_now THEN
     -- Already expired: reap it.
-    DELETE FROM bullmq_dedup WHERE queue = p_queue AND dedup_id = p_dedup_id;
+    DELETE FROM dedup WHERE queue = p_queue AND dedup_id = p_dedup_id;
   END IF;
 END;
 $$;
 
 -- ── Removal: clear the key (and any proto-next data) when its winner job is
 --    removed (mirrors removeDeduplicationKeyIfNeededOnRemoval).
-CREATE FUNCTION bullmq_dedup_on_removal(
+CREATE FUNCTION dedup_on_removal(
   p_queue text, p_job_id text, p_dedup_id text
 ) RETURNS void
 LANGUAGE plpgsql
@@ -2617,14 +2617,14 @@ BEGIN
   IF p_dedup_id IS NULL OR p_dedup_id = '' THEN
     RETURN;
   END IF;
-  DELETE FROM bullmq_dedup
+  DELETE FROM dedup
    WHERE queue = p_queue AND dedup_id = p_dedup_id AND job_id = p_job_id;
 END;
 $$;
 
 -- Stash the new job as the proto-next IF keepLastIfActive and the current
 -- winner is active. Returns true when stashed. Mirrors storeDeduplicatedNextJob.
-CREATE FUNCTION bullmq_dedup_store_next(
+CREATE FUNCTION dedup_store_next(
   p_queue text, p_dedup_id text, p_winner text, p_job_id text,
   p_keeplast boolean, p_name text, p_data jsonb, p_opts jsonb
 ) RETURNS boolean
@@ -2636,17 +2636,17 @@ BEGIN
     RETURN false;
   END IF;
   IF NOT EXISTS (
-    SELECT 1 FROM bullmq_job
+    SELECT 1 FROM job
      WHERE queue = p_queue AND id = p_winner AND state = 'active'
   ) THEN
     RETURN false;
   END IF;
-  INSERT INTO bullmq_dedup_next (queue, dedup_id, payload)
+  INSERT INTO dedup_next (queue, dedup_id, payload)
     VALUES (p_queue, p_dedup_id, jsonb_build_object(
       'name', p_name, 'data', p_data, 'opts', p_opts, 'jobId', p_job_id))
   ON CONFLICT (queue, dedup_id) DO UPDATE SET payload = EXCLUDED.payload;
   -- Persist the dedup key so it outlives the active job's duration.
-  UPDATE bullmq_dedup SET expire_at_ms = NULL
+  UPDATE dedup SET expire_at_ms = NULL
    WHERE queue = p_queue AND dedup_id = p_dedup_id;
   RETURN true;
 END;
@@ -2654,7 +2654,7 @@ $$;
 
 -- Turn a stored proto-next into a real job (the new winner) when the active
 -- winner finishes. Mirrors requeueDeduplicatedJob.
-CREATE FUNCTION bullmq_requeue_dedup_next(
+CREATE FUNCTION requeue_dedup_next(
   p_queue text, p_dedup_id text, p_now bigint
 ) RETURNS void
 LANGUAGE plpgsql
@@ -2673,14 +2673,14 @@ DECLARE
   v_keeplast boolean;
   v_ttl      bigint;
   v_seq      bigint;
-  v_state    bullmq_job_state;
+  v_state    job_state;
   v_process_at bigint;
 BEGIN
   IF p_dedup_id IS NULL OR p_dedup_id = '' THEN
     RETURN;
   END IF;
   SELECT payload INTO v_payload
-    FROM bullmq_dedup_next WHERE queue = p_queue AND dedup_id = p_dedup_id;
+    FROM dedup_next WHERE queue = p_queue AND dedup_id = p_dedup_id;
   IF NOT FOUND THEN
     RETURN;
   END IF;
@@ -2690,7 +2690,7 @@ BEGIN
   v_opts   := COALESCE(v_payload->'opts', '{}'::jsonb);
   v_job_id := v_payload->>'jobId';
   IF v_job_id IS NULL OR v_job_id = '' THEN
-    v_job_id := bullmq_next_job_id(p_queue);
+    v_job_id := next_job_id(p_queue);
   END IF;
 
   v_de       := COALESCE(v_opts->'deduplication', v_opts->'debounce');
@@ -2700,7 +2700,7 @@ BEGIN
   v_keeplast := COALESCE((v_de->>'keepLastIfActive')::boolean, false);
   v_ttl      := NULLIF(v_de->>'ttl', '')::bigint;
 
-  v_seq := nextval('bullmq_job_seq');
+  v_seq := nextval('job_seq');
   IF v_lifo THEN
     v_seq := -v_seq;
   END IF;
@@ -2712,7 +2712,7 @@ BEGIN
     v_process_at := NULL;
   END IF;
 
-  INSERT INTO bullmq_job (
+  INSERT INTO job (
     queue, id, seq, name, state, data, opts, priority, delay_ms,
     max_attempts, added_at_ms, process_at_ms, dedup_id
   ) VALUES (
@@ -2723,21 +2723,21 @@ BEGIN
   ON CONFLICT (queue, id) DO NOTHING;
 
   -- New winner key (no expiry while keepLastIfActive, else honour ttl).
-  INSERT INTO bullmq_dedup (queue, dedup_id, job_id, expire_at_ms)
+  INSERT INTO dedup (queue, dedup_id, job_id, expire_at_ms)
     VALUES (p_queue, p_dedup_id, v_job_id,
       CASE WHEN v_keeplast OR COALESCE(v_ttl, 0) <= 0
            THEN NULL ELSE p_now + v_ttl END)
   ON CONFLICT (queue, dedup_id) DO UPDATE
     SET job_id = EXCLUDED.job_id, expire_at_ms = EXCLUDED.expire_at_ms;
 
-  DELETE FROM bullmq_dedup_next WHERE queue = p_queue AND dedup_id = p_dedup_id;
+  DELETE FROM dedup_next WHERE queue = p_queue AND dedup_id = p_dedup_id;
 
   PERFORM pg_notify('bullmq_jobs', p_queue);
   IF v_state = 'delayed' THEN
-    PERFORM bullmq_publish_event(p_queue, 'delayed',
+    PERFORM publish_event(p_queue, 'delayed',
       jsonb_build_object('jobId', v_job_id, 'delay', v_process_at));
   ELSE
-    PERFORM bullmq_publish_event(p_queue, 'waiting',
+    PERFORM publish_event(p_queue, 'waiting',
       jsonb_build_object('jobId', v_job_id));
   END IF;
 END;
@@ -2746,7 +2746,7 @@ $$;
 -- ── Core decision (mirrors deduplicateJob / deduplicateJobWithoutReplace).
 -- Returns the existing winner's id when the new job should be deduplicated
 -- (i.e. NOT inserted); returns NULL when the caller should go on to add it.
-CREATE FUNCTION bullmq_deduplicate_job(
+CREATE FUNCTION deduplicate_job(
   p_queue text, p_dedup jsonb, p_job_id text, p_now bigint,
   p_name text, p_data jsonb, p_opts jsonb
 ) RETURNS text
@@ -2761,7 +2761,7 @@ DECLARE
   v_keeplast boolean := COALESCE((p_dedup->>'keepLastIfActive')::boolean, false);
   v_cur      text;
   v_exp      bigint;
-  v_state    bullmq_job_state;
+  v_state    job_state;
 BEGIN
   IF v_id IS NULL OR v_id = '' THEN
     RETURN NULL;
@@ -2769,7 +2769,7 @@ BEGIN
 
   -- The current winner (only if the key is still live).
   SELECT job_id, expire_at_ms INTO v_cur, v_exp
-    FROM bullmq_dedup WHERE queue = p_queue AND dedup_id = v_id;
+    FROM dedup WHERE queue = p_queue AND dedup_id = v_id;
   IF v_cur IS NULL OR (v_exp IS NOT NULL AND v_exp <= p_now) THEN
     v_cur := NULL;
   END IF;
@@ -2777,24 +2777,24 @@ BEGIN
   IF v_replace THEN
     IF v_cur IS NOT NULL THEN
       SELECT state INTO v_state
-        FROM bullmq_job WHERE queue = p_queue AND id = v_cur;
+        FROM job WHERE queue = p_queue AND id = v_cur;
       IF v_state = 'delayed' THEN
         -- Drop the previous delayed job and take its place.
-        DELETE FROM bullmq_job WHERE queue = p_queue AND id = v_cur;
-        PERFORM bullmq_publish_event(p_queue, 'removed',
+        DELETE FROM job WHERE queue = p_queue AND id = v_cur;
+        PERFORM publish_event(p_queue, 'removed',
           jsonb_build_object('jobId', v_cur, 'prev', 'delayed'));
-        PERFORM bullmq_publish_event(p_queue, 'deduplicated',
+        PERFORM publish_event(p_queue, 'deduplicated',
           jsonb_build_object('jobId', p_job_id, 'deduplicationId', v_id,
             'deduplicatedJobId', v_cur));
         IF v_keeplast THEN
-          UPDATE bullmq_dedup SET job_id = p_job_id, expire_at_ms = NULL
+          UPDATE dedup SET job_id = p_job_id, expire_at_ms = NULL
            WHERE queue = p_queue AND dedup_id = v_id;
         ELSIF NOT v_extend AND COALESCE(v_ttl, 0) > 0 THEN
           -- KEEPTTL: keep the existing window, just swap the winner.
-          UPDATE bullmq_dedup SET job_id = p_job_id
+          UPDATE dedup SET job_id = p_job_id
            WHERE queue = p_queue AND dedup_id = v_id;
         ELSE
-          UPDATE bullmq_dedup
+          UPDATE dedup
              SET job_id = p_job_id,
                  expire_at_ms = CASE WHEN COALESCE(v_ttl, 0) > 0
                                      THEN p_now + v_ttl ELSE NULL END
@@ -2804,12 +2804,12 @@ BEGIN
       ELSE
         -- Winner is not a removable delayed job: stash proto-next if it is
         -- active + keepLastIfActive, then deduplicate.
-        PERFORM bullmq_dedup_store_next(p_queue, v_id, v_cur, p_job_id,
+        PERFORM dedup_store_next(p_queue, v_id, v_cur, p_job_id,
           v_keeplast, p_name, p_data, p_opts);
         RETURN v_cur;
       END IF;
     ELSE
-      INSERT INTO bullmq_dedup (queue, dedup_id, job_id, expire_at_ms)
+      INSERT INTO dedup (queue, dedup_id, job_id, expire_at_ms)
         VALUES (p_queue, v_id, p_job_id,
           CASE WHEN NOT v_keeplast AND COALESCE(v_ttl, 0) > 0
                THEN p_now + v_ttl ELSE NULL END)
@@ -2824,18 +2824,18 @@ BEGIN
     IF v_cur IS NOT NULL THEN
       -- Stash proto-next if active+keepLast; else extend the window (or
       -- persist when keepLastIfActive). Either way keep the current winner.
-      IF NOT bullmq_dedup_store_next(p_queue, v_id, v_cur, p_job_id,
+      IF NOT dedup_store_next(p_queue, v_id, v_cur, p_job_id,
                v_keeplast, p_name, p_data, p_opts) THEN
-        UPDATE bullmq_dedup
+        UPDATE dedup
            SET expire_at_ms = CASE WHEN v_keeplast THEN NULL ELSE p_now + v_ttl END
          WHERE queue = p_queue AND dedup_id = v_id;
       END IF;
-      PERFORM bullmq_publish_event(p_queue, 'deduplicated',
+      PERFORM publish_event(p_queue, 'deduplicated',
         jsonb_build_object('jobId', v_cur, 'deduplicationId', v_id,
           'deduplicatedJobId', p_job_id));
       RETURN v_cur;
     END IF;
-    INSERT INTO bullmq_dedup (queue, dedup_id, job_id, expire_at_ms)
+    INSERT INTO dedup (queue, dedup_id, job_id, expire_at_ms)
       VALUES (p_queue, v_id, p_job_id,
         CASE WHEN v_keeplast THEN NULL ELSE p_now + v_ttl END)
     ON CONFLICT (queue, dedup_id) DO UPDATE
@@ -2845,15 +2845,15 @@ BEGIN
 
   -- SET NX semantics (ttl>0 non-extend, or no ttl at all).
   IF v_cur IS NOT NULL THEN
-    PERFORM bullmq_dedup_store_next(p_queue, v_id, v_cur, p_job_id,
+    PERFORM dedup_store_next(p_queue, v_id, v_cur, p_job_id,
       v_keeplast, p_name, p_data, p_opts);
-    PERFORM bullmq_publish_event(p_queue, 'deduplicated',
+    PERFORM publish_event(p_queue, 'deduplicated',
       jsonb_build_object('jobId', v_cur, 'deduplicationId', v_id,
         'deduplicatedJobId', p_job_id));
     RETURN v_cur;
   END IF;
 
-  INSERT INTO bullmq_dedup (queue, dedup_id, job_id, expire_at_ms)
+  INSERT INTO dedup (queue, dedup_id, job_id, expire_at_ms)
     VALUES (p_queue, v_id, p_job_id,
       CASE WHEN NOT v_keeplast AND COALESCE(v_ttl, 0) > 0
            THEN p_now + v_ttl ELSE NULL END)
@@ -2883,7 +2883,7 @@ $$;
 -- Release a parent from waiting-children to wait (mirrors moveParentToWait —
 -- priority is preserved by the row's `priority` column; FIFO order via a fresh
 -- seq). Emits the 'waiting' (prev waiting-children) event and wakes a worker.
-CREATE FUNCTION bullmq_move_parent_to_wait(
+CREATE FUNCTION move_parent_to_wait(
   p_parent_queue text, p_parent_id text, p_now bigint
 ) RETURNS void
 LANGUAGE plpgsql
@@ -2894,7 +2894,7 @@ DECLARE
   v_process_at bigint;
 BEGIN
   SELECT delay_ms INTO v_delay
-    FROM bullmq_job
+    FROM job
    WHERE queue = p_parent_queue AND id = p_parent_id
      AND state = 'waiting-children';
   IF NOT FOUND THEN
@@ -2905,28 +2905,28 @@ BEGIN
     -- The parent carries a delay: release it into the delayed set (mirrors the
     -- delay branch of moveParentToWait), scored from the release moment.
     v_process_at := p_now + v_delay;
-    UPDATE bullmq_job
+    UPDATE job
        SET state = 'delayed', process_at_ms = v_process_at,
-           seq = nextval('bullmq_job_seq')
+           seq = nextval('job_seq')
      WHERE queue = p_parent_queue AND id = p_parent_id;
     PERFORM pg_notify('bullmq_jobs', p_parent_queue);
-    PERFORM bullmq_publish_event(p_parent_queue, 'delayed',
+    PERFORM publish_event(p_parent_queue, 'delayed',
       jsonb_build_object('jobId', p_parent_id, 'delay', v_process_at));
   ELSE
     -- No delay: release to wait. Priority is preserved by the row's `priority`
     -- column, so a prioritized parent stays prioritized.
-    UPDATE bullmq_job
-       SET state = 'waiting', seq = nextval('bullmq_job_seq')
+    UPDATE job
+       SET state = 'waiting', seq = nextval('job_seq')
      WHERE queue = p_parent_queue AND id = p_parent_id;
     PERFORM pg_notify('bullmq_jobs', p_parent_queue);
-    PERFORM bullmq_publish_event(p_parent_queue, 'waiting',
+    PERFORM publish_event(p_parent_queue, 'waiting',
       jsonb_build_object('jobId', p_parent_id, 'prev', 'waiting-children'));
   END IF;
 END;
 $$;
 
 -- Propagate a child's permanent failure to its parent.
-CREATE FUNCTION bullmq_handle_child_failure(
+CREATE FUNCTION handle_child_failure(
   p_queue text, p_id text, p_reason text, p_now bigint
 ) RETURNS void
 LANGUAGE plpgsql
@@ -2940,7 +2940,7 @@ DECLARE
   v_remaining integer;
 BEGIN
   SELECT parent_queue, parent_id, opts INTO v_pq, v_pid, v_opts
-    FROM bullmq_job WHERE queue = p_queue AND id = p_id;
+    FROM job WHERE queue = p_queue AND id = p_id;
   IF v_pid IS NULL OR v_pq IS NULL THEN
     RETURN;
   END IF;
@@ -2950,61 +2950,61 @@ BEGIN
   -- (completion or failure). Mirrors the single-threaded atomicity Redis relies
   -- on and prevents the `pending_deps` UPDATE from deadlocking against a
   -- sibling's decrement (SQLSTATE 40P01). Taken on the direct parent only, so it
-  -- never nests and auto-releases at commit (see bullmq_move_to_completed).
+  -- never nests and auto-releases at commit (see move_to_completed).
   PERFORM pg_advisory_xact_lock(
     hashtext('bullmq:parent:' || v_pq || ':' || v_pid));
 
   IF COALESCE((v_opts->>'failParentOnFailure')::boolean, false) THEN
-    UPDATE bullmq_job_dependency
+    UPDATE job_dependency
        SET status = 'failed', value = to_jsonb(p_reason)
      WHERE parent_queue = v_pq AND parent_id = v_pid
        AND child_key = v_child_key AND status = 'pending';
     IF FOUND THEN
-      UPDATE bullmq_job SET pending_deps = GREATEST(pending_deps - 1, 0)
+      UPDATE job SET pending_deps = GREATEST(pending_deps - 1, 0)
        WHERE queue = v_pq AND id = v_pid;
       -- Defer the failure onto the parent; when a worker activates it the
       -- deferred failure fails it immediately (worker checks job.deferredFailure).
-      UPDATE bullmq_job
+      UPDATE job
          SET deferred_failure = 'child ' || v_child_key || ' failed'
        WHERE queue = v_pq AND id = v_pid;
-      PERFORM bullmq_move_parent_to_wait(v_pq, v_pid, p_now);
+      PERFORM move_parent_to_wait(v_pq, v_pid, p_now);
     END IF;
 
   ELSIF COALESCE((v_opts->>'continueParentOnFailure')::boolean, false) THEN
-    UPDATE bullmq_job_dependency
+    UPDATE job_dependency
        SET status = 'ignored', value = to_jsonb(p_reason)
      WHERE parent_queue = v_pq AND parent_id = v_pid
        AND child_key = v_child_key AND status = 'pending';
     IF FOUND THEN
-      UPDATE bullmq_job SET pending_deps = GREATEST(pending_deps - 1, 0)
+      UPDATE job SET pending_deps = GREATEST(pending_deps - 1, 0)
        WHERE queue = v_pq AND id = v_pid;
-      PERFORM bullmq_move_parent_to_wait(v_pq, v_pid, p_now);
+      PERFORM move_parent_to_wait(v_pq, v_pid, p_now);
     END IF;
 
   ELSIF COALESCE((v_opts->>'ignoreDependencyOnFailure')::boolean, false) THEN
-    UPDATE bullmq_job_dependency
+    UPDATE job_dependency
        SET status = 'ignored', value = to_jsonb(p_reason)
      WHERE parent_queue = v_pq AND parent_id = v_pid
        AND child_key = v_child_key AND status = 'pending';
     IF FOUND THEN
-      UPDATE bullmq_job SET pending_deps = GREATEST(pending_deps - 1, 0)
+      UPDATE job SET pending_deps = GREATEST(pending_deps - 1, 0)
        WHERE queue = v_pq AND id = v_pid
       RETURNING pending_deps INTO v_remaining;
       IF v_remaining = 0 THEN
-        PERFORM bullmq_move_parent_to_wait(v_pq, v_pid, p_now);
+        PERFORM move_parent_to_wait(v_pq, v_pid, p_now);
       END IF;
     END IF;
 
   ELSIF COALESCE((v_opts->>'removeDependencyOnFailure')::boolean, false) THEN
-    DELETE FROM bullmq_job_dependency
+    DELETE FROM job_dependency
      WHERE parent_queue = v_pq AND parent_id = v_pid
        AND child_key = v_child_key AND status = 'pending';
     IF FOUND THEN
-      UPDATE bullmq_job SET pending_deps = GREATEST(pending_deps - 1, 0)
+      UPDATE job SET pending_deps = GREATEST(pending_deps - 1, 0)
        WHERE queue = v_pq AND id = v_pid
       RETURNING pending_deps INTO v_remaining;
       IF v_remaining = 0 THEN
-        PERFORM bullmq_move_parent_to_wait(v_pq, v_pid, p_now);
+        PERFORM move_parent_to_wait(v_pq, v_pid, p_now);
       END IF;
     END IF;
   END IF;
@@ -3015,7 +3015,7 @@ $$;
 --    removeChildDependency-1.lua). Returns 0 when the relationship existed and
 --    was removed, 1 when there was no relationship; raises -1 (missing job) /
 --    -5 (missing parent).
-CREATE FUNCTION bullmq_remove_child_dependency(
+CREATE FUNCTION remove_child_dependency(
   p_queue text, p_id text, p_parent_key text, p_now bigint
 ) RETURNS integer
 LANGUAGE plpgsql
@@ -3028,7 +3028,7 @@ DECLARE
   v_remaining integer;
 BEGIN
   SELECT parent_queue, parent_id INTO v_pq, v_pid
-    FROM bullmq_job WHERE queue = p_queue AND id = p_id;
+    FROM job WHERE queue = p_queue AND id = p_id;
   IF NOT FOUND THEN
     RAISE EXCEPTION 'bullmq: missing job %', p_id
       USING ERRCODE = 'BM001', DETAIL = '-1';
@@ -3037,13 +3037,13 @@ BEGIN
     RETURN 1; -- no relationship
   END IF;
   IF NOT EXISTS (
-    SELECT 1 FROM bullmq_job WHERE queue = v_pq AND id = v_pid
+    SELECT 1 FROM job WHERE queue = v_pq AND id = v_pid
   ) THEN
     RAISE EXCEPTION 'bullmq: missing parent %', p_parent_key
       USING ERRCODE = 'BM001', DETAIL = '-5';
   END IF;
 
-  DELETE FROM bullmq_job_dependency
+  DELETE FROM job_dependency
    WHERE parent_queue = v_pq AND parent_id = v_pid
      AND child_key = p_queue || ':' || p_id;
   GET DIAGNOSTICS v_deleted = ROW_COUNT;
@@ -3052,18 +3052,18 @@ BEGIN
   END IF;
 
   -- Detach the child and release the parent if it has no more pending deps.
-  UPDATE bullmq_job
+  UPDATE job
      SET parent_queue = NULL, parent_id = NULL, parent_key = NULL
    WHERE queue = p_queue AND id = p_id;
   -- Serialize with concurrent child resolutions of the same parent (see
-  -- bullmq_move_to_completed) to avoid a pending_deps deadlock.
+  -- move_to_completed) to avoid a pending_deps deadlock.
   PERFORM pg_advisory_xact_lock(
     hashtext('bullmq:parent:' || v_pq || ':' || v_pid));
-  UPDATE bullmq_job SET pending_deps = GREATEST(pending_deps - 1, 0)
+  UPDATE job SET pending_deps = GREATEST(pending_deps - 1, 0)
    WHERE queue = v_pq AND id = v_pid
   RETURNING pending_deps INTO v_remaining;
   IF v_remaining = 0 THEN
-    PERFORM bullmq_move_parent_to_wait(v_pq, v_pid, p_now);
+    PERFORM move_parent_to_wait(v_pq, v_pid, p_now);
   END IF;
   RETURN 0;
 END;
@@ -3072,7 +3072,7 @@ $$;
 -- ── removeUnprocessedChildren: recursively remove a parent's still-pending
 --    children (skipping active/locked ones), mirroring removeUnprocessedChildren-2.
 --    Emits 'removed' for each child taken out; cascades clean up dependency rows.
-CREATE FUNCTION bullmq_remove_unprocessed_children(
+CREATE FUNCTION remove_unprocessed_children(
   p_queue text, p_id text
 ) RETURNS void
 LANGUAGE plpgsql
@@ -3084,8 +3084,8 @@ BEGIN
   FOR r IN
     WITH RECURSIVE subtree AS (
       SELECT j.queue AS q, j.id AS id
-        FROM bullmq_job_dependency d
-        JOIN bullmq_job j ON j.queue = d.child_queue AND j.id = d.child_id
+        FROM job_dependency d
+        JOIN job j ON j.queue = d.child_queue AND j.id = d.child_id
        WHERE d.parent_queue = p_queue AND d.parent_id = p_id
          AND d.status = 'pending'
          AND j.state NOT IN ('active', 'failed', 'completed')
@@ -3093,21 +3093,21 @@ BEGIN
       UNION
       SELECT j.queue, j.id
         FROM subtree s
-        JOIN bullmq_job_dependency d
+        JOIN job_dependency d
           ON d.parent_queue = s.q AND d.parent_id = s.id AND d.status = 'pending'
-        JOIN bullmq_job j ON j.queue = d.child_queue AND j.id = d.child_id
+        JOIN job j ON j.queue = d.child_queue AND j.id = d.child_id
        WHERE j.state NOT IN ('active', 'failed', 'completed')
          AND j.lock_token IS NULL
     )
     SELECT q, id FROM subtree
   LOOP
     -- Decrement the (live) parent's pending counter for direct children.
-    UPDATE bullmq_job p SET pending_deps = GREATEST(pending_deps - 1, 0)
-      FROM bullmq_job_dependency d
+    UPDATE job p SET pending_deps = GREATEST(pending_deps - 1, 0)
+      FROM job_dependency d
      WHERE d.child_queue = r.q AND d.child_id = r.id AND d.status = 'pending'
        AND p.queue = d.parent_queue AND p.id = d.parent_id;
-    DELETE FROM bullmq_job WHERE queue = r.q AND id = r.id;
-    PERFORM bullmq_publish_event(r.q, 'removed',
+    DELETE FROM job WHERE queue = r.q AND id = r.id;
+    PERFORM publish_event(r.q, 'removed',
       jsonb_build_object('jobId', r.id, 'prev', 'waiting'));
   END LOOP;
 END;
@@ -3126,7 +3126,7 @@ $$;
 --     already-completed job is recorded as a processed dependency (carrying its
 --     return value) and, if it clears the parent's last pending dependency, the
 --     parent is released.
-CREATE FUNCTION bullmq_handle_duplicated_job(
+CREATE FUNCTION handle_duplicated_job(
   p_queue        text,
   p_id           text,
   p_parent_queue text,
@@ -3140,28 +3140,28 @@ AS $$
 DECLARE
   v_ex_pq     text;
   v_ex_pid    text;
-  v_state     bullmq_job_state;
+  v_state     job_state;
   v_rv        jsonb;
   v_remaining integer;
   v_added     boolean;
 BEGIN
   -- No new parent to attach: still a duplicate add, so announce it.
   IF p_parent_id IS NULL OR p_parent_queue IS NULL THEN
-    PERFORM bullmq_publish_event(p_queue, 'duplicated',
+    PERFORM publish_event(p_queue, 'duplicated',
       jsonb_build_object('jobId', p_id));
     RETURN 0;
   END IF;
 
   SELECT parent_queue, parent_id, state, return_value
     INTO v_ex_pq, v_ex_pid, v_state, v_rv
-    FROM bullmq_job WHERE queue = p_queue AND id = p_id;
+    FROM job WHERE queue = p_queue AND id = p_id;
 
   -- The existing job already belongs to a different (still-existing) parent.
   IF v_ex_pq IS NOT NULL
      AND (v_ex_pq IS DISTINCT FROM p_parent_queue
           OR v_ex_pid IS DISTINCT FROM p_parent_id)
      AND EXISTS (
-       SELECT 1 FROM bullmq_job WHERE queue = v_ex_pq AND id = v_ex_pid
+       SELECT 1 FROM job WHERE queue = v_ex_pq AND id = v_ex_pid
      ) THEN
     RETURN -7;
   END IF;
@@ -3169,7 +3169,7 @@ BEGIN
   IF v_state = 'completed' THEN
     -- Already finished: record a processed dependency (no pending increment)
     -- and release the parent if this was its last outstanding dependency.
-    INSERT INTO bullmq_job_dependency (
+    INSERT INTO job_dependency (
       parent_queue, parent_id, child_queue, child_id, child_key, status, value
     ) VALUES (
       p_parent_queue, p_parent_id, p_queue, p_id,
@@ -3179,13 +3179,13 @@ BEGIN
       DO UPDATE SET status = 'processed', value = v_rv;
 
     SELECT pending_deps INTO v_remaining
-      FROM bullmq_job WHERE queue = p_parent_queue AND id = p_parent_id;
+      FROM job WHERE queue = p_parent_queue AND id = p_parent_id;
     IF COALESCE(v_remaining, 0) = 0 THEN
-      PERFORM bullmq_move_parent_to_wait(p_parent_queue, p_parent_id, p_now);
+      PERFORM move_parent_to_wait(p_parent_queue, p_parent_id, p_now);
     END IF;
   ELSE
     -- Still pending: register a pending dependency and count it on the parent.
-    INSERT INTO bullmq_job_dependency (
+    INSERT INTO job_dependency (
       parent_queue, parent_id, child_queue, child_id, child_key, status
     ) VALUES (
       p_parent_queue, p_parent_id, p_queue, p_id,
@@ -3194,19 +3194,19 @@ BEGIN
     ON CONFLICT (parent_queue, parent_id, child_key) DO NOTHING;
     GET DIAGNOSTICS v_added = ROW_COUNT;
     IF v_added THEN
-      UPDATE bullmq_job SET pending_deps = pending_deps + 1
+      UPDATE job SET pending_deps = pending_deps + 1
        WHERE queue = p_parent_queue AND id = p_parent_id;
     END IF;
   END IF;
 
   -- Point the existing job at its new parent.
-  UPDATE bullmq_job
+  UPDATE job
      SET parent_queue = p_parent_queue,
          parent_id    = p_parent_id,
          parent_key   = p_parent_key
    WHERE queue = p_queue AND id = p_id;
 
-  PERFORM bullmq_publish_event(p_queue, 'duplicated',
+  PERFORM publish_event(p_queue, 'duplicated',
     jsonb_build_object('jobId', p_id));
 
   RETURN 0;
@@ -3215,7 +3215,7 @@ $$;
 
 -- Record one finished job into the queue/kind metrics (mirrors collectMetrics).
 -- `p_max` is the worker's `metrics.maxDataPoints`; `p_ts` the finish timestamp.
-CREATE FUNCTION bullmq_collect_metrics(
+CREATE FUNCTION collect_metrics(
   p_queue text, p_kind text, p_max integer, p_ts bigint
 ) RETURNS void
 LANGUAGE plpgsql
@@ -3231,15 +3231,15 @@ DECLARE
 BEGIN
   -- Increment the cumulative count; v_count is the value BEFORE this job
   -- (matches Lua's `HINCRBY count 1) - 1`).
-  INSERT INTO bullmq_metrics (queue, kind, count, prev_ts, prev_count, data)
+  INSERT INTO metrics (queue, kind, count, prev_ts, prev_count, data)
     VALUES (p_queue, p_kind, 1, NULL, 0, '{}')
-  ON CONFLICT (queue, kind) DO UPDATE SET count = bullmq_metrics.count + 1
+  ON CONFLICT (queue, kind) DO UPDATE SET count = metrics.count + 1
   RETURNING count - 1, prev_ts, prev_count, data
     INTO v_count, v_prev_ts, v_prev_count, v_data;
 
   -- First data point only establishes the baseline.
   IF v_prev_ts IS NULL THEN
-    UPDATE bullmq_metrics SET prev_ts = p_ts, prev_count = 0
+    UPDATE metrics SET prev_ts = p_ts, prev_count = 0
      WHERE queue = p_queue AND kind = p_kind;
     RETURN;
   END IF;
@@ -3261,7 +3261,7 @@ BEGIN
     END IF;
     -- Trim to the max number of data points.
     v_data := v_data[1 : p_max];
-    UPDATE bullmq_metrics
+    UPDATE metrics
        SET data = v_data, prev_count = v_count, prev_ts = p_ts
      WHERE queue = p_queue AND kind = p_kind;
   END IF;
@@ -3280,9 +3280,9 @@ $$;
 --
 -- These wrappers fuse the two into a single function call — one transaction, one
 -- commit — by simply invoking the existing, unchanged finish and claim functions
--- in sequence. No logic is duplicated: `bullmq_move_to_completed` /
--- `bullmq_move_to_failed` keep all their semantics (parent release, retention,
--- dedup, events, retries), and `bullmq_move_to_active` keeps all of its
+-- in sequence. No logic is duplicated: `move_to_completed` /
+-- `move_to_failed` keep all their semantics (parent release, retention,
+-- dedup, events, retries), and `move_to_active` keeps all of its
 -- (delayed promotion, pause/concurrency/limiter checks, FOR UPDATE SKIP LOCKED
 -- claim). The finish runs first; if it raises (BM001 lock/state errors) the
 -- whole transaction rolls back and nothing is claimed — matching the old
@@ -3296,7 +3296,7 @@ $$;
 -- ──────────────────────────────────────────────────────────────────────────
 -- complete + claim next (0 or 1 job rows)
 -- ──────────────────────────────────────────────────────────────────────────
-CREATE FUNCTION bullmq_move_to_completed_fetch(
+CREATE FUNCTION move_to_completed_fetch(
   p_queue            text,
   p_id               text,
   p_token            text,
@@ -3310,16 +3310,16 @@ CREATE FUNCTION bullmq_move_to_completed_fetch(
   p_name             text,
   p_limiter_max      integer,
   p_limiter_duration bigint
-) RETURNS SETOF bullmq_job
+) RETURNS SETOF job
 LANGUAGE plpgsql
 SET search_path FROM CURRENT
 AS $$
 BEGIN
-  PERFORM bullmq_move_to_completed(
+  PERFORM move_to_completed(
     p_queue, p_id, p_token, p_return_value,
     p_finished_on, p_remove_all, p_keep_age, p_keep_count);
 
-  RETURN QUERY SELECT * FROM bullmq_move_to_active(
+  RETURN QUERY SELECT * FROM move_to_active(
     p_queue, p_token, p_lock_ms, p_now, p_name, p_limiter_max, p_limiter_duration);
 END;
 $$;
@@ -3327,7 +3327,7 @@ $$;
 -- ──────────────────────────────────────────────────────────────────────────
 -- fail (or retry) + claim next (0 or 1 job rows)
 -- ──────────────────────────────────────────────────────────────────────────
-CREATE FUNCTION bullmq_move_to_failed_fetch(
+CREATE FUNCTION move_to_failed_fetch(
   p_queue            text,
   p_id               text,
   p_token            text,
@@ -3342,16 +3342,16 @@ CREATE FUNCTION bullmq_move_to_failed_fetch(
   p_name             text,
   p_limiter_max      integer,
   p_limiter_duration bigint
-) RETURNS SETOF bullmq_job
+) RETURNS SETOF job
 LANGUAGE plpgsql
 SET search_path FROM CURRENT
 AS $$
 BEGIN
-  PERFORM bullmq_move_to_failed(
+  PERFORM move_to_failed(
     p_queue, p_id, p_token, p_failed_reason, p_stacktrace,
     p_finished_on, p_remove_all, p_keep_age, p_keep_count);
 
-  RETURN QUERY SELECT * FROM bullmq_move_to_active(
+  RETURN QUERY SELECT * FROM move_to_active(
     p_queue, p_token, p_lock_ms, p_now, p_name, p_limiter_max, p_limiter_duration);
 END;
 $$;
@@ -3359,20 +3359,20 @@ $$;
 -- ──────────────────────────────────────────────────────────────────────────
 -- add_jobs_bulk: fast set-based bulk insert for INDEPENDENT jobs (no parents,
 -- no deduplication). This is the common Queue.add_bulk case. Unlike
--- bullmq_add_flow — which loops row-by-row to support flow trees, dedup and
+-- add_flow — which loops row-by-row to support flow trees, dedup and
 -- mixed states — this inserts the whole batch with a single set-based INSERT
 -- and emits the lifecycle events in one more set-based INSERT, so it is several
 -- times faster. Returns the job ids in input order. Callers must route flows or
--- deduplicated jobs to bullmq_add_flow instead.
-CREATE FUNCTION bullmq_add_jobs_bulk(p_queue text, p_entries jsonb)
+-- deduplicated jobs to add_flow instead.
+CREATE FUNCTION add_jobs_bulk(p_queue text, p_entries jsonb)
 RETURNS SETOF text
 LANGUAGE plpgsql
 SET search_path FROM CURRENT
 AS $$
 DECLARE
-  v_seq_name text := bullmq_job_id_seq_name(p_queue);
+  v_seq_name text := job_id_seq_name(p_queue);
 BEGIN
-  -- Ensure the per-queue id sequence exists (mirrors bullmq_next_job_id).
+  -- Ensure the per-queue id sequence exists (mirrors next_job_id).
   IF to_regclass(v_seq_name) IS NULL THEN
     PERFORM pg_advisory_xact_lock(hashtext('bullmq:jidseq:' || p_queue));
     EXECUTE format('CREATE SEQUENCE IF NOT EXISTS %I', v_seq_name);
@@ -3405,7 +3405,7 @@ BEGIN
   -- value with the ord-th entry, so seq is strictly monotonic in input order
   -- regardless of evaluation order.
   reserved AS (
-    SELECT ord, nextval('bullmq_job_seq') AS s FROM prepared
+    SELECT ord, nextval('job_seq') AS s FROM prepared
   ),
   rr AS (SELECT s, row_number() OVER (ORDER BY s) AS rn FROM reserved),
   rp AS (SELECT prepared.*, row_number() OVER (ORDER BY ord) AS rn FROM prepared),
@@ -3413,8 +3413,8 @@ BEGIN
     SELECT rp.ord, rp.id, rp.name, rp.data, rp.opts, rp.priority, rp.delay,
            rp.ts, rp.attempts, rp.scheduler_id,
            CASE WHEN rp.lifo THEN -rr.s ELSE rr.s END AS seq,
-           CASE WHEN rp.delay > 0 THEN 'delayed'::bullmq_job_state
-                ELSE 'waiting'::bullmq_job_state END   AS state,
+           CASE WHEN rp.delay > 0 THEN 'delayed'::job_state
+                ELSE 'waiting'::job_state END   AS state,
            CASE WHEN rp.delay > 0 THEN rp.ts + rp.delay ELSE NULL END AS process_at
       FROM rp JOIN rr ON rp.rn = rr.rn
   )
@@ -3424,10 +3424,10 @@ BEGIN
   -- skips ids that already exist and in-batch duplicate ids. Events and the
   -- wakeup are driven from this set, so a batch that repeats or reuses an id
   -- does not emit spurious added/waiting/delayed events or a bogus NOTIFY —
-  -- mirroring bullmq_add_flow's per-row `IF v_inserted` gating.
+  -- mirroring add_flow's per-row `IF v_inserted` gating.
   CREATE TEMP TABLE _bulk_inserted ON COMMIT DROP AS
   WITH ins AS (
-    INSERT INTO bullmq_job (
+    INSERT INTO job (
       queue, id, seq, name, state, data, opts, priority, delay_ms, max_attempts,
       added_at_ms, process_at_ms, scheduler_id, pending_deps
     )
@@ -3442,7 +3442,7 @@ BEGIN
   -- One set-based event flush ('added' then the state event per inserted job),
   -- ordered by each inserted job's first input ordinality so stream ordering
   -- matches caller payload order even when seq is negated by LIFO.
-  INSERT INTO bullmq_event (queue, event, data, created_at_ms)
+  INSERT INTO event (queue, event, data, created_at_ms)
   WITH inserted AS (
     SELECT i.id, i.name, i.state, i.process_at_ms, MIN(r.ord) AS ord
       FROM _bulk_inserted i

--- a/src/postgres/migrations/index.ts
+++ b/src/postgres/migrations/index.ts
@@ -3,7 +3,7 @@ import { loadMigrationSql } from '../sql-loader';
 /**
  * A single, ordered schema migration. The `.sql` file is the source of truth;
  * `version` is the monotonically increasing schema version recorded in the
- * `bullmq_migration` ledger table once applied.
+ * `migration` ledger table once applied.
  */
 export interface Migration {
   /** Monotonically increasing schema version (1, 2, 3, …). */

--- a/src/postgres/migrator.ts
+++ b/src/postgres/migrator.ts
@@ -248,14 +248,14 @@ export async function getCurrentSchemaVersion(
   client: PgQueryable,
 ): Promise<number> {
   const { rows } = await client.query<{ version: number }>(
-    'SELECT COALESCE(MAX(version), 0)::int AS version FROM bullmq_migration',
+    'SELECT COALESCE(MAX(version), 0)::int AS version FROM migration',
   );
   return rows[0]?.version ?? 0;
 }
 
 async function ensureLedgerTable(client: PgQueryable): Promise<void> {
   await client.query(
-    `CREATE TABLE IF NOT EXISTS bullmq_migration (
+    `CREATE TABLE IF NOT EXISTS migration (
        version    integer PRIMARY KEY,
        name       text NOT NULL,
        applied_at timestamptz NOT NULL DEFAULT now()
@@ -268,8 +268,8 @@ async function applyMigration(
   migration: Migration,
 ): Promise<void> {
   await client.query(migration.load());
-  await client.query(
-    'INSERT INTO bullmq_migration (version, name) VALUES ($1, $2)',
-    [migration.version, migration.name],
-  );
+  await client.query('INSERT INTO migration (version, name) VALUES ($1, $2)', [
+    migration.version,
+    migration.name,
+  ]);
 }

--- a/src/postgres/postgres-queue-backend.ts
+++ b/src/postgres/postgres-queue-backend.ts
@@ -28,7 +28,7 @@ import { PostgresConnection } from './postgres-connection';
 import { PgNotification, PgListenClient, PgQueryResult } from './pg-types';
 import { loadCommandSql } from './sql-loader';
 /**
- * A raw `bullmq_job` row as returned by `pg`. `jsonb` columns arrive already
+ * A raw `job` row as returned by `pg`. `jsonb` columns arrive already
  * parsed; `bigint`/`int8` columns arrive as strings (node-postgres default).
  */
 interface JobRow {
@@ -114,7 +114,7 @@ function normalizeKeep(opt: boolean | number | KeepJobs | undefined): {
 }
 
 /**
- * Maps a `bullmq_job` row to the public {@link JobJson} shape consumed by
+ * Maps a `job` row to the public {@link JobJson} shape consumed by
  * `Job.fromJSON`. JSON-string fields (`data`, `returnvalue`, `stacktrace`) are
  * re-stringified; `opts` is returned as the stored object.
  */
@@ -160,7 +160,7 @@ function notImplemented(op: string): never {
   );
 }
 
-/** Raw `bullmq_scheduler` row as returned by the `get_job_scheduler` command. */
+/** Raw `scheduler` row as returned by the `get_job_scheduler` command. */
 interface SchedulerRow {
   name: string | null;
   iteration_count: number | string | null;
@@ -608,7 +608,7 @@ export class PostgresQueueBackend
     return rows.map(r => r.id);
   }
 
-  /** Builds one entry of the JSONB batch consumed by `bullmq_add_flow`. */
+  /** Builds one entry of the JSONB batch consumed by `add_flow`. */
   private toBatchEntry(
     queueName: string,
     data: JobJson,
@@ -2069,10 +2069,10 @@ export class PostgresQueueBackend
   // Worker blocking primitive
   // ============================================================
 
-  /** The shared notify channel all producers post to (see `bullmq_add_job`). */
+  /** The shared notify channel all producers post to (see `add_job`). */
   private static readonly NOTIFY_CHANNEL = 'bullmq_jobs';
 
-  /** The shared event-stream channel (see `bullmq_publish_event`). */
+  /** The shared event-stream channel (see `publish_event`). */
   private static readonly EVENTS_CHANNEL = 'bullmq_events';
 
   /** Subscribes the dedicated client to the shared jobs channel (once). */
@@ -2135,7 +2135,7 @@ export class PostgresQueueBackend
   /**
    * Blocks (up to `blockTimeout` seconds) until a job for this queue may be
    * available, via `LISTEN`/`NOTIFY`. Producers notify the shared `bullmq_jobs`
-   * channel with the queue name as payload (in `bullmq_add_job`), so a producer
+   * channel with the queue name as payload (in `add_job`), so a producer
    * in any process wakes a blocked worker immediately. Returns a marker
    * (`score` 0 = "check now") or `null` on timeout. The Redis backend
    * implements this with `BZPOPMIN`.

--- a/tests/postgres/migration.test.ts
+++ b/tests/postgres/migration.test.ts
@@ -56,13 +56,13 @@ describe('PostgreSQL migrations', () => {
       await connection.waitUntilReady();
 
       const { rows } = await pool.query<{ version: number }>(
-        `SELECT COALESCE(MAX(version), 0)::int AS version FROM "${schema}".bullmq_migration`,
+        `SELECT COALESCE(MAX(version), 0)::int AS version FROM "${schema}".migration`,
       );
       expect(rows[0].version).toBe(LATEST_SCHEMA_VERSION);
 
       // The v1 schema creates the meta table inside the namespace schema.
       const { rows: metaRows } = await pool.query<{ exists: boolean }>(
-        `SELECT to_regclass('"${schema}".bullmq_meta') IS NOT NULL AS exists`,
+        `SELECT to_regclass('"${schema}".meta') IS NOT NULL AS exists`,
       );
       expect(metaRows[0].exists).toBe(true);
     } finally {
@@ -76,14 +76,14 @@ describe('PostgreSQL migrations', () => {
       await connection.waitUntilReady();
 
       const tables = [
-        'bullmq_job',
-        'bullmq_job_log',
-        'bullmq_job_dependency',
-        'bullmq_event',
-        'bullmq_metrics',
-        'bullmq_rate_limit',
-        'bullmq_dedup',
-        'bullmq_scheduler',
+        'job',
+        'job_log',
+        'job_dependency',
+        'event',
+        'metrics',
+        'rate_limit',
+        'dedup',
+        'scheduler',
       ];
       for (const table of tables) {
         const { rows } = await pool.query<{ exists: boolean }>(
@@ -98,14 +98,14 @@ describe('PostgreSQL migrations', () => {
          FROM pg_type t
          JOIN pg_namespace n ON n.oid = t.typnamespace
          WHERE n.nspname = $1
-           AND t.typname IN ('bullmq_job_state', 'bullmq_dep_status')`,
+           AND t.typname IN ('job_state', 'dep_status')`,
         [schema],
       );
       expect(enumRows[0].n).toBe(2);
 
       // The partial index that powers the "claim next ready job" hot path.
       const { rows: idxRows } = await pool.query<{ exists: boolean }>(
-        `SELECT to_regclass('"${schema}".bullmq_job_ready_idx') IS NOT NULL AS exists`,
+        `SELECT to_regclass('"${schema}".job_ready_idx') IS NOT NULL AS exists`,
       );
       expect(idxRows[0].exists).toBe(true);
     } finally {
@@ -120,7 +120,7 @@ describe('PostgreSQL migrations', () => {
     await first.close();
 
     const { rows: before } = await pool.query<{ version: number; n: number }>(
-      `SELECT COALESCE(MAX(version), 0)::int AS version, COUNT(*)::int AS n FROM "${schema}".bullmq_migration`,
+      `SELECT COALESCE(MAX(version), 0)::int AS version, COUNT(*)::int AS n FROM "${schema}".migration`,
     );
 
     // Second run on a brand-new connection.
@@ -129,7 +129,7 @@ describe('PostgreSQL migrations', () => {
     await second.close();
 
     const { rows: after } = await pool.query<{ version: number; n: number }>(
-      `SELECT COALESCE(MAX(version), 0)::int AS version, COUNT(*)::int AS n FROM "${schema}".bullmq_migration`,
+      `SELECT COALESCE(MAX(version), 0)::int AS version, COUNT(*)::int AS n FROM "${schema}".migration`,
     );
 
     expect(after[0].version).toBe(before[0].version);
@@ -144,7 +144,7 @@ describe('PostgreSQL migrations', () => {
 
     const futureVersion = LATEST_SCHEMA_VERSION + 1;
     await pool.query(
-      `INSERT INTO "${schema}".bullmq_migration (version, name) VALUES ($1, $2)`,
+      `INSERT INTO "${schema}".migration (version, name) VALUES ($1, $2)`,
       [futureVersion, 'future'],
     );
 
@@ -155,10 +155,9 @@ describe('PostgreSQL migrations', () => {
       );
     } finally {
       client.release();
-      await pool.query(
-        `DELETE FROM "${schema}".bullmq_migration WHERE version = $1`,
-        [futureVersion],
-      );
+      await pool.query(`DELETE FROM "${schema}".migration WHERE version = $1`, [
+        futureVersion,
+      ]);
     }
   });
 


### PR DESCRIPTION
Objects live in a dedicated (configurable) `bullmq` schema, so prefixing every
table/function with `bullmq_` was redundant (`bullmq.bullmq_job`). Rename all
schema-scoped objects to their bare names (`bullmq.job`, `bullmq.add_job()`, …).

Since the SQL backend was only just published and is unannounced/unused, this is
a deliberate breaking change without a major-version bump (early adopters simply
drop the `bullmq` schema and let it re-create).

- Migrations edited in place (no rename migration, no duplicated function defs):
  tables (job, event, meta, scheduler, dedup, dedup_next, job_dependency,
  job_log, metrics, rate_limit), types (job_state, dep_status), sequences
  (job_seq, event_seq, job_id_seq), 52 functions, and the ledger table
  bullmq_migration -> migration.
- Kept unchanged (database-global / not schema-scoped): LISTEN/NOTIFY channels
  `bullmq_jobs` / `bullmq_events`, advisory-lock namespaces (`bullmq:…`,
  `bullmq_jid_`), and the `bullmq_test` database name.

Applied consistently across the single SQL source of truth (src/postgres) and
all runtime adapters that copy from it at packaging time:
- Node.js (migrator.ts, postgres-queue-backend.ts, tests/postgres)
- Elixir (backends/postgres.ex, migrator.ex)
- Python (backends/postgres_backend.py, postgres_connection.py)
