### PR TITLE
fix(worker): recover blocking reads that never settle after a reconnect fixes #4479

### DIFF
--- a/src/classes/redis-queue-backend.ts
+++ b/src/classes/redis-queue-backend.ts
@@ -2735,21 +2735,43 @@ export class RedisQueueBackend extends EventEmitter implements IQueueBackend {
       ? blockTimeout
       : Math.ceil(blockTimeout);
 
-    // We cannot trust that the blocking connection stays blocking forever due
-    // to issues in Redis and IORedis, so we reconnect the (owned) blocking
-    // connection if we don't get a response within the expected time.
-    const watchdog = setTimeout(
-      () => {
-        bclient.disconnect(!this.closing);
-      },
-      roundedTimeout * 1000 + 1000,
-    );
+    const bzpopmin = bclient.bzpopmin(
+      this.queue.keys.marker,
+      roundedTimeout,
+    ) as Promise<[string, string, string] | null>;
+    // If the watchdog abandons this command below, its (possibly much later)
+    // rejection must not surface as an unhandled promise rejection.
+    bzpopmin.catch((): null => null);
+
+    // We cannot trust that the blocking connection stays blocking for exactly
+    // the expected time due to issues in Redis and IORedis. In particular,
+    // blocking connections must use `maxRetriesPerRequest: null`, and with that
+    // setting IORedis silently re-queues and re-sends an interrupted blocking
+    // command after a reconnect instead of rejecting it (see #4479). As a
+    // result the awaited `bzpopmin` can hang forever after a transient
+    // connection reset, parking the worker's fetch loop permanently.
+    //
+    // To make this robust we race the blocking command against a watchdog
+    // timeout: when the deadline passes we disconnect the (owned) blocking
+    // connection to abandon the possibly-stuck command and resolve the wait as
+    // a timeout, so the worker loop always advances (and can promote due
+    // delayed jobs / write markers) regardless of whether IORedis ever settles
+    // the command.
+    let timedOut = false;
+    let watchdog: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<null>(resolve => {
+      watchdog = setTimeout(
+        () => {
+          timedOut = true;
+          bclient.disconnect(false);
+          resolve(null);
+        },
+        roundedTimeout * 1000 + 1000,
+      );
+    });
 
     try {
-      const result = await bclient.bzpopmin(
-        this.queue.keys.marker,
-        roundedTimeout,
-      );
+      const result = await Promise.race([bzpopmin, timeout]);
       if (result) {
         const [, member, score] = result;
         if (member) {
@@ -2759,6 +2781,18 @@ export class RedisQueueBackend extends EventEmitter implements IQueueBackend {
       return null;
     } finally {
       clearTimeout(watchdog);
+      // The watchdog disconnected the blocking connection without letting
+      // IORedis auto-resend the abandoned command. Since we resolved the wait
+      // as a timeout (rather than surfacing a rejection to the worker's own
+      // reconnect path), re-establish the dedicated blocking connection here so
+      // the next `waitForJob` starts from a healthy, unblocked connection.
+      if (timedOut && !this.closing) {
+        try {
+          await this.reconnectBlocking();
+        } catch {
+          // Ignored: the next waitForJob call will retry the reconnect.
+        }
+      }
     }
   }
 
@@ -2775,9 +2809,55 @@ export class RedisQueueBackend extends EventEmitter implements IQueueBackend {
 
   async readEvents(id: string, blockTimeout: number): Promise<StreamReadRaw> {
     const client = await this.queue.client;
-    return client.xread([{ key: this.queue.keys.events, id }], {
+
+    const xread = client.xread([{ key: this.queue.keys.events, id }], {
       BLOCK: blockTimeout,
+    }) as Promise<StreamReadRaw>;
+
+    // A non-positive BLOCK means "block forever"; there is no bounded deadline
+    // to guard, so fall back to the plain blocking read.
+    if (blockTimeout <= 0) {
+      return xread;
+    }
+
+    // If the watchdog abandons this command below, its (possibly much later)
+    // rejection must not surface as an unhandled promise rejection.
+    xread.catch((): null => null);
+
+    // Same class of hang as `waitForJob` (#4479): the event-stream connection
+    // must use `maxRetriesPerRequest: null`, and with that setting IORedis
+    // silently re-queues and re-sends an interrupted blocking `XREAD` after a
+    // reconnect instead of rejecting it — so the awaited read can hang forever
+    // after a transient connection reset, permanently stalling the event
+    // consumer loop. Race the read against a watchdog: when the deadline passes
+    // (the server-side BLOCK plus a small margin) we disconnect the connection
+    // to abandon the stuck command and resolve as a timeout, so the consumer
+    // loop always advances and can re-issue the read.
+    let timedOut = false;
+    let watchdog: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<null>(resolve => {
+      watchdog = setTimeout(() => {
+        timedOut = true;
+        client.disconnect(false);
+        resolve(null);
+      }, blockTimeout + 1000);
     });
+
+    try {
+      return (await Promise.race([xread, timeout])) as StreamReadRaw;
+    } finally {
+      clearTimeout(watchdog);
+      // The watchdog disconnected the connection without letting IORedis
+      // auto-resend the abandoned command. Re-establish it here so the next
+      // read starts from a healthy, unblocked connection.
+      if (timedOut && !this.closing) {
+        try {
+          await this.connection.reconnect();
+        } catch {
+          // Ignored: the next readEvents call will retry the reconnect.
+        }
+      }
+    }
   }
 }
 

--- a/src/classes/redis-queue-backend.ts
+++ b/src/classes/redis-queue-backend.ts
@@ -2814,8 +2814,8 @@ export class RedisQueueBackend extends EventEmitter implements IQueueBackend {
       BLOCK: blockTimeout,
     }) as Promise<StreamReadRaw>;
 
-    // A non-positive BLOCK means "block forever"; there is no bounded deadline
-    // to guard, so fall back to the plain blocking read.
+    // Redis XREAD `BLOCK 0` means "block forever". If `blockTimeout` is <= 0 we
+    // cannot enforce a bounded deadline, so fall back to the plain blocking read.
     if (blockTimeout <= 0) {
       return xread;
     }

--- a/tests/events.redis.test.ts
+++ b/tests/events.redis.test.ts
@@ -27,6 +27,7 @@ import {
   QueueEvents,
   QueueEventsListener,
   QueueEventsProducer,
+  RedisQueueBackend,
   Worker,
 } from '../src/classes';
 import { delay, randomUUID, removeAllQueueData } from '../src/utils';
@@ -64,6 +65,54 @@ describe('events (redis-only)', () => {
 
   afterAll(async function () {
     await connection.quit();
+  });
+
+  describe('when the blocking XREAD never settles (#4479)', () => {
+    it('recovers via the readEvents watchdog', async () => {
+      // Reproduce the #4479 wedge for the event-stream consumer: under
+      // `maxRetriesPerRequest: null` IORedis silently re-queues and re-sends an
+      // interrupted blocking `XREAD` after a reconnect instead of rejecting it,
+      // so the awaited read never settles. The watchdog must conclude the read
+      // as a timeout, abandon the stuck command (disconnect) and re-establish
+      // the connection. We drive `readEvents` against a fake client/connection
+      // so the never-settling read is deterministic and Redis-independent.
+      let disconnectedWithReconnect: boolean | undefined;
+      let reconnectCalls = 0;
+
+      const fakeClient = {
+        xread: () => new Promise(() => {}), // never settles
+        disconnect: (reconnect: boolean) => {
+          disconnectedWithReconnect = reconnect;
+        },
+      };
+
+      const fakeBackend = {
+        closing: false,
+        connection: {
+          reconnect: async () => {
+            reconnectCalls++;
+          },
+        },
+        queue: {
+          client: Promise.resolve(fakeClient),
+          keys: { events: `${prefix}:${queueName}:events` },
+        },
+      };
+
+      // A tiny BLOCK keeps the watchdog window small (~1s).
+      const result = await (
+        RedisQueueBackend.prototype.readEvents as (
+          this: unknown,
+          id: string,
+          blockTimeout: number,
+        ) => Promise<unknown>
+      ).call(fakeBackend, '$', 50);
+
+      expect(result).toBe(null);
+      // Abandoned without auto-resend so the stuck command is discarded.
+      expect(disconnectedWithReconnect).toBe(false);
+      expect(reconnectCalls).toBe(1);
+    });
   });
 
   describe('when jobs removal is attempted on non-existed records', async () => {

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1152,6 +1152,42 @@ describe('workers', () => {
         await worker.close();
       }
     });
+
+    it('recovers when the blocking command never settles (#4479)', async () => {
+      const worker = new Worker(queueName, NoopProc, {
+        autorun: false,
+        connection,
+        prefix,
+      });
+      await worker.waitUntilReady();
+
+      const backend = worker.getBackend();
+      const bclient = (await backend.blockingClient)!;
+
+      // Reproduce the #4479 wedge: blocking connections must use
+      // `maxRetriesPerRequest: null`, and with that setting IORedis silently
+      // re-queues and re-sends an interrupted blocking command after a
+      // reconnect instead of rejecting it — so the awaited `bzpopmin` never
+      // settles. Before the watchdog fix this parked `waitForJob` forever.
+      const bzpopmin = sandbox
+        .stub(bclient, 'bzpopmin')
+        .returns(new Promise(() => {}) as any);
+      const reconnectBlocking = sandbox
+        .stub(backend, 'reconnectBlocking')
+        .resolves();
+
+      try {
+        // A tiny block timeout keeps the watchdog window small. The watchdog
+        // must conclude the wait as a timeout (null) even though `bzpopmin`
+        // never settles, and re-establish the blocking connection.
+        const result = await backend.waitForJob(0.001);
+        expect(result).toBe(null);
+        expect(bzpopmin.calledOnce).toBe(true);
+        expect(reconnectBlocking.calledOnce).toBe(true);
+      } finally {
+        await worker.close();
+      }
+    });
   });
 
   describe('when calling getBlockTimeout', () => {


### PR DESCRIPTION
Both ioredis blocking primitives could hang forever after a transient
connection reset, silently wedging the worker/event consumer without any
error until a process restart.

Blocking connections must use [maxRetriesPerRequest: null](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), and with that
setting IORedis (via autoResendUnfulfilledCommands) silently re-queues and
re-sends an interrupted in-flight blocking command on reconnect instead of
rejecting it. The awaited BZPOPMIN ([waitForJob](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) / XREAD ([readEvents](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
therefore never settles. The previous one-shot watchdog assumed [disconnect()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
would reject the pending command, so it fired once and then the loop parked
indefinitely: [waitForJob](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) never returned, [moveToActive](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) was never called,
due-delayed jobs were never promoted and no marker was ever written (only an
external [queue.add](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) or a restart recovered it). This is the standalone/
single-primary counterpart to the Sentinel case fixed in #4378.

Make both blocking reads race the command against a watchdog timeout so the
wait always concludes at the deadline regardless of whether IORedis ever
settles the command. On the watchdog firing, disconnect the connection to
abandon the stuck command (no auto-resend), resolve the wait as a timeout so
the loop advances (promoting due-delayed jobs / writing markers), and
re-establish the blocking connection.

Only the Node ioredis backend is affected: the PostgreSQL backend bounds its
wait with a local timer, and the Python (redis-py), Elixir (Redix), Rust
(redis-rs) and .NET (StackExchange.Redis) runtimes fault the pending command
on disconnect rather than re-sending it. PHP has no blocking worker.

Add regression test for [waitForJob](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) ([worker.test.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
Add regression test for [readEvents](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) ([events.redis.test.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))