### PR TITLE
fix(worker): fail jobs with deferred failure in task-based worker path [elixir]

### DIFF
--- a/elixir/lib/bullmq/worker.ex
+++ b/elixir/lib/bullmq/worker.ex
@@ -1110,6 +1110,16 @@ defmodule BullMQ.Worker do
     end
   end
 
+  def handle_info({:job_unrecoverable, job_id, reason}, state) do
+    case Map.get(state.active_jobs, job_id) do
+      nil ->
+        {:noreply, state}
+
+      {job, _task_ref} ->
+        handle_job_unrecoverable(job, reason, state)
+    end
+  end
+
   def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
     # Find the job associated with this task
     case find_job_by_ref(state.active_jobs, ref) do
@@ -1791,48 +1801,74 @@ defmodule BullMQ.Worker do
 
   # Execute processor without telemetry
   defp execute_processor(processor_fn, job, worker_pid) do
-    try do
-      result = processor_fn.()
-      send(worker_pid, {:job_completed, job.id, result})
-    rescue
-      e ->
-        stacktrace = __STACKTRACE__
-        send(worker_pid, {:job_failed, job.id, Exception.message(e), stacktrace})
-    catch
-      :exit, reason ->
-        stacktrace = __STACKTRACE__
-        send(worker_pid, {:job_failed, job.id, inspect(reason), stacktrace})
+    case deferred_failure_reason(job) do
+      nil ->
+        try do
+          result = processor_fn.()
+          send(worker_pid, {:job_completed, job.id, result})
+        rescue
+          e ->
+            stacktrace = __STACKTRACE__
+            send(worker_pid, {:job_failed, job.id, Exception.message(e), stacktrace})
+        catch
+          :exit, reason ->
+            stacktrace = __STACKTRACE__
+            send(worker_pid, {:job_failed, job.id, inspect(reason), stacktrace})
 
-      :throw, value ->
-        stacktrace = __STACKTRACE__
-        send(worker_pid, {:job_failed, job.id, inspect(value), stacktrace})
+          :throw, value ->
+            stacktrace = __STACKTRACE__
+            send(worker_pid, {:job_failed, job.id, inspect(value), stacktrace})
+        end
+
+      reason ->
+        # Jobs carrying a deferred failure (e.g. stalled over the allowable
+        # limit) must fail immediately without running the processor.
+        send(worker_pid, {:job_unrecoverable, job.id, reason})
     end
   end
 
   # Execute processor with telemetry span
   defp execute_processor_with_span(processor_fn, job, worker_pid, telemetry_mod, span) do
-    try do
-      result = processor_fn.()
-      telemetry_mod.end_span(span, :ok)
-      send(worker_pid, {:job_completed, job.id, result})
-    rescue
-      e ->
-        stacktrace = __STACKTRACE__
-        telemetry_mod.record_exception(span, e, stacktrace)
-        telemetry_mod.end_span(span, {:error, Exception.message(e)})
-        send(worker_pid, {:job_failed, job.id, Exception.message(e), stacktrace})
-    catch
-      :exit, reason ->
-        stacktrace = __STACKTRACE__
-        telemetry_mod.end_span(span, {:error, inspect(reason)})
-        send(worker_pid, {:job_failed, job.id, inspect(reason), stacktrace})
+    case deferred_failure_reason(job) do
+      nil ->
+        try do
+          result = processor_fn.()
+          telemetry_mod.end_span(span, :ok)
+          send(worker_pid, {:job_completed, job.id, result})
+        rescue
+          e ->
+            stacktrace = __STACKTRACE__
+            telemetry_mod.record_exception(span, e, stacktrace)
+            telemetry_mod.end_span(span, {:error, Exception.message(e)})
+            send(worker_pid, {:job_failed, job.id, Exception.message(e), stacktrace})
+        catch
+          :exit, reason ->
+            stacktrace = __STACKTRACE__
+            telemetry_mod.end_span(span, {:error, inspect(reason)})
+            send(worker_pid, {:job_failed, job.id, inspect(reason), stacktrace})
 
-      :throw, value ->
-        stacktrace = __STACKTRACE__
-        telemetry_mod.end_span(span, {:error, inspect(value)})
-        send(worker_pid, {:job_failed, job.id, inspect(value), stacktrace})
+          :throw, value ->
+            stacktrace = __STACKTRACE__
+            telemetry_mod.end_span(span, {:error, inspect(value)})
+            send(worker_pid, {:job_failed, job.id, inspect(value), stacktrace})
+        end
+
+      reason ->
+        # Jobs carrying a deferred failure (e.g. stalled over the allowable
+        # limit) must fail immediately without running the processor.
+        telemetry_mod.end_span(span, {:error, reason})
+        send(worker_pid, {:job_unrecoverable, job.id, reason})
     end
   end
+
+  # Jobs carrying a deferred failure must fail immediately instead of running
+  # the processor or retrying.
+  defp deferred_failure_reason(%Job{deferred_failure: deferred_failure})
+       when is_binary(deferred_failure) and deferred_failure != "" do
+    deferred_failure
+  end
+
+  defp deferred_failure_reason(_), do: nil
 
   # Check if processor accepts cancellation token (arity 2)
   defp processor_supports_cancellation?(processor) when is_function(processor) do
@@ -2047,6 +2083,33 @@ defmodule BullMQ.Worker do
       updated_job = %{job | attempts_made: job.attempts_made + 1, failed_reason: error_message}
       emit_event(state.on_failed, [updated_job, error_message])
     end
+
+    # Untrack job from LockManager
+    if state.lock_manager do
+      LockManager.untrack_job(state.lock_manager, job.id)
+    end
+
+    # Remove from active jobs, clean up cancellation token, and handle next job
+    new_state = cleanup_job_resources(job.id, state)
+    handle_next_job_or_fetch(next_job_result, new_state)
+  end
+
+  # A deferred/unrecoverable failure moves the job straight to failed,
+  # bypassing the retry logic (mirrors the autonomous worker path).
+  defp handle_job_unrecoverable(job, reason, state) do
+    error_message = if is_binary(reason), do: reason, else: inspect(reason)
+
+    next_job_result =
+      Backend.move_to_failed(
+        state.backend,
+        job.id,
+        job.token,
+        error_message,
+        build_move_opts(state, job) ++ [stacktrace: nil]
+      )
+
+    updated_job = %{job | attempts_made: job.attempts_made + 1, failed_reason: error_message}
+    emit_event(state.on_failed, [updated_job, error_message])
 
     # Untrack job from LockManager
     if state.lock_manager do

--- a/elixir/test/bullmq/backends/postgres_integration_test.exs
+++ b/elixir/test/bullmq/backends/postgres_integration_test.exs
@@ -115,6 +115,65 @@ defmodule BullMQ.Backends.PostgresIntegrationTest do
     Worker.close(worker)
   end
 
+  # Regression: a job that stalled more than `max_stalled_count` allows is moved
+  # back to `waiting` with its `deferred_failure` column set (see
+  # `move_stalled_jobs_to_wait`). The worker must fail such a job immediately —
+  # without running the processor and without retrying — instead of running the
+  # user code again and letting the job cycle through active/stalled forever.
+  test "job carrying deferred_failure is failed without running the processor or retrying",
+       %{conn: conn, queue: queue} do
+    test_pid = self()
+    reason = "job stalled more than allowable limit"
+
+    # Seed a normal waiting job that still has retry attempts left, so proving it
+    # ends `failed` also proves the deferred failure bypasses the retry logic.
+    {:ok, job} = Queue.add(queue, "stalled-job", %{}, connection: conn, attempts: 5)
+
+    # Stamp the deferred failure exactly as the stalled-recovery flow does.
+    {:ok, _} =
+      Postgrex.query(
+        Backends.Postgres.Connection.pool(conn),
+        "UPDATE job SET deferred_failure = $1 WHERE queue = $2 AND id = $3",
+        [reason, queue, job.id]
+      )
+
+    {:ok, worker} =
+      Worker.start_link(
+        queue: queue,
+        connection: conn,
+        processor: fn _job ->
+          send(test_pid, :processor_ran)
+          {:ok, :should_not_happen}
+        end,
+        on_completed: fn j, _result -> send(test_pid, {:completed, j.id}) end,
+        on_failed: fn j, failed_reason ->
+          send(test_pid, {:failed, j.id, j.attempts_made, failed_reason})
+        end
+      )
+
+    # The job is failed immediately, carrying the deferred reason, with its
+    # attempt counter advanced once.
+    assert_receive {:failed, job_id, attempts_made, failed_reason}, 10_000
+    assert job_id == job.id
+    assert to_string(failed_reason) =~ "stalled more than allowable limit"
+    assert attempts_made == 1
+
+    # The processor never runs and the job never completes.
+    refute_receive :processor_ran, 500
+    refute_receive {:completed, _}, 200
+
+    # The job ends in `failed` — not stuck in active/waiting, and not retried.
+    assert {:ok, "failed"} = Queue.get_job_state(queue, job.id, connection: conn)
+
+    backend = Backend.create(queue, connection: conn, backend: Backends.Postgres)
+    {:ok, counts} = Backend.get_counts(backend)
+    assert counts["failed"] == 1
+    assert counts["active"] == 0
+    assert counts["waiting"] == 0
+
+    Worker.close(worker)
+  end
+
   test "FlowProducer parent completes after its children are processed", %{conn: conn, queue: queue} do
     test_pid = self()
 


### PR DESCRIPTION

The task-based (coordinator) execution path ran the processor even when a job carried a deferred failure (e.g. a job stalled more than the allowable limit, or a child failing a parent via failParentOnFailure). This let such jobs keep cycling through active/stalled instead of being finalized as failed. Only the autonomous worker loop guarded against this.

Short-circuit `execute_processor` and `execute_processor_with_span` when `job.deferred_failure` is set: skip the processor and route the job through a new `:job_unrecoverable` message to `handle_job_unrecoverable/3`, which moves it straight to failed via `Backend.move_to_failed`, bypassing the retry logic (mirroring the autonomous path's `{:unrecoverable_error, _}` handling). This avoids incorrectly retrying jobs that still have attempts remaining, since a deferred failure is terminal.
