### PR TITLE
fix(worker): resolve worker delay in picking up new jobs (rust)(#4512)

### DIFF
--- a/rust/src/redis_connection.rs
+++ b/rust/src/redis_connection.rs
@@ -1,5 +1,5 @@
 use redis::aio::MultiplexedConnection;
-use redis::{Client, ClientTlsConfig, TlsCertificates};
+use redis::{AsyncConnectionConfig, Client, ClientTlsConfig, TlsCertificates};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::debug;
@@ -138,8 +138,27 @@ struct BlockingInner {
 
 impl BlockingRedisConnection {
     /// Create a new blocking connection from a client.
+    ///
+    /// The connection is created with its response timeout **disabled**.
+    /// redis-rs applies a 500ms default response timeout to every multiplexed
+    /// connection. This connection is dedicated to blocking reads (`BZPOPMIN`
+    /// on the marker key) that must wait up to `drain_delay` seconds for a job
+    /// to appear. With the default timeout, the client abandons the in-flight
+    /// `BZPOPMIN` after 500ms — long before a marker is written for an idle
+    /// worker. When the marker eventually arrives, the server-side `BZPOPMIN`
+    /// pops it and replies, but the client has already discarded that request
+    /// slot, so the marker is silently consumed without waking the worker. The
+    /// worker then only picks up the job on its periodic empty-queue re-poll,
+    /// yielding 0–`drain_delay`s pickup latency (see issue #4512). Disabling
+    /// the response timeout lets the command block for its full duration so the
+    /// reply is always delivered to a live waiter. This mirrors the TypeScript
+    /// worker, whose stuck-connection watchdog fires at `blockTimeout + 1s`,
+    /// deliberately longer than the block rather than shorter.
     pub async fn new(client: &Client) -> Result<Self, Error> {
-        let conn = client.get_multiplexed_async_connection().await?;
+        let config = AsyncConnectionConfig::new().set_response_timeout(None);
+        let conn = client
+            .get_multiplexed_async_connection_with_config(&config)
+            .await?;
         Ok(Self {
             inner: Arc::new(BlockingInner {
                 conn: Mutex::new(conn),

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use tokio::sync::{broadcast, mpsc, Mutex, Notify, RwLock};
-use tokio::task::{JoinHandle, JoinSet};
+use tokio::task::JoinHandle;
 use tracing::{debug, error, warn};
 use uuid::Uuid;
 
@@ -764,7 +764,10 @@ impl Worker {
                 break;
             }
             if tokio::time::Instant::now() >= deadline {
-                warn!("close timeout reached with active work remaining");
+                warn!(
+                    active_job_count,
+                    active_fetchers, "close timeout reached with active work remaining"
+                );
                 break;
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
@@ -885,16 +888,9 @@ impl Worker {
     /// the concurrency gate, giving parallel processing without waking many idle
     /// fetchers per job. This mirrors the Node.js single-driver `mainLoop`.
     async fn run_main_driver(ctx: Arc<LoopContext>, blocking_conn: BlockingRedisConnection) {
-        let mut processing_tasks = JoinSet::new();
         loop {
-            while let Some(_finished) = processing_tasks.try_join_next() {}
-
             if ctx.closing.load(Ordering::Relaxed) {
-                if processing_tasks.is_empty() {
-                    break;
-                }
-                let _ = processing_tasks.join_next().await;
-                continue;
+                break;
             }
 
             if ctx.paused.load(Ordering::Relaxed) {
@@ -943,7 +939,7 @@ impl Worker {
                     // immediately to fetch the next job, so fetching stays
                     // single-threaded while processing runs in parallel.
                     let task_ctx = ctx.clone();
-                    processing_tasks.spawn(async move {
+                    tokio::spawn(async move {
                         let _slot = slot_guard;
                         let mut next = Some(*job);
                         while let Some(current) = next.take() {

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use tokio::sync::{broadcast, mpsc, Mutex, Notify, RwLock};
-use tokio::task::JoinHandle;
+use tokio::task::{JoinHandle, JoinSet};
 use tracing::{debug, error, warn};
 use uuid::Uuid;
 
@@ -873,9 +873,16 @@ impl Worker {
     /// the concurrency gate, giving parallel processing without waking many idle
     /// fetchers per job. This mirrors the Node.js single-driver `mainLoop`.
     async fn run_main_driver(ctx: Arc<LoopContext>, blocking_conn: BlockingRedisConnection) {
+        let mut processing_tasks = JoinSet::new();
         loop {
+            while let Some(_finished) = processing_tasks.try_join_next() {}
+
             if ctx.closing.load(Ordering::Relaxed) {
-                break;
+                if processing_tasks.is_empty() {
+                    break;
+                }
+                let _ = processing_tasks.join_next().await;
+                continue;
             }
 
             if ctx.paused.load(Ordering::Relaxed) {
@@ -924,7 +931,7 @@ impl Worker {
                     // immediately to fetch the next job, so fetching stays
                     // single-threaded while processing runs in parallel.
                     let task_ctx = ctx.clone();
-                    tokio::spawn(async move {
+                    processing_tasks.spawn(async move {
                         let _slot = slot_guard;
                         let mut next = Some(*job);
                         while let Some(current) = next.take() {
@@ -957,7 +964,12 @@ impl Worker {
                     let _ = ctx.event_tx.send(WorkerEvent::Drained);
                     // The queue is empty: park on the single blocking BZPOPMIN
                     // until a job's marker arrives or drain_delay elapses.
-                    Self::wait_for_marker(&blocking_conn, &ctx, ctx.opts.drain_delay * 1000).await;
+                    Self::wait_for_marker(
+                        &blocking_conn,
+                        &ctx,
+                        ctx.opts.drain_delay.saturating_mul(1000),
+                    )
+                    .await;
                 }
                 Err(e) => {
                     drop(slot_guard);

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -770,10 +770,22 @@ impl Worker {
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
 
-        // Cancel background tasks
+        // Let the main loop finish gracefully so any in-flight processing tasks
+        // owned by its JoinSet can complete. Abort only if we run out of time.
         if let Some(handle) = self.main_loop_handle.lock().await.take() {
-            handle.abort();
+            let mut handle = handle;
+            let now = tokio::time::Instant::now();
+            if now < deadline {
+                let remaining = deadline - now;
+                if tokio::time::timeout(remaining, &mut handle).await.is_err() {
+                    warn!("close timeout reached while waiting for main loop to stop");
+                    handle.abort();
+                }
+            } else {
+                handle.abort();
+            }
         }
+        // Cancel remaining background tasks.
         if let Some(handle) = self.stalled_check_handle.lock().await.take() {
             handle.abort();
         }

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -773,15 +773,14 @@ impl Worker {
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
 
-        // Let the main loop finish gracefully so any in-flight processing tasks
-        // owned by its JoinSet can complete. Abort only if we run out of time.
-        if let Some(handle) = self.main_loop_handle.lock().await.take() {
-            let mut handle = handle;
+        // Let the main loop finish naturally so any in-flight processing tasks
+        // tracked by its JoinSet can complete and persist final job state.
+        if let Some(mut handle) = self.main_loop_handle.lock().await.take() {
             let now = tokio::time::Instant::now();
             if now < deadline {
                 let remaining = deadline - now;
                 if tokio::time::timeout(remaining, &mut handle).await.is_err() {
-                    warn!("close timeout reached while waiting for main loop to stop");
+                    warn!("close timeout reached while waiting for main loop");
                     handle.abort();
                 }
             } else {
@@ -902,7 +901,9 @@ impl Worker {
             // fetching, so we never fetch a job we cannot immediately process.
             // Blocks on the concurrency gate while all slots are busy.
             if !Self::acquire_concurrency_slot(&ctx).await {
-                break; // closing
+                // Closing was requested while we were waiting for a slot.
+                // Loop back so the closing branch can drain in-flight tasks.
+                continue;
             }
             let slot_guard = ConcurrencySlotGuard::new(ctx.clone());
 

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -850,44 +850,29 @@ impl Worker {
         ));
 
         let blocking_conn = self.blocking_conn.clone();
-        let concurrency = self.opts.concurrency;
-        let job_available = Arc::new(Notify::new());
 
-        let handle = tokio::spawn(async move {
-            let mut worker_handles = Vec::with_capacity(concurrency + 1);
-
-            // Spawn N worker loops — each independently fetches and processes
-            for _ in 0..concurrency {
-                let ctx = ctx.clone();
-                let job_available = job_available.clone();
-                worker_handles.push(tokio::spawn(Self::run_worker_loop(ctx, job_available)));
-            }
-
-            // Blocking watcher: waits on BZPOPMIN and wakes idle workers
-            {
-                let closing = ctx.closing.clone();
-                let drain_delay = ctx.opts.drain_delay;
-                let marker_key = ctx.keys.marker();
-                let job_available = job_available.clone();
-                worker_handles.push(tokio::spawn(Self::run_blocking_watcher(
-                    closing,
-                    blocking_conn,
-                    marker_key,
-                    drain_delay,
-                    job_available,
-                )));
-            }
-
-            for h in worker_handles {
-                let _ = h.await;
-            }
-        });
+        // A single fetch-driver owns all blocking reads and job dispatch,
+        // mirroring the Node.js `mainLoop`. It fetches at most one job at a time
+        // (issuing at most one blocking `BZPOPMIN` when the queue is empty) and
+        // dispatches each fetched job to its own processing task, so up to
+        // `concurrency` jobs run in parallel — without a job arrival waking many
+        // idle fetch loops at once (the "thundering herd" the previous N-loop +
+        // notify_waiters design reintroduced, which Node deliberately avoids).
+        let handle = tokio::spawn(Self::run_main_driver(ctx, blocking_conn));
 
         *self.main_loop_handle.lock().await = Some(handle);
     }
 
-    /// A single worker's fetch-process loop. Runs until `closing` is set.
-    async fn run_worker_loop(ctx: Arc<LoopContext>, job_available: Arc<Notify>) {
+    /// The single fetch-and-dispatch driver. Runs until `closing` is set.
+    ///
+    /// Fetches at most one job at a time. When the queue is empty (or waiting on
+    /// a delayed job / rate limit) it issues a single blocking `BZPOPMIN` on the
+    /// marker key and parks until a marker arrives or the timeout elapses — so
+    /// exactly one blocking command is ever in flight regardless of
+    /// `concurrency`. Each fetched job is dispatched to its own task, bounded by
+    /// the concurrency gate, giving parallel processing without waking many idle
+    /// fetchers per job. This mirrors the Node.js single-driver `mainLoop`.
+    async fn run_main_driver(ctx: Arc<LoopContext>, blocking_conn: BlockingRedisConnection) {
         loop {
             if ctx.closing.load(Ordering::Relaxed) {
                 break;
@@ -898,15 +883,30 @@ impl Worker {
                 continue;
             }
 
-            // Wait for a concurrency slot
+            // Bound in-flight processing to the concurrency limit *before*
+            // fetching, so we never fetch a job we cannot immediately process.
+            // Blocks on the concurrency gate while all slots are busy.
             if !Self::acquire_concurrency_slot(&ctx).await {
                 break; // closing
             }
             let slot_guard = ConcurrencySlotGuard::new(ctx.clone());
 
+            // `acquire_concurrency_slot` can block while all slots are busy, so
+            // re-check state after it returns: the worker may have been closed or
+            // paused (and new jobs enqueued) while we waited. Without this we
+            // could fetch a job right after being paused.
+            if ctx.closing.load(Ordering::Relaxed) {
+                break;
+            }
+            if ctx.paused.load(Ordering::Relaxed) {
+                drop(slot_guard);
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                continue;
+            }
+
             let token = ctx.next_token();
 
-            // Try to fetch a job (non-blocking — script only)
+            // Non-blocking fetch (moveToActive script only).
             let fetch_result = Self::try_fetch_job_fast(
                 &ctx.conn,
                 &ctx.move_to_active_keys,
@@ -918,61 +918,75 @@ impl Worker {
 
             match fetch_result {
                 Ok(FetchResult::Job(job)) => {
-                    // Process the fetched job. When the finishing script fetches
-                    // the next job in the same round-trip, keep processing that
-                    // job directly (reusing the same token, as Node.js does)
-                    // until the chain runs dry — avoiding a `moveToActive` call
-                    // per job.
-                    let mut next = Some(*job);
-                    while let Some(current) = next.take() {
-                        next = Self::process_fetched_job(&ctx, current, &token).await;
-                    }
+                    // Dispatch processing to its own task, moving the concurrency
+                    // slot into it (released only when the task — including any
+                    // finish-script chained jobs — completes). The driver loops
+                    // immediately to fetch the next job, so fetching stays
+                    // single-threaded while processing runs in parallel.
+                    let task_ctx = ctx.clone();
+                    tokio::spawn(async move {
+                        let _slot = slot_guard;
+                        let mut next = Some(*job);
+                        while let Some(current) = next.take() {
+                            next = Self::process_fetched_job(&task_ctx, current, &token).await;
+                        }
+                    });
                 }
                 Ok(FetchResult::NextTimestamp(next_ts)) => {
                     drop(slot_guard);
-                    // No job ready, but there's a delayed job coming
+                    // No job ready, but there's a delayed job coming. Block on the
+                    // marker until it is promoted or the delay elapses.
                     let now = SystemTime::now()
                         .duration_since(UNIX_EPOCH)
                         .unwrap()
                         .as_millis() as u64;
                     if next_ts > now {
-                        // Cap the sleep to periodically re-check `closing`.
+                        // Cap the wait to periodically re-check `closing`.
                         let delay_ms = (next_ts - now).min(5_000);
-                        // Wait for either the delay or a notification
-                        tokio::select! {
-                            _ = tokio::time::sleep(Duration::from_millis(delay_ms)) => {}
-                            _ = job_available.notified() => {}
-                        }
+                        Self::wait_for_marker(&blocking_conn, &ctx, delay_ms).await;
                     }
-                    continue;
                 }
                 Ok(FetchResult::RateLimited(ttl_ms)) => {
                     drop(slot_guard);
-                    // Rate limited — wait for the TTL to expire (capped by maximumRateLimitDelay)
-                    let delay = ttl_ms.min(ctx.opts.maximum_rate_limit_delay);
-                    tokio::select! {
-                        _ = tokio::time::sleep(Duration::from_millis(delay)) => {}
-                        _ = job_available.notified() => {}
-                    }
-                    continue;
+                    // Rate limited — wait for the TTL (capped by maximumRateLimitDelay).
+                    let delay_ms = ttl_ms.min(ctx.opts.maximum_rate_limit_delay);
+                    Self::wait_for_marker(&blocking_conn, &ctx, delay_ms).await;
                 }
                 Ok(FetchResult::Empty) => {
                     drop(slot_guard);
                     let _ = ctx.event_tx.send(WorkerEvent::Drained);
-                    // Use select to allow periodic re-check of `closing` flag
-                    tokio::select! {
-                        _ = job_available.notified() => {}
-                        _ = tokio::time::sleep(Duration::from_millis(5_000)) => {}
-                    }
-                    continue;
+                    // The queue is empty: park on the single blocking BZPOPMIN
+                    // until a job's marker arrives or drain_delay elapses.
+                    Self::wait_for_marker(&blocking_conn, &ctx, ctx.opts.drain_delay * 1000).await;
                 }
                 Err(e) => {
                     drop(slot_guard);
                     let _ = ctx.event_tx.send(WorkerEvent::Error(e.to_string()));
                     tokio::time::sleep(Duration::from_millis(ctx.opts.run_retry_delay)).await;
-                    continue;
                 }
             };
+        }
+    }
+
+    /// Block on the marker key until a job/marker arrives or `timeout_ms`
+    /// elapses. This is the worker's only blocking Redis command; it replaces
+    /// the previous shared watcher + `Notify` fan-out. The response timeout is
+    /// disabled on the blocking connection (see [`BlockingRedisConnection::new`])
+    /// so the command is allowed to block for its full duration.
+    async fn wait_for_marker(
+        blocking_conn: &BlockingRedisConnection,
+        ctx: &LoopContext,
+        timeout_ms: u64,
+    ) {
+        // BZPOPMIN takes a timeout in (fractional) seconds. Guard against a zero
+        // timeout, which Redis interprets as "block forever".
+        let timeout_secs = (timeout_ms.max(1) as f64) / 1000.0;
+        if let Err(_e) = blocking_conn.bzpopmin(&ctx.marker_key, timeout_secs).await {
+            // Transient error (e.g. connection reset): back off briefly before
+            // the driver loops and retries, unless we are shutting down.
+            if !ctx.closing.load(Ordering::Relaxed) {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
         }
     }
 
@@ -1749,39 +1763,6 @@ impl Worker {
         match result {
             redis::Value::Int(code) if code < 0 => Err(Error::from_script_code(code)),
             _ => Ok(()),
-        }
-    }
-
-    /// Blocking watcher loop — uses BZPOPMIN to detect new/delayed jobs.
-    async fn run_blocking_watcher(
-        closing: Arc<AtomicBool>,
-        blocking_conn: BlockingRedisConnection,
-        marker_key: String,
-        drain_delay: u64,
-        job_available: Arc<Notify>,
-    ) {
-        loop {
-            if closing.load(Ordering::Relaxed) {
-                break;
-            }
-
-            match blocking_conn
-                .bzpopmin(&marker_key, drain_delay as f64)
-                .await
-            {
-                Ok(Some(_)) => {
-                    job_available.notify_waiters();
-                }
-                Ok(None) => {
-                    job_available.notify_waiters();
-                }
-                Err(_) => {
-                    if closing.load(Ordering::Relaxed) {
-                        break;
-                    }
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                }
-            }
         }
     }
 

--- a/rust/tests/worker_test.rs
+++ b/rust/tests/worker_test.rs
@@ -63,6 +63,180 @@ async fn test_worker_processes_job() {
     cleanup_queue(&queue).await;
 }
 
+/// Regression test for https://github.com/taskforcesh/bullmq/issues/4512
+///
+/// An idle worker must wake up and process a newly added job promptly via the
+/// marker -> BZPOPMIN -> notify_waiters chain, rather than waiting for the
+/// periodic empty-queue re-poll (`drain_delay`, default 5s). Previously the
+/// blocking connection inherited redis-rs's default 500ms response timeout,
+/// which aborted every BZPOPMIN before it could observe the marker, so idle
+/// workers only picked up jobs on the 5s poll.
+#[tokio::test]
+async fn test_idle_worker_picks_up_new_job_quickly() {
+    let name = test_queue_name();
+    let conn_opts = test_connection();
+
+    let queue_opts = QueueOptions {
+        connection: conn_opts.clone(),
+        ..Default::default()
+    };
+    let queue = Queue::with_options(&name, queue_opts).await.unwrap();
+
+    let (tx, mut rx) = mpsc::channel::<String>(1);
+    let processor: ProcessorFn = Arc::new(move |job: Job, _token: CancellationToken| {
+        let tx = tx.clone();
+        Box::pin(async move {
+            tx.send(job.id().to_string()).await.unwrap();
+            Ok(serde_json::json!({"processed": true}))
+        })
+    });
+
+    let worker_opts = WorkerOptions {
+        connection: conn_opts,
+        autorun: true,
+        ..Default::default()
+    };
+
+    let worker = Worker::with_options(&name, processor, worker_opts)
+        .await
+        .unwrap();
+
+    // Let the worker go idle: its first fetch finds nothing and it parks on
+    // the blocking BZPOPMIN watcher.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let added_at = std::time::Instant::now();
+    queue
+        .add("wake-up", serde_json::json!({"hello": "world"}))
+        .await
+        .unwrap();
+
+    let processed_id = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+        .await
+        .expect("timeout waiting for job")
+        .expect("channel closed");
+    let latency = added_at.elapsed();
+
+    assert!(!processed_id.is_empty());
+    // The blocking watcher should wake the worker well before the 5s poll.
+    // A healthy wake-up is near-instant; allow generous slack for CI while
+    // still failing if pickup regresses to the poll interval.
+    assert!(
+        latency < Duration::from_secs(3),
+        "idle worker took {latency:?} to pick up a new job; expected a near-instant \
+         wake-up via BZPOPMIN, not the 5s empty-queue poll"
+    );
+
+    worker.close(5000).await.unwrap();
+    cleanup_queue(&queue).await;
+}
+
+/// Stress test for the marker -> `notify_waiters()` wake-up path.
+///
+/// `tokio::Notify::notify_waiters()` does **not** store a permit: if it fires
+/// after a worker's non-blocking fetch returns `Empty` but before that worker
+/// re-registers on `job_available.notified()`, the notification is lost. A lost
+/// wake-up would strand the job until the worker's periodic empty-queue re-poll
+/// (`drain_delay`, 5s), since the marker that triggered it has already been
+/// consumed by the watcher's `BZPOPMIN`.
+///
+/// This drives many idle -> add -> process cycles, varying the delay between the
+/// worker going idle and the job being added (nanosecond-derived jitter) so the
+/// marker sometimes lands right inside that re-park window. Every job must be
+/// picked up promptly; any single stall near `drain_delay` fails the test.
+#[tokio::test]
+async fn test_idle_worker_wakeup_is_not_lost_under_race() {
+    let name = test_queue_name();
+    let conn_opts = test_connection();
+
+    let queue_opts = QueueOptions {
+        connection: conn_opts.clone(),
+        ..Default::default()
+    };
+    let queue = Queue::with_options(&name, queue_opts).await.unwrap();
+
+    // One job processed -> one message. Buffer a few so a fast processor never
+    // blocks on send.
+    let (tx, mut rx) = mpsc::channel::<String>(8);
+    let processor: ProcessorFn = Arc::new(move |job: Job, _token: CancellationToken| {
+        let tx = tx.clone();
+        Box::pin(async move {
+            tx.send(job.id().to_string()).await.unwrap();
+            Ok(serde_json::json!({"processed": true}))
+        })
+    });
+
+    let worker_opts = WorkerOptions {
+        connection: conn_opts,
+        autorun: true,
+        concurrency: 1,
+        ..Default::default()
+    };
+
+    let worker = Worker::with_options(&name, processor, worker_opts)
+        .await
+        .unwrap();
+
+    // Let the worker reach its idle/parked state before the first add.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    const ITERATIONS: usize = 60;
+    let mut max_latency = Duration::ZERO;
+    let mut slow_count = 0usize;
+
+    for i in 0..ITERATIONS {
+        // Jitter the gap between "worker is idle" and "job added" so the marker
+        // sometimes arrives exactly as the worker transitions back to parking —
+        // the window where a `notify_waiters()` wake-up could be lost. Derive it
+        // from the wall-clock nanoseconds (0..=7ms) so timing varies per run.
+        let jitter_us = (std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos()
+            % 7_000) as u64;
+        tokio::time::sleep(Duration::from_micros(jitter_us)).await;
+
+        let added_at = std::time::Instant::now();
+        queue
+            .add("race", serde_json::json!({"i": i}))
+            .await
+            .unwrap();
+
+        // Tight timeout: a healthy wake-up is ~instant. If a notify is lost the
+        // job only surfaces on the 5s poll, which this timeout catches.
+        tokio::time::timeout(Duration::from_secs(4), rx.recv())
+            .await
+            .unwrap_or_else(|_| {
+                panic!(
+                    "iteration {i}: job was not processed within 4s — the marker \
+                 wake-up was likely lost, leaving the worker parked until the \
+                 {drain}s empty-queue poll",
+                    drain = 5
+                )
+            })
+            .expect("event channel closed");
+
+        let latency = added_at.elapsed();
+        if latency > max_latency {
+            max_latency = latency;
+        }
+        if latency > Duration::from_secs(1) {
+            slow_count += 1;
+        }
+    }
+
+    // No job should ever have waited near the 5s poll. Allow generous slack for
+    // CI scheduling, but fail if pickup regresses toward the poll interval.
+    assert!(
+        max_latency < Duration::from_secs(3),
+        "worst-case pickup latency was {max_latency:?} over {ITERATIONS} \
+         iterations ({slow_count} slower than 1s); a wake-up was likely lost",
+    );
+
+    worker.close(5000).await.unwrap();
+    cleanup_queue(&queue).await;
+}
+
 #[tokio::test]
 async fn test_worker_processes_jobs_serially() {
     let name = test_queue_name();

--- a/rust/tests/worker_test.rs
+++ b/rust/tests/worker_test.rs
@@ -66,8 +66,8 @@ async fn test_worker_processes_job() {
 /// Regression test for https://github.com/taskforcesh/bullmq/issues/4512
 ///
 /// An idle worker must wake up and process a newly added job promptly via the
-/// marker -> BZPOPMIN -> notify_waiters chain, rather than waiting for the
-/// periodic empty-queue re-poll (`drain_delay`, default 5s). Previously the
+/// marker -> BZPOPMIN path, rather than waiting for the periodic empty-queue
+/// re-poll (`drain_delay`, default 5s). Previously the
 /// blocking connection inherited redis-rs's default 500ms response timeout,
 /// which aborted every BZPOPMIN before it could observe the marker, so idle
 /// workers only picked up jobs on the 5s poll.
@@ -101,9 +101,18 @@ async fn test_idle_worker_picks_up_new_job_quickly() {
         .await
         .unwrap();
 
-    // Let the worker go idle: its first fetch finds nothing and it parks on
-    // the blocking BZPOPMIN watcher.
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    // Wait for the worker to reach idle/parked state before adding a job.
+    tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            match worker.next_event().await {
+                Some(WorkerEvent::Drained) => break,
+                Some(_) => {}
+                None => panic!("worker event channel closed"),
+            }
+        }
+    })
+    .await
+    .expect("timeout waiting for worker to become drained");
 
     let added_at = std::time::Instant::now();
     queue
@@ -131,19 +140,12 @@ async fn test_idle_worker_picks_up_new_job_quickly() {
     cleanup_queue(&queue).await;
 }
 
-/// Stress test for the marker -> `notify_waiters()` wake-up path.
-///
-/// `tokio::Notify::notify_waiters()` does **not** store a permit: if it fires
-/// after a worker's non-blocking fetch returns `Empty` but before that worker
-/// re-registers on `job_available.notified()`, the notification is lost. A lost
-/// wake-up would strand the job until the worker's periodic empty-queue re-poll
-/// (`drain_delay`, 5s), since the marker that triggered it has already been
-/// consumed by the watcher's `BZPOPMIN`.
+/// Stress test for the marker -> `BZPOPMIN` wake-up path.
 ///
 /// This drives many idle -> add -> process cycles, varying the delay between the
 /// worker going idle and the job being added (nanosecond-derived jitter) so the
-/// marker sometimes lands right inside that re-park window. Every job must be
-/// picked up promptly; any single stall near `drain_delay` fails the test.
+/// marker sometimes lands right as the worker re-parks. Every job must be picked
+/// up promptly; any single stall near `drain_delay` fails the test.
 #[tokio::test]
 async fn test_idle_worker_wakeup_is_not_lost_under_race() {
     let name = test_queue_name();
@@ -177,8 +179,18 @@ async fn test_idle_worker_wakeup_is_not_lost_under_race() {
         .await
         .unwrap();
 
-    // Let the worker reach its idle/parked state before the first add.
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    // Wait for the worker to reach its idle/parked state before the first add.
+    tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            match worker.next_event().await {
+                Some(WorkerEvent::Drained) => break,
+                Some(_) => {}
+                None => panic!("worker event channel closed"),
+            }
+        }
+    })
+    .await
+    .expect("timeout waiting for worker to become drained");
 
     const ITERATIONS: usize = 60;
     let mut max_latency = Duration::ZERO;
@@ -186,8 +198,8 @@ async fn test_idle_worker_wakeup_is_not_lost_under_race() {
 
     for i in 0..ITERATIONS {
         // Jitter the gap between "worker is idle" and "job added" so the marker
-        // sometimes arrives exactly as the worker transitions back to parking —
-        // the window where a `notify_waiters()` wake-up could be lost. Derive it
+        // sometimes arrives exactly as the worker transitions back to parking.
+        // Derive it
         // from the wall-clock nanoseconds (0..=7ms) so timing varies per run.
         let jitter_us = (std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -202,7 +214,7 @@ async fn test_idle_worker_wakeup_is_not_lost_under_race() {
             .await
             .unwrap();
 
-        // Tight timeout: a healthy wake-up is ~instant. If a notify is lost the
+        // Tight timeout: a healthy wake-up is ~instant. If wake-up regresses, the
         // job only surfaces on the 5s poll, which this timeout catches.
         tokio::time::timeout(Duration::from_secs(4), rx.recv())
             .await


### PR DESCRIPTION
The Rust worker could take up to 5 seconds to pick up a newly added job,
falling back to the periodic poll instead of waking on the marker. This
was caused by three distinct problems, all fixed here:

1. redis-rs applies a default 500ms response timeout to multiplexed
   connections, which abandoned the in-flight blocking BZPOPMIN before
   the server delivered the pop reply on marker arrival. The reply hit a
   discarded request slot and was lost, so the worker only woke on the
   5s drain poll. Fixed by disabling the response timeout on the
   dedicated blocking connection via
   AsyncConnectionConfig::set_response_timeout(None).

2. The shared watcher used tokio::Notify::notify_waiters(), which stores
   no permit: a wake firing between a fetch returning Empty and the
   worker registering .notified() was lost. This is now moot after the
   refactor below, which removes the check-then-wait gap entirely.

3. The worker spawned N fetch loops plus a shared blocking watcher that
   woke ALL loops on every marker, causing a thundering herd of wasted
   moveToActive calls (a regression vs. the Node.js implementation, which
   uses a single fetch-driver to avoid this). Replaced with a single
   run_main_driver that fetches one job at a time, dispatches each to its
   own task (moving the concurrency slot in), and issues the only
   blocking BZPOPMIN via wait_for_marker when idle. Deleted
   run_worker_loop and run_blocking_watcher.