### PR TITLE
fix(events): type completed event returnvalue as deserialized value

### DIFF
--- a/docs/gitbook/bullmq-pro/nestjs/queue-events-listeners.md
+++ b/docs/gitbook/bullmq-pro/nestjs/queue-events-listeners.md
@@ -8,7 +8,7 @@ import {
   QueueEventsHost,
   OnQueueEvent,
 } from '@taskforcesh/nestjs-bullmq-pro';
-// Aliased because `QueueEventsListener` from the decorator package is the decorator
+// Aliased because `QueueEventsListener` from '@taskforcesh/nestjs-bullmq-pro' is the decorator
 import type { QueueEventsListener as QueueEventsListenerType } from 'bullmq';
 
 // Use the generic to type the event payload with your job's return value

--- a/docs/gitbook/bullmq-pro/nestjs/queue-events-listeners.md
+++ b/docs/gitbook/bullmq-pro/nestjs/queue-events-listeners.md
@@ -12,13 +12,7 @@ import {
 @QueueEventsListener('queueName')
 export class TestQueueEvents extends QueueEventsHost {
   @OnQueueEvent('completed')
-  onCompleted({
-    jobId,
-  }: {
-    jobId: string;
-    returnvalue: string;
-    prev?: string;
-  }) {
+  onCompleted({ jobId }: { jobId: string; returnvalue: any; prev?: string }) {
     // do some stuff
   }
 }

--- a/docs/gitbook/bullmq-pro/nestjs/queue-events-listeners.md
+++ b/docs/gitbook/bullmq-pro/nestjs/queue-events-listeners.md
@@ -8,11 +8,19 @@ import {
   QueueEventsHost,
   OnQueueEvent,
 } from '@taskforcesh/nestjs-bullmq-pro';
+// Aliased because `QueueEventsListener` from the decorator package is the decorator
+import type { QueueEventsListener as QueueEventsListenerType } from 'bullmq';
+
+// Use the generic to type the event payload with your job's return value
+type CompletedEvent = QueueEventsListenerType<{ result: number }>['completed'];
+
+type CompletedEventArgs = Parameters<CompletedEvent>[0];
 
 @QueueEventsListener('queueName')
 export class TestQueueEvents extends QueueEventsHost {
   @OnQueueEvent('completed')
-  onCompleted({ jobId }: { jobId: string; returnvalue: any; prev?: string }) {
+  onCompleted({ jobId, returnvalue }: CompletedEventArgs) {
+    // returnvalue is typed as { result: number }
     // do some stuff
   }
 }

--- a/docs/gitbook/guide/nestjs/queue-events-listeners.md
+++ b/docs/gitbook/guide/nestjs/queue-events-listeners.md
@@ -12,13 +12,7 @@ import {
 @QueueEventsListener('queueName')
 export class TestQueueEvents extends QueueEventsHost {
   @OnQueueEvent('completed')
-  onCompleted({
-    jobId,
-  }: {
-    jobId: string;
-    returnvalue: string;
-    prev?: string;
-  }) {
+  onCompleted({ jobId }: { jobId: string; returnvalue: any; prev?: string }) {
     // do some stuff
   }
 }

--- a/docs/gitbook/guide/nestjs/queue-events-listeners.md
+++ b/docs/gitbook/guide/nestjs/queue-events-listeners.md
@@ -8,11 +8,19 @@ import {
   QueueEventsHost,
   OnQueueEvent,
 } from '@nestjs/bullmq';
+// Aliased because `QueueEventsListener` from '@nestjs/bullmq' is the decorator
+import type { QueueEventsListener as QueueEventsListenerType } from 'bullmq';
+
+// Use the generic to type the event payload with your job's return value
+type CompletedEvent = QueueEventsListenerType<{ result: number }>['completed'];
+
+type CompletedEventArgs = Parameters<CompletedEvent>[0];
 
 @QueueEventsListener('queueName')
 export class TestQueueEvents extends QueueEventsHost {
   @OnQueueEvent('completed')
-  onCompleted({ jobId }: { jobId: string; returnvalue: any; prev?: string }) {
+  onCompleted({ jobId, returnvalue }: CompletedEventArgs) {
+    // returnvalue is typed as { result: number }
     // do some stuff
   }
 }

--- a/src/classes/queue-events.ts
+++ b/src/classes/queue-events.ts
@@ -9,7 +9,7 @@ import { array2obj, isRedisInstance, QUEUE_EVENT_SUFFIX } from '../utils';
 import { QueueBase } from './queue-base';
 import { createIORedisClient, isIRedisClient } from './ioredis-client';
 
-export interface QueueEventsListener extends IoredisListener {
+export interface QueueEventsListener<ReturnType = any> extends IoredisListener {
   /**
    * Listen to 'active' event.
    *
@@ -54,12 +54,12 @@ export interface QueueEventsListener extends IoredisListener {
    *
    * @param args - An object containing details about the completed job.
    *   - `jobId` - The unique identifier of the job that completed.
-   *   - `returnvalue` - The return value of the job, serialized as a string.
+   *   - `returnvalue` - The value returned by the job's processor, deserialized from JSON.
    *   - `prev` - The previous state of the job before completion (e.g., 'active'), if applicable.
    * @param id - The identifier of the event.
    */
   completed: (
-    args: { jobId: string; returnvalue: string; prev?: string },
+    args: { jobId: string; returnvalue: ReturnType; prev?: string },
     id: string,
   ) => void;
 
@@ -256,7 +256,7 @@ type KeyOf<T extends object> = Extract<keyof T, string>;
  * This class requires a dedicated redis connection.
  *
  */
-export class QueueEvents extends QueueBase {
+export class QueueEvents<ReturnType = any> extends QueueBase {
   private running = false;
   private blocking = false;
 
@@ -295,14 +295,16 @@ export class QueueEvents extends QueueBase {
   }
 
   emit<
-    QEL extends QueueEventsListener = QueueEventsListener,
+    QEL extends QueueEventsListener<ReturnType> =
+      QueueEventsListener<ReturnType>,
     U extends KeyOf<QEL> = KeyOf<QEL>,
   >(event: U, ...args: CustomParameters<QEL[U]>): boolean {
     return super.emit(event, ...args);
   }
 
   off<
-    QEL extends QueueEventsListener = QueueEventsListener,
+    QEL extends QueueEventsListener<ReturnType> =
+      QueueEventsListener<ReturnType>,
     U extends KeyOf<QEL> = KeyOf<QEL>,
   >(eventName: U, listener: QEL[U]): this {
     super.off(eventName, listener as (...args: any[]) => void);
@@ -310,7 +312,8 @@ export class QueueEvents extends QueueBase {
   }
 
   on<
-    QEL extends QueueEventsListener = QueueEventsListener,
+    QEL extends QueueEventsListener<ReturnType> =
+      QueueEventsListener<ReturnType>,
     U extends KeyOf<QEL> = KeyOf<QEL>,
   >(event: U, listener: QEL[U]): this {
     super.on(event, listener as (...args: any[]) => void);
@@ -318,7 +321,8 @@ export class QueueEvents extends QueueBase {
   }
 
   once<
-    QEL extends QueueEventsListener = QueueEventsListener,
+    QEL extends QueueEventsListener<ReturnType> =
+      QueueEventsListener<ReturnType>,
     U extends KeyOf<QEL> = KeyOf<QEL>,
   >(event: U, listener: QEL[U]): this {
     super.once(event, listener as (...args: any[]) => void);

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -587,4 +587,31 @@ describe('events', () => {
     await completed;
     await worker.close();
   });
+
+  it('emits completed global event with the deserialized return value', async () => {
+    const worker = new Worker(queueName, async () => ({ result: 42 }), {
+      connection,
+      prefix,
+    });
+
+    const completed = new Promise<void>((resolve, reject) => {
+      queueEvents.once<QueueEventsListener<{ result: number }>, 'completed'>(
+        'completed',
+        async function ({ jobId, returnvalue }) {
+          try {
+            expect(jobId).toBe('1');
+            expect(returnvalue).toEqual({ result: 42 });
+            resolve();
+          } catch (err) {
+            reject(err);
+          }
+        },
+      );
+    });
+
+    await queue.add('test', {});
+
+    await completed;
+    await worker.close();
+  });
 });


### PR DESCRIPTION
## Summary

Closes #4147

This PR fixes the `completed` event typing on `QueueEvents`. At runtime, `queue-events.ts` deserializes the job return value with `JSON.parse` before emitting it to listeners, so the `returnvalue` received by event handlers is the actual processor return value (object, number, boolean, etc.) — not the string it was previously typed as.

### Changes

- Make `QueueEventsListener` generic with a `ReturnType = any` type parameter (mirroring the existing `MinimalJob<DataType, ReturnType>` / `WorkerListener` conventions).
- Type the `completed` event as `args: { jobId: string; returnvalue: ReturnType; prev?: string }`.
- Make the `QueueEvents` class generic (`QueueEvents<ReturnType = any>`) and thread the type parameter through `emit`/`off`/`on`/`once`.
- Update the JSDoc for `completed` to reflect that `returnvalue` is deserialized from JSON.
- Update the NestJS guide docs examples that still showed `returnvalue: string`.

### Usage

```ts
const queueEvents = new QueueEvents(queueName);

queueEvents.on<QueueEventsListener<{ result: number }>, "completed">(
  "completed",
  ({ returnvalue }) => {
    // returnvalue is now typed as { result: number }
  },
);
```

### Tests

- Added a regression test in `tests/events.test.ts` (`emits completed global event with the deserialized return value`) that processes a job returning an object and asserts the `completed` event delivers the deserialized object.
- All 17 tests in `tests/events.test.ts` pass.
- `tsc`, `eslint`, and `prettier` are clean.