### PR TITLE
ci(renovate): separate dev dependency prs

### DIFF
--- a/docs/gitbook/changelog.md
+++ b/docs/gitbook/changelog.md
@@ -17,7 +17,7 @@
 
 ### Bug Fixes
 
-* **deps:** update python dependencies (python) ([#4453](https://github.com/taskforcesh/bullmq/issues/4453)) ([e58f9e1](https://github.com/taskforcesh/bullmq/commit/e58f9e1892463da4ca411506d66ee01413e5daeb))
+* No Node.js changes.
 
 ## [6.0.4](https://github.com/taskforcesh/bullmq/compare/v6.0.3...v6.0.4) (2026-08-01)
 

--- a/docs/gitbook/elixir/changelog.md
+++ b/docs/gitbook/elixir/changelog.md
@@ -3,8 +3,6 @@
 
 ### Bug Fixes
 
-* **deps:** update python dependencies (python) ([#4453](https://github.com/taskforcesh/bullmq/issues/4453)) ([e58f9e1](https://github.com/taskforcesh/bullmq/commit/e58f9e1892463da4ca411506d66ee01413e5daeb))
-* **deps:** update security patches [security] ([#4444](https://github.com/taskforcesh/bullmq/issues/4444)) ([c1cf328](https://github.com/taskforcesh/bullmq/commit/c1cf32881474f3f1e9b620e025abde07a359eb06))
 * **worker:** fail jobs with deferred failure in task-based worker path [elixir] ([#4458](https://github.com/taskforcesh/bullmq/issues/4458)) ([740985a](https://github.com/taskforcesh/bullmq/commit/740985ae2f67a9144e7787f89955bf8c7f9500e0))
 
 ## [2.0.2](https://github.com/taskforcesh/bullmq/compare/vex2.0.1...vex2.0.2) (2026-07-31)
@@ -12,7 +10,6 @@
 
 ### Bug Fixes
 
-* **deps:** update dependency redis to v7.4.1 ([#4426](https://github.com/taskforcesh/bullmq/issues/4426)) ([2ac754f](https://github.com/taskforcesh/bullmq/commit/2ac754fd718927e2c0043d6d7787de32d0d196f7))
 * **postgres:** drop redundant bullmq_ prefix from schema objects ([#4436](https://github.com/taskforcesh/bullmq/issues/4436)) (elixir) (python) (node) ([067a73f](https://github.com/taskforcesh/bullmq/commit/067a73f3666a493c36c03ec2cca8228ae149f043))
 
 ## [2.0.1](https://github.com/taskforcesh/bullmq/compare/vex2.0.0...vex2.0.1) (2026-07-31)

--- a/docs/gitbook/python/changelog.md
+++ b/docs/gitbook/python/changelog.md
@@ -3,8 +3,7 @@
 
 ### Bug Fixes
 
-* **deps:** update python dependencies (python) ([#4453](https://github.com/taskforcesh/bullmq/issues/4453)) ([e58f9e1](https://github.com/taskforcesh/bullmq/commit/e58f9e1892463da4ca411506d66ee01413e5daeb))
-* **deps:** update security patches [security] ([#4444](https://github.com/taskforcesh/bullmq/issues/4444)) ([c1cf328](https://github.com/taskforcesh/bullmq/commit/c1cf32881474f3f1e9b620e025abde07a359eb06))
+* **deps:** update python dependencies [python] ([#4453](https://github.com/taskforcesh/bullmq/issues/4453)) ([e58f9e1](https://github.com/taskforcesh/bullmq/commit/e58f9e1892463da4ca411506d66ee01413e5daeb))
 
 ## [3.0.2](https://github.com/taskforcesh/bullmq/compare/vpy3.0.1...vpy3.0.2) (2026-07-31)
 

--- a/dotnet/package.json
+++ b/dotnet/package.json
@@ -36,7 +36,7 @@
         {
           "preset": "angular",
           "presetConfig": {
-            "ignoreCommits": "^(?![^]*\\(dotnet\\))(?![^]*\\[dotnet\\]).*$"
+            "ignoreCommits": "^(?!.*\\(dotnet\\))(?!.*\\[dotnet\\]).*$"
           }
         }
       ],

--- a/elixir/package.json
+++ b/elixir/package.json
@@ -46,7 +46,7 @@
         {
           "preset": "angular",
           "presetConfig": {
-            "ignoreCommits": "^(?![^]*\\(elixir\\))(?![^]*\\[elixir\\]).*$"
+            "ignoreCommits": "^(?!.*\\(elixir\\))(?!.*\\[elixir\\]).*$"
           }
         }
       ],

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
               "release": false
             },
             {
-              "header": "**/*\\(dotnet\\)*",
+              "header": "**/*\\[dotnet\\]*",
               "release": false
             }
           ]
@@ -210,7 +210,7 @@
         {
           "preset": "angular",
           "presetConfig": {
-            "ignoreCommits": "(\\[python\\]|\\[elixir\\]|\\[php\\]|\\[rust\\]|\\[dotnet\\]|\\(dotnet\\))"
+            "ignoreCommits": "(\\[python\\]|\\[elixir\\]|\\[php\\]|\\[rust\\]|\\[dotnet\\])"
           }
         }
       ],

--- a/php/package.json
+++ b/php/package.json
@@ -46,7 +46,7 @@
         {
           "preset": "angular",
           "presetConfig": {
-            "ignoreCommits": "^(?![^]*\\(php\\))(?![^]*\\[php\\]).*$"
+            "ignoreCommits": "^(?!.*\\(php\\))(?!.*\\[php\\]).*$"
           }
         }
       ],

--- a/python/package.json
+++ b/python/package.json
@@ -50,7 +50,7 @@
         {
           "preset": "angular",
           "presetConfig": {
-            "ignoreCommits": "^(?![^]*\\(python\\))(?![^]*\\[python\\]).*$"
+            "ignoreCommits": "^(?!.*\\(python\\))(?!.*\\[python\\]).*$"
           }
         }
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -19,10 +19,23 @@
       "schedule": ["before 9am"]
     },
     {
+      "description": "Use chore commit type for all dev dependency updates",
+      "matchDepTypes": ["devDependencies", "require-dev", "dev-dependencies"],
+      "semanticCommitType": "chore"
+    },
+    {
       "description": "Group every non-major Node.js/npm update (minor + patch) into a single PR",
       "matchCategories": ["js", "node"],
       "groupName": "Node.js dependencies",
       "groupSlug": "nodejs"
+    },
+    {
+      "description": "Group every non-major Node.js/npm dev dependency update into a single PR",
+      "matchCategories": ["js", "node"],
+      "matchDepTypes": ["devDependencies"],
+      "groupName": "Node.js dev dependencies",
+      "groupSlug": "nodejs-dev",
+      "semanticCommitType": "chore"
     },
     {
       "description": "Group every PHP (composer) update into a single PR",
@@ -32,11 +45,29 @@
       "commitMessageSuffix": "[php]"
     },
     {
+      "description": "Group every PHP (composer) dev dependency update into a single PR",
+      "matchCategories": ["php"],
+      "matchDepTypes": ["require-dev"],
+      "groupName": "PHP dev dependencies",
+      "groupSlug": "php-dev",
+      "commitMessageSuffix": "[php]",
+      "semanticCommitType": "chore"
+    },
+    {
       "description": "Group every Python update into a single PR",
       "matchCategories": ["python"],
       "groupName": "Python dependencies",
       "groupSlug": "python",
       "commitMessageSuffix": "[python]"
+    },
+    {
+      "description": "Group every Python dev dependency update into a single PR",
+      "matchCategories": ["python"],
+      "matchDepTypes": ["dev-dependencies"],
+      "groupName": "Python dev dependencies",
+      "groupSlug": "python-dev",
+      "commitMessageSuffix": "[python]",
+      "semanticCommitType": "chore"
     },
     {
       "description": "Group every Elixir (mix) update into a single PR",
@@ -51,6 +82,15 @@
       "groupName": "Rust dependencies",
       "groupSlug": "rust",
       "commitMessageSuffix": "[rust]"
+    },
+    {
+      "description": "Group every Rust (cargo) dev dependency update into a single PR",
+      "matchCategories": ["rust"],
+      "matchDepTypes": ["dev-dependencies"],
+      "groupName": "Rust dev dependencies",
+      "groupSlug": "rust-dev",
+      "commitMessageSuffix": "[rust]",
+      "semanticCommitType": "chore"
     },
     {
       "description": "Group every .NET (NuGet) update into a single PR",
@@ -79,6 +119,15 @@
       "groupSlug": "nodejs-major"
     },
     {
+      "description": "Separate Node.js major dev dependency updates into their own PR",
+      "matchCategories": ["js", "node"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "Node.js dev dependencies (major)",
+      "groupSlug": "nodejs-dev-major",
+      "semanticCommitType": "chore"
+    },
+    {
       "description": "Separate PHP major updates into their own PR",
       "matchCategories": ["php"],
       "matchUpdateTypes": ["major"],
@@ -87,12 +136,32 @@
       "commitMessageSuffix": "[php]"
     },
     {
+      "description": "Separate PHP major dev dependency updates into their own PR",
+      "matchCategories": ["php"],
+      "matchDepTypes": ["require-dev"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "PHP dev dependencies (major)",
+      "groupSlug": "php-dev-major",
+      "commitMessageSuffix": "[php]",
+      "semanticCommitType": "chore"
+    },
+    {
       "description": "Separate Python major updates into their own PR",
       "matchCategories": ["python"],
       "matchUpdateTypes": ["major"],
       "groupName": "Python dependencies (major)",
       "groupSlug": "python-major",
       "commitMessageSuffix": "[python]"
+    },
+    {
+      "description": "Separate Python major dev dependency updates into their own PR",
+      "matchCategories": ["python"],
+      "matchDepTypes": ["dev-dependencies"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "Python dev dependencies (major)",
+      "groupSlug": "python-dev-major",
+      "commitMessageSuffix": "[python]",
+      "semanticCommitType": "chore"
     },
     {
       "description": "Separate Elixir major updates into their own PR",
@@ -109,6 +178,16 @@
       "groupName": "Rust dependencies (major)",
       "groupSlug": "rust-major",
       "commitMessageSuffix": "[rust]"
+    },
+    {
+      "description": "Separate Rust major dev dependency updates into their own PR",
+      "matchCategories": ["rust"],
+      "matchDepTypes": ["dev-dependencies"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "Rust dev dependencies (major)",
+      "groupSlug": "rust-dev-major",
+      "commitMessageSuffix": "[rust]",
+      "semanticCommitType": "chore"
     },
     {
       "description": "Separate .NET major updates into their own PR",

--- a/rust/package.json
+++ b/rust/package.json
@@ -35,7 +35,7 @@
         {
           "preset": "angular",
           "presetConfig": {
-            "ignoreCommits": "^(?![^]*\\(rust\\))(?![^]*\\[rust\\]).*$"
+            "ignoreCommits": "^(?!.*\\(rust\\))(?!.*\\[rust\\]).*$"
           }
         }
       ],


### PR DESCRIPTION
<!--
  Thank you for submitting a PR!
  Please fill out all sections below to help us understand your changes.

  PR TITLE FORMAT
  ───────────────
  We use Conventional Commits: <type>(<scope>): <description>

  If your change affects one or more ports, append a tag at the end of the
  PR title (outside the conventional-commit part) to indicate their status:

    [python] / [elixir] / [php] / [rust] / [dotnet]
      → The change is ONLY relevant to that port (Node.js is NOT affected).
        Multiple ports can be listed: [python][elixir]

    (python) / (elixir) / (php) / (rust) / (dotnet)
      → The change affects that port AND Node.js.
        Multiple ports can be listed: (python)(php)

  Examples:
    fix(worker): handle stalled jobs correctly (python)(elixir)
    docs: update rate-limiting guide [python]
    feat(queue): add group priority support

  Please review all listed ports below before setting your title.
-->

### Port Impact Checklist

<!--
  Review each port and tick every box that applies.
  If a port is not affected at all, leave its box unchecked.
-->

- [x] **Python** – does this change need to be ported or documented in the Python library?
- [x] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [x] **PHP** – does this change need to be ported or documented in the PHP library?
- [x] **Rust** – does this change need to be ported or documented in the Rust library?
- [x] **.NET** – does this change need to be ported or documented in the .NET library?

### Why

<!--
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->

  1. Why is this change necessary? Commits not including port names were added in changelog. Replace [^]* with .* in the pattern. The [^] (empty negated character class matching any character including newlines) is a JavaScript-specific extension that breaks in some regex engines used by conventional-changelog. Since commit subjects are single-line, .* is correct and portable. Additionally this pr separates dev dependency upgrades by renovate in their own prs that should not trigger new releases

### How

<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->

_Enter the implementation details here._

### Additional Notes (Optional)

<!--
  Use this space for additional considerations:
  - Potential side effects
  - Dependencies
  - Testing instructions
  - Anything else reviewers should know
-->

_Any extra info here._
