### PR TITLE
feat: add generic ProgressType parameter to Job and Worker

### DIFF
--- a/docs/gitbook/guide/workers/README.md
+++ b/docs/gitbook/guide/workers/README.md
@@ -133,6 +133,33 @@ It is also possible to specify the data types for the Job data and return value 
 const worker = new Worker<MyData, MyReturn>(queueName, async (job: Job) => {});
 ```
 
+By default the job progress is typed as `string | boolean | number | object`. If you report progress with a specific shape, you can also specify a progress type so that `updateProgress` and the `progress` event are type-safe:
+
+```typescript
+import { Worker, RedisQueueBackend } from 'bullmq';
+
+type MyProgress = { percentage: number; message: string };
+
+const worker = new Worker<
+  MyData,
+  MyReturn,
+  string,
+  RedisQueueBackend,
+  MyProgress
+>(queueName, async job => {
+  // progress is checked against MyProgress
+  await job.updateProgress({ percentage: 42, message: 'halfway' });
+});
+
+worker.on('progress', (job, progress) => {
+  console.log(progress.percentage, progress.message);
+});
+```
+
+{% hint style="info" %}
+The progress type must be JSON-serializable, as progress is persisted in the queue's backend. Sandboxed processors always receive the default progress type, since the value crosses a process boundary.
+{% endhint %}
+
 ## Read more:
 
 - 💡 [Worker API Reference](https://docs.bullmq.io/api/classes/v6.Worker.html)

--- a/src/classes/job.ts
+++ b/src/classes/job.ts
@@ -55,7 +55,8 @@ export class Job<
   DataType = any,
   ReturnType = any,
   NameType extends string = string,
-> implements MinimalJob<DataType, ReturnType, NameType> {
+  ProgressType extends JobProgress = JobProgress,
+> implements MinimalJob<DataType, ReturnType, NameType, ProgressType> {
   /**
    * It includes the prefix, the namespace separator :, and queue name.
    * @see {@link https://www.gnu.org/software/gawk/manual/html_node/Qualified-Names.html}
@@ -66,7 +67,7 @@ export class Job<
    * The progress a job has performed so far.
    * @defaultValue 0
    */
-  progress: JobProgress = 0;
+  progress: ProgressType = 0 as ProgressType;
 
   /**
    * The value returned by the processor when processing this job.
@@ -539,7 +540,7 @@ export class Job<
    *
    * @param progress - number or object to be saved as progress.
    */
-  async updateProgress(progress: JobProgress): Promise<void> {
+  async updateProgress(progress: ProgressType): Promise<void> {
     this.progress = progress;
     await this.backend.updateProgress(this.id, progress);
     this.queue.emit('progress', this, progress);

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -55,13 +55,17 @@ export interface WorkerListener<
   DataType = any,
   ResultType = any,
   NameType extends string = string,
+  ProgressType extends JobProgress = JobProgress,
 > extends IoredisListener {
   /**
    * Listen to 'active' event.
    *
    * This event is triggered when a job enters the 'active' state.
    */
-  active: (job: Job<DataType, ResultType, NameType>, prev: string) => void;
+  active: (
+    job: Job<DataType, ResultType, NameType, ProgressType>,
+    prev: string,
+  ) => void;
 
   /**
    * Listen to 'closed' event.
@@ -83,7 +87,7 @@ export interface WorkerListener<
    * This event is triggered when a job has successfully completed.
    */
   completed: (
-    job: Job<DataType, ResultType, NameType>,
+    job: Job<DataType, ResultType, NameType, ProgressType>,
     result: ResultType,
     prev: string,
   ) => void;
@@ -112,7 +116,7 @@ export interface WorkerListener<
    * reaches the stalled limit and it is deleted by the removeOnFail option.
    */
   failed: (
-    job: Job<DataType, ResultType, NameType> | undefined,
+    job: Job<DataType, ResultType, NameType, ProgressType> | undefined,
     error: Error,
     prev: string,
   ) => void;
@@ -133,8 +137,8 @@ export interface WorkerListener<
    * world.
    */
   progress: (
-    job: Job<DataType, ResultType, NameType>,
-    progress: JobProgress,
+    job: Job<DataType, ResultType, NameType, ProgressType>,
+    progress: ProgressType,
   ) => void;
 
   /**
@@ -180,12 +184,21 @@ export interface WorkerListener<
  * As soon as the class is instantiated and a connection to Redis is established
  * it will start processing jobs.
  *
+ * @typeParam DataType - The type of the data that the job will process.
+ * @typeParam ResultType - The type of the result of the job.
+ * @typeParam NameType - The type of the name of the job.
+ * @typeParam B - The queue backend used by this worker.
+ * @typeParam ProgressType - The type of the job progress. Defaults to
+ * {@link JobProgress}. Must be JSON-serializable, as progress is persisted
+ * in the backend.
+ *
  */
 export class Worker<
   DataType = any,
   ResultType = any,
   NameType extends string = string,
   B extends IQueueBackend = RedisQueueBackend,
+  ProgressType extends JobProgress = JobProgress,
 > extends QueueBase<B> {
   declare readonly opts: WorkerOptions;
   readonly id: string;
@@ -206,7 +219,7 @@ export class Worker<
   protected _jobScheduler: JobScheduler;
 
   protected paused: boolean;
-  protected processFn: Processor<DataType, ResultType, NameType>;
+  protected processFn: Processor<DataType, ResultType, NameType, ProgressType>;
   protected running = false;
   protected mainLoopRunning: Promise<void> | null = null;
 
@@ -216,7 +229,11 @@ export class Worker<
 
   constructor(
     name: string,
-    processor?: string | URL | null | Processor<DataType, ResultType, NameType>,
+    processor?:
+      | string
+      | URL
+      | null
+      | Processor<DataType, ResultType, NameType, ProgressType>,
     opts?: WorkerOptions,
     backendFactory?: BackendFactory<B>,
   ) {
@@ -401,39 +418,69 @@ export class Worker<
     return this.backend.extendLocks(jobIds, tokens, duration);
   }
 
-  emit<U extends keyof WorkerListener<DataType, ResultType, NameType>>(
+  emit<
+    U extends keyof WorkerListener<
+      DataType,
+      ResultType,
+      NameType,
+      ProgressType
+    >,
+  >(
     event: U,
-    ...args: Parameters<WorkerListener<DataType, ResultType, NameType>[U]>
+    ...args: Parameters<
+      WorkerListener<DataType, ResultType, NameType, ProgressType>[U]
+    >
   ): boolean {
     return super.emit(event, ...args);
   }
 
-  off<U extends keyof WorkerListener<DataType, ResultType, NameType>>(
+  off<
+    U extends keyof WorkerListener<
+      DataType,
+      ResultType,
+      NameType,
+      ProgressType
+    >,
+  >(
     eventName: U,
-    listener: WorkerListener<DataType, ResultType, NameType>[U],
+    listener: WorkerListener<DataType, ResultType, NameType, ProgressType>[U],
   ): this {
     super.off(eventName, listener);
     return this;
   }
 
-  on<U extends keyof WorkerListener<DataType, ResultType, NameType>>(
+  on<
+    U extends keyof WorkerListener<
+      DataType,
+      ResultType,
+      NameType,
+      ProgressType
+    >,
+  >(
     event: U,
-    listener: WorkerListener<DataType, ResultType, NameType>[U],
+    listener: WorkerListener<DataType, ResultType, NameType, ProgressType>[U],
   ): this {
     super.on(event, listener);
     return this;
   }
 
-  once<U extends keyof WorkerListener<DataType, ResultType, NameType>>(
+  once<
+    U extends keyof WorkerListener<
+      DataType,
+      ResultType,
+      NameType,
+      ProgressType
+    >,
+  >(
     event: U,
-    listener: WorkerListener<DataType, ResultType, NameType>[U],
+    listener: WorkerListener<DataType, ResultType, NameType, ProgressType>[U],
   ): this {
     super.once(event, listener);
     return this;
   }
 
   protected callProcessJob(
-    job: Job<DataType, ResultType, NameType>,
+    job: Job<DataType, ResultType, NameType, ProgressType>,
     token: string,
     signal?: AbortSignal,
   ): Promise<ResultType> {
@@ -443,11 +490,12 @@ export class Worker<
   protected createJob(
     data: JobJson,
     jobId: string,
-  ): Job<DataType, ResultType, NameType> {
+  ): Job<DataType, ResultType, NameType, ProgressType> {
     return this.Job.fromJSON(this as MinimalQueue, data, jobId) as Job<
       DataType,
       ResultType,
-      NameType
+      NameType,
+      ProgressType
     >;
   }
 
@@ -567,7 +615,8 @@ export class Worker<
     const asyncFifoQueue = new AsyncFifoQueue<void | Job<
       DataType,
       ResultType,
-      NameType
+      NameType,
+      ProgressType
     >>();
 
     let tokenPostfix = 0;
@@ -589,7 +638,8 @@ export class Worker<
         const fetchedJob = this.retryIfFailed<void | Job<
           DataType,
           ResultType,
-          NameType
+          NameType,
+          ProgressType
         >>(() => this._getNextJob(token, { block: true }), {
           delayInMs: this.opts.runRetryDelay,
           onlyEmitError: true,
@@ -619,7 +669,7 @@ export class Worker<
 
       // Since there can be undefined jobs in the queue (when a job fails or queue is empty)
       // we iterate until we find a job.
-      let job: Job<DataType, ResultType, NameType> | void;
+      let job: Job<DataType, ResultType, NameType, ProgressType> | void;
       do {
         job = await asyncFifoQueue.fetch();
       } while (!job && asyncFifoQueue.numQueued() > 0);
@@ -628,7 +678,7 @@ export class Worker<
         const token = job.token;
         asyncFifoQueue.add(
           this.processJob(
-            <Job<DataType, ResultType, NameType>>job,
+            <Job<DataType, ResultType, NameType, ProgressType>>job,
             token,
             () => asyncFifoQueue.numTotal() <= this._concurrency,
           ),
@@ -647,7 +697,9 @@ export class Worker<
   async getNextJob(token: string, { block = true }: GetNextJobOptions = {}) {
     const nextJob = await this._getNextJob(token, { block });
 
-    return this.trace<Job<DataType, ResultType, NameType> | undefined>(
+    return this.trace<
+      Job<DataType, ResultType, NameType, ProgressType> | undefined
+    >(
       SpanKind.INTERNAL,
       'getNextJob',
       this.name,
@@ -669,7 +721,7 @@ export class Worker<
   private async _getNextJob(
     token: string,
     { block = true }: GetNextJobOptions = {},
-  ): Promise<Job<DataType, ResultType, NameType> | undefined> {
+  ): Promise<Job<DataType, ResultType, NameType, ProgressType> | undefined> {
     if (this.paused) {
       return;
     }
@@ -678,7 +730,7 @@ export class Worker<
       return;
     }
 
-    let job: Job<DataType, ResultType, NameType> | undefined;
+    let job: Job<DataType, ResultType, NameType, ProgressType> | undefined;
     if (this.drained && block && !this.limitUntil && !this.waiting) {
       this.waiting = this.waitForJob(this.blockUntil);
       try {
@@ -731,7 +783,7 @@ export class Worker<
   protected async moveToActive(
     token: string,
     name?: string,
-  ): Promise<Job<DataType, ResultType, NameType>> {
+  ): Promise<Job<DataType, ResultType, NameType, ProgressType>> {
     const [jobData, id, rateLimitDelay, delayUntil] =
       await this.backend.moveToActive(token, name);
     this.updateDelays(rateLimitDelay, delayUntil);
@@ -844,7 +896,7 @@ export class Worker<
     jobData?: JobJson,
     jobId?: string,
     token?: string,
-  ): Promise<Job<DataType, ResultType, NameType>> {
+  ): Promise<Job<DataType, ResultType, NameType, ProgressType>> {
     if (!jobData) {
       if (!this.drained) {
         this.emit('drained');
@@ -922,13 +974,13 @@ export class Worker<
   }
 
   async processJob(
-    job: Job<DataType, ResultType, NameType>,
+    job: Job<DataType, ResultType, NameType, ProgressType>,
     token: string,
     fetchNextCallback = () => true,
-  ): Promise<void | Job<DataType, ResultType, NameType>> {
+  ): Promise<void | Job<DataType, ResultType, NameType, ProgressType>> {
     const srcPropagationMetadata = job.opts?.telemetry?.metadata;
 
-    return this.trace<void | Job<DataType, ResultType, NameType>>(
+    return this.trace<void | Job<DataType, ResultType, NameType, ProgressType>>(
       SpanKind.CONSUMER,
       'process',
       this.name,
@@ -954,7 +1006,8 @@ export class Worker<
             const failed = await this.retryIfFailed<void | Job<
               DataType,
               ResultType,
-              NameType
+              NameType,
+              ProgressType
             >>(
               () => {
                 this.lockManager.untrackJob(job.id);
@@ -981,7 +1034,8 @@ export class Worker<
           return await this.retryIfFailed<void | Job<
             DataType,
             ResultType,
-            NameType
+            NameType,
+            ProgressType
           >>(
             () => {
               this.lockManager.untrackJob(job.id);
@@ -999,7 +1053,8 @@ export class Worker<
           const failed = await this.retryIfFailed<void | Job<
             DataType,
             ResultType,
-            NameType
+            NameType,
+            ProgressType
           >>(
             () => {
               this.lockManager.untrackJob(job.id);
@@ -1030,7 +1085,7 @@ export class Worker<
   }
 
   private getUnrecoverableErrorMessage(
-    job: Job<DataType, ResultType, NameType>,
+    job: Job<DataType, ResultType, NameType, ProgressType>,
   ) {
     if (job.deferredFailure) {
       return job.deferredFailure;
@@ -1045,7 +1100,7 @@ export class Worker<
 
   protected async handleCompleted(
     result: ResultType,
-    job: Job<DataType, ResultType, NameType>,
+    job: Job<DataType, ResultType, NameType, ProgressType>,
     token: string,
     fetchNextCallback = () => true,
     span?: Span,
@@ -1077,7 +1132,7 @@ export class Worker<
 
   protected async handleFailed(
     err: Error,
-    job: Job<DataType, ResultType, NameType>,
+    job: Job<DataType, ResultType, NameType, ProgressType>,
     token: string,
     fetchNextCallback = () => true,
     span?: Span,
@@ -1413,7 +1468,7 @@ export class Worker<
   }
 
   private moveLimitedBackToWait(
-    job: Job<DataType, ResultType, NameType>,
+    job: Job<DataType, ResultType, NameType, ProgressType>,
     token: string,
   ) {
     return job.moveToWait(token);

--- a/src/interfaces/minimal-job.ts
+++ b/src/interfaces/minimal-job.ts
@@ -58,6 +58,7 @@ export interface MinimalJob<
   DataType = any,
   ReturnType = any,
   NameType extends string = string,
+  ProgressType extends JobProgress = JobProgress,
 > {
   /**
    * The name of the Job
@@ -76,7 +77,7 @@ export interface MinimalJob<
    * The progress a job has performed so far.
    * @defaultValue 0
    */
-  progress: JobProgress;
+  progress: ProgressType;
   /**
    * The value returned by the processor when processing this job.
    * @defaultValue null
@@ -146,7 +147,7 @@ export interface MinimalJob<
    *
    * @param progress - number or object to be saved as progress.
    */
-  updateProgress(progress: JobProgress): Promise<void>;
+  updateProgress(progress: ProgressType): Promise<void>;
   /**
    * Logs one row of log data.
    *

--- a/src/types/processor.ts
+++ b/src/types/processor.ts
@@ -1,10 +1,12 @@
 import { Job } from '../classes/job';
+import { JobProgress } from './job-progress';
 
 /**
  * An async function that receives `Job`s and handles them.
  */
-export type Processor<T = any, R = any, N extends string = string> = (
-  job: Job<T, R, N>,
-  token?: string,
-  signal?: AbortSignal,
-) => Promise<R>;
+export type Processor<
+  T = any,
+  R = any,
+  N extends string = string,
+  P extends JobProgress = JobProgress,
+> = (job: Job<T, R, N, P>, token?: string, signal?: AbortSignal) => Promise<R>;

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -24,6 +24,7 @@ import {
   WaitingChildrenError,
   DelayedError,
   WaitingError,
+  RedisQueueBackend,
 } from '../src/classes';
 import { MinimalJob, IRedisClient } from '../src/interfaces';
 import { JobsOptions, KeepJobs } from '../src/types';
@@ -287,6 +288,50 @@ describe('workers', () => {
 
     const worker = new Worker(queueName, processor, { connection, prefix });
     await worker.waitUntilReady();
+
+    await processing;
+
+    await worker.close();
+  });
+
+  it('process a job that updates progress with a typed progress generic', async () => {
+    type CustomProgress = { percentage: number; message: string };
+    const expected: CustomProgress = { percentage: 42, message: 'halfway' };
+
+    const job = await queue.add('test', { foo: 'bar' });
+    expect(job.id).toBeTruthy();
+    expect(job.data.foo).toEqual('bar');
+
+    const worker = new Worker<
+      { foo: string },
+      void,
+      string,
+      RedisQueueBackend,
+      CustomProgress
+    >(
+      queueName,
+      async job => {
+        expect(job.data.foo).toBe('bar');
+        // `progress` is typed as CustomProgress here, not JobProgress.
+        await job.updateProgress(expected);
+      },
+      { autorun: false, connection, prefix },
+    );
+    await worker.waitUntilReady();
+
+    const processing = new Promise<void>((resolve, reject) => {
+      worker.on('progress', (_job, progress) => {
+        try {
+          expect(progress.percentage).toEqual(42);
+          expect(progress.message).toEqual('halfway');
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+
+    worker.run();
 
     await processing;
 


### PR DESCRIPTION
The progress type was hardcoded to JobProgress
(string | boolean | number | object), so there was no way to get type-safe progress when calling updateProgress() or when listening to the progress event.

Add an optional ProgressType generic parameter, constrained to JobProgress and defaulting to JobProgress, to MinimalJob, Job, Processor, Worker and WorkerListener. Existing code that passes fewer generics keeps compiling unchanged.

Because ProgressType is constrained to JobProgress, Job<..., P> stays assignable to the internal MinimalJob helpers, which never read or write progress, so the generic does not need to be threaded through them. This also keeps the persistence contract intact, since progress is ultimately serialized before being stored in the backend.

On Worker the parameter is added after the backend generic B so that the existing public signature is not broken.

Sandboxed processors keep JobProgress by design, as progress crosses a process boundary where the static type is lost. Queue side getters such as getJob and Job.fromId also keep the default.

Closes #3721

---

### Port Impact Checklist

- [ ] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?
- [ ] **Rust** – does this change need to be ported or documented in the Rust library?
- [ ] **.NET** – does this change need to be ported or documented in the .NET library?

TypeScript types only — no runtime or Lua changes, nothing to port.

### Why

`JobProgress` is hardcoded as `string | boolean | number | object`, so progress can't be type-safe:

```typescript
worker.on('progress', (job, progress) => {
  progress.percentage; // TS error: Property 'percentage' does not exist on type 'JobProgress'
});
```

Closes #3721 (also discussed in #3184).

Continues #3909 by @claygeo, closed when the head repo was deleted. Rebased onto current `master` and reworked for the v6 backend generic. @claygeo credited as co-author.

### How

Add an optional `ProgressType` generic to `MinimalJob`, `Job`, `Processor`, `Worker` and `WorkerListener`, constrained `extends JobProgress` and defaulting to `JobProgress`. Existing code with fewer generics compiles unchanged.

```typescript
type MyProgress = { percentage: number; message: string };

const worker = new Worker<MyData, MyReturn, string, RedisQueueBackend, MyProgress>(
  'myQueue',
  async job => {
    await job.updateProgress({ percentage: 50, message: 'halfway' }); // type-safe
  },
  { connection },
);

worker.on('progress', (job, progress) => {
  console.log(progress.percentage, progress.message); // number, string
});
```

Two decisions worth noting:

- **The constraint replaces internal plumbing.** `ProgressType extends JobProgress` keeps `Job<…, P>` assignable to the internal `MinimalJob<…, JobProgress>` helpers, which never touch `progress`. So `Scripts`/`Backoffs` need no threading and are untouched.
- **`ProgressType` sits after `B` on `Worker`.** The 4th slot is taken by the v6 backend generic, so adding it 5th avoids breaking the v6 signature. On `Job`/`MinimalJob`/`Processor` it is purely additive as the 4th.

### Additional Notes (Optional)

**Ordering is open.** Cost of the above is that users must name the backend to reach `ProgressType`. Happy to move it to `Worker`'s 4th slot instead if you'll take it as a breaking change.

**Intentionally out of scope:**

- Sandboxed processors keep `JobProgress` — the value crosses a process boundary where the static type is lost.
- `getJob`, `Job.fromId`/`fromJSON` keep the default; threading `ProgressType` through the getter surface can be a follow-up.
- `progress` still defaults to `0`, typed as `ProgressType` with the initial value cast rather than widened to `ProgressType | number`, which would defeat the generic at every read.

**Verified:** `tsc --noEmit` clean on both tsconfigs; eslint, prettier and madge clean; `tests/worker.test.ts` 123/123 and the `job`/`queue`/`events`/`flow` suites 198/198 against Redis 8. Type safety checked with `@ts-expect-error` assertions (narrowed type in the processor and the `progress`/`active`/`completed`/`failed` handlers, `bigint` rejected by the constraint, 0- and 3-generic usage still compiles).

Reproduce with `yarn && yarn pretest && npx vitest run --no-file-parallelism tests/worker.test.ts`.
