### PR TITLE
fix(bun): duplicate() and reconnect target the correct server

### DIFF
--- a/src/classes/bun-redis-client.ts
+++ b/src/classes/bun-redis-client.ts
@@ -91,7 +91,7 @@ export interface BunRedisRawClient {
   // public connection info (no `url`/host/port/options). Optional so exotic
   // custom raw clients that don't implement it still satisfy the constraint;
   // the adapter falls back to URL-based reconstruction when it is absent.
-  duplicate?(): Promise<BunRedisRawClient>;
+  duplicate?(): Promise<this>;
   send<T = any>(command: string, args: RedisCommandArgument[]): Promise<T>;
   get(key: string): Promise<string | null | undefined>;
   smembers(key: string): Promise<unknown[] | null | undefined>;
@@ -471,10 +471,23 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
    */
   private async _duplicateRaw(src: TClient): Promise<TClient> {
     if (typeof src.duplicate === 'function') {
-      return (await src.duplicate()) as TClient;
+      return await src.duplicate();
     }
     const Ctor = src.constructor as BunRedisClientConstructor<TClient>;
     return new Ctor(src.url);
+  }
+
+  /**
+   * Return the raw client, materializing it first when this adapter is a
+   * lazily-initialized duplicate (created via `duplicate()` with a
+   * `rawFactory`). Command paths that touch `this.raw` directly use this so a
+   * duplicate can be used immediately without an explicit `connect()`.
+   */
+  async _ensureRaw(): Promise<TClient> {
+    if (!this.raw) {
+      await this.connect();
+    }
+    return this.raw;
   }
 
   duplicate(...args: any[]): IRedisClient {
@@ -606,6 +619,15 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
       return Promise.reject(new ConnectionClosedError('Connection is closed'));
     }
 
+    // A duplicate created via `duplicate()` builds its raw client lazily on the
+    // first `connect()` (Bun's native `duplicate()` is async). Materialize it
+    // here so commands issued before an explicit `connect()` don't throw on an
+    // undefined `raw` — matching other adapters where duplicates connect
+    // implicitly on first use.
+    if (!this.raw) {
+      return this.connect().then(() => this.sendCommand<T>(command, args));
+    }
+
     // Send directly to the underlying Bun client. Redis protocol guarantees
     // responses arrive in the same order as requests on a single connection,
     // so concurrent send() calls are safe and enable implicit pipelining
@@ -637,11 +659,11 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
   // ---------------------------------------------------------------
 
   multi(): IRedisTransaction {
-    return new BunRedisTransaction(this.raw, this.scripts, true, this);
+    return new BunRedisTransaction(this.scripts, true, this);
   }
 
   pipeline(): IRedisTransaction {
-    return new BunRedisTransaction(this.raw, this.scripts, false, this);
+    return new BunRedisTransaction(this.scripts, false, this);
   }
 
   // ---------------------------------------------------------------
@@ -850,7 +872,7 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
     for (const [k, v] of Object.entries(fields)) {
       args.push(k, String(v));
     }
-    return await this.raw.send('XADD', args);
+    return await (await this._ensureRaw()).send('XADD', args);
   }
 
   async xread(
@@ -1133,7 +1155,6 @@ class BunRedisTransaction implements IRedisTransaction {
   private scriptsToLoad: LuaScript[] = [];
 
   constructor(
-    private readonly raw: any,
     private readonly scripts: Map<string, LuaScript>,
     private readonly transactional: boolean,
     private readonly adapter: BunRedisAdapter<any>,
@@ -1327,17 +1348,20 @@ class BunRedisTransaction implements IRedisTransaction {
     const swallow = (_: unknown) => {
       /* error surfaces via EXEC or the outer try/catch */
     };
+    // Materialize the raw client (a lazily-initialized duplicate may not have
+    // one yet) so the MULTI…EXEC frames can be written as a contiguous burst.
+    const raw = await this.adapter._ensureRaw();
     try {
       // Fire MULTI without awaiting — no round-trip needed before commands.
-      this.raw.send('MULTI', []).catch(swallow);
+      raw.send('MULTI', []).catch(swallow);
 
       // Fire all queued commands synchronously (no awaits).
       for (const { cmd, args } of this.commands) {
-        this.raw.send(cmd, args).catch(swallow);
+        raw.send(cmd, args).catch(swallow);
       }
 
       // EXEC is the only await — it returns the array of results.
-      const results = await this.raw.send('EXEC', []);
+      const results = await raw.send('EXEC', []);
 
       if (!results) {
         return null;
@@ -1355,7 +1379,7 @@ class BunRedisTransaction implements IRedisTransaction {
     } catch (err) {
       // Try to discard the MULTI state on error
       try {
-        await this.raw.send('DISCARD', []);
+        await raw.send('DISCARD', []);
       } catch {
         // ignore
       }

--- a/src/classes/bun-redis-client.ts
+++ b/src/classes/bun-redis-client.ts
@@ -380,6 +380,31 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
     }
 
     await this.connecting;
+
+    // Bun may report the socket as connected before this adapter transitions
+    // to ready (for example while applying CLIENT SETNAME on duplicates).
+    // Keep connect() aligned with ioredis semantics by waiting until the
+    // adapter is either ready or closed.
+    if (!this.ready && !this.closed && !this.closing && this.raw?.connected) {
+      await new Promise<void>(resolve => {
+        const cleanup = () => {
+          this.off('ready', onDone);
+          this.off('close', onDone);
+          this.off('end', onDone);
+        };
+        const onDone = () => {
+          cleanup();
+          resolve();
+        };
+        this.on('ready', onDone);
+        this.on('close', onDone);
+        this.on('end', onDone);
+
+        if (this.ready || this.closed || this.closing || !this.raw?.connected) {
+          onDone();
+        }
+      });
+    }
   }
 
   private _closeRaw(): void {

--- a/src/classes/bun-redis-client.ts
+++ b/src/classes/bun-redis-client.ts
@@ -146,6 +146,7 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectAttempts = 0;
   private maxReconnectDelay = 20000; // cap at 20s (matches ioredis default)
+  private ready = false;
 
   get status(): string {
     if (this.statusOverride) {
@@ -156,8 +157,11 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
     }
     // `raw` may not exist yet on a duplicate whose raw client is created
     // lazily (via `rawFactory`) on first connect.
-    if (this.raw?.connected) {
+    if (this.ready) {
       return 'ready';
+    }
+    if (this.raw?.connected) {
+      return 'connect';
     }
     return this.hasConnected ? 'end' : 'wait';
   }
@@ -215,6 +219,7 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
     // see the name already applied.
     this.raw.onconnect = () => {
       this.hasConnected = true;
+      this.ready = false;
       this.closed = false;
       this.closing = false;
       this.reconnecting = false;
@@ -225,14 +230,23 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
       this.loadedScriptShas.clear();
       if (this.connectionName) {
         this.clientSetName(this.connectionName).then(
-          () => this.emit('ready'),
-          () => this.emit('ready'), // emit ready even if setName fails
+          () => {
+            this.ready = true;
+            this.emit('ready');
+          },
+          () => {
+            // emit ready even if setName fails
+            this.ready = true;
+            this.emit('ready');
+          },
         );
       } else {
+        this.ready = true;
         this.emit('ready');
       }
     };
     this.raw.onclose = (error?: Error) => {
+      this.ready = false;
       if (this.closing) {
         // User-initiated close – no reconnect
         this.closed = true;

--- a/src/classes/bun-redis-client.ts
+++ b/src/classes/bun-redis-client.ts
@@ -147,6 +147,7 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
   private reconnectAttempts = 0;
   private maxReconnectDelay = 20000; // cap at 20s (matches ioredis default)
   private ready = false;
+  private readying?: Promise<void>;
 
   get status(): string {
     if (this.statusOverride) {
@@ -218,32 +219,7 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
     // event until CLIENT SETNAME completes so callers waiting for 'ready'
     // see the name already applied.
     this.raw.onconnect = () => {
-      this.hasConnected = true;
-      this.ready = false;
-      this.closed = false;
-      this.closing = false;
-      this.reconnecting = false;
-      this.reconnectAttempts = 0;
-      this.statusOverride = undefined;
-      // The server-side SCRIPT cache is gone for this (possibly new) raw
-      // connection. Force re-loading on next use.
-      this.loadedScriptShas.clear();
-      if (this.connectionName) {
-        this.clientSetName(this.connectionName).then(
-          () => {
-            this.ready = true;
-            this.emit('ready');
-          },
-          () => {
-            // emit ready even if setName fails
-            this.ready = true;
-            this.emit('ready');
-          },
-        );
-      } else {
-        this.ready = true;
-        this.emit('ready');
-      }
+      this._handleConnected();
     };
     this.raw.onclose = (error?: Error) => {
       this.ready = false;
@@ -265,6 +241,36 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
 
       this._scheduleReconnect();
     };
+  }
+
+  private _handleConnected(): Promise<void> {
+    this.hasConnected = true;
+    this.ready = false;
+    this.closed = false;
+    this.closing = false;
+    this.reconnecting = false;
+    this.reconnectAttempts = 0;
+    this.statusOverride = undefined;
+    // The server-side SCRIPT cache is gone for this (possibly new) raw
+    // connection. Force re-loading on next use.
+    this.loadedScriptShas.clear();
+
+    const markReady = () => {
+      this.ready = true;
+      this.emit('ready');
+    };
+
+    const readying = this.connectionName
+      ? this.clientSetName(this.connectionName).then(markReady, markReady)
+      : (markReady(), Promise.resolve());
+
+    this.readying = readying.finally(() => {
+      if (this.readying === readying) {
+        this.readying = undefined;
+      }
+    });
+
+    return this.readying;
   }
 
   /**
@@ -350,6 +356,9 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
       this.closed = false;
       this.closing = false;
       this.statusOverride = undefined;
+      if (!this.ready) {
+        await (this.readying ?? this._handleConnected());
+      }
       return;
     }
 
@@ -380,6 +389,7 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
     }
 
     await this.connecting;
+    await this.readying;
 
     // Bun may report the socket as connected before this adapter transitions
     // to ready (for example while applying CLIENT SETNAME on duplicates).

--- a/src/classes/bun-redis-client.ts
+++ b/src/classes/bun-redis-client.ts
@@ -85,6 +85,13 @@ export interface BunRedisRawClient {
 
   connect(): Promise<void>;
   close(): void;
+  // Bun's native `duplicate()` creates a new client to the *same* server with
+  // the same options. It is async (returns a Promise) and is the only reliable
+  // way to clone the connection target, since Bun's RedisClient exposes no
+  // public connection info (no `url`/host/port/options). Optional so exotic
+  // custom raw clients that don't implement it still satisfy the constraint;
+  // the adapter falls back to URL-based reconstruction when it is absent.
+  duplicate?(): Promise<BunRedisRawClient>;
   send<T = any>(command: string, args: RedisCommandArgument[]): Promise<T>;
   get(key: string): Promise<string | null | undefined>;
   smembers(key: string): Promise<unknown[] | null | undefined>;
@@ -128,6 +135,12 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
   private closing = false;
   private connecting?: Promise<void>;
   private connectionName: string | undefined;
+  // Factory that lazily creates the raw client on first connect. Used by
+  // `duplicate()`, whose IRedisClient contract is synchronous while Bun's
+  // native `duplicate()` (the only way to preserve the connection target) is
+  // async. The duplicate adapter is created immediately with a `rawFactory`
+  // and resolves its raw client when it connects.
+  private rawFactory?: () => Promise<TClient>;
   // Auto-reconnect state
   private reconnecting = false;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -141,7 +154,9 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
     if (this.closed) {
       return 'end';
     }
-    if (this.raw.connected) {
+    // `raw` may not exist yet on a duplicate whose raw client is created
+    // lazily (via `rawFactory`) on first connect.
+    if (this.raw?.connected) {
       return 'ready';
     }
     return this.hasConnected ? 'end' : 'wait';
@@ -166,11 +181,20 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
 
   constructor(
     private raw: TClient,
-    opts?: { lazyConnect?: boolean },
+    opts?: {
+      lazyConnect?: boolean;
+      rawFactory?: () => Promise<TClient>;
+    },
   ) {
     super();
 
-    this._setupCallbacks();
+    this.rawFactory = opts?.rawFactory;
+
+    // When a `rawFactory` is provided the raw client is created lazily on the
+    // first `connect()`; callbacks are wired up there once it exists.
+    if (this.raw) {
+      this._setupCallbacks();
+    }
 
     // ioredis auto-connects by default. Mimic that behavior unless
     // lazyConnect is set.
@@ -254,10 +278,16 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
       }
 
       try {
-        // Create a fresh raw client with the same URL
-        const BunRedisClient = this.raw
-          .constructor as BunRedisClientConstructor<TClient>;
-        const newRaw = new BunRedisClient(this.raw.url);
+        // Create a fresh raw client aimed at the *same* server. Bun's native
+        // `duplicate()` preserves the connection target and options; the old
+        // `new BunRedisClient(this.raw.url)` produced a client pointed at Bun's
+        // default target because `url` is always undefined (#4582). If the raw
+        // client was never created (a duplicate reconnecting before its first
+        // connect), fall back to its lazy factory.
+        const newRaw = this.raw
+          ? await this._duplicateRaw(this.raw)
+          : await this.rawFactory!();
+        this.rawFactory = undefined;
 
         // Swap the raw client reference
         this.raw = newRaw;
@@ -284,6 +314,14 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
   // ---------------------------------------------------------------
 
   async connect(): Promise<void> {
+    // A duplicate created with a `rawFactory` builds its raw client lazily on
+    // the first connect (Bun's native `duplicate()` is async).
+    if (!this.raw && this.rawFactory) {
+      this.raw = await this.rawFactory();
+      this.rawFactory = undefined;
+      this._setupCallbacks();
+    }
+
     const replaceRaw =
       this.hasConnected && (this.closed || !this.raw.connected);
 
@@ -307,11 +345,10 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
       this.statusOverride = undefined;
 
       // If the raw client was previously closed, Bun doesn't support
-      // reconnecting on the same instance. Create a fresh raw client.
+      // reconnecting on the same instance. Create a fresh raw client aimed at
+      // the same server via Bun's native `duplicate()` (see #4582).
       if (replaceRaw) {
-        const BunRedisClient = this.raw
-          .constructor as BunRedisClientConstructor<TClient>;
-        this.raw = new BunRedisClient(this.raw.url);
+        this.raw = await this._duplicateRaw(this.raw);
         this._setupCallbacks();
       }
 
@@ -339,7 +376,12 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
     }
     this.reconnecting = false;
 
+    // A duplicate closed before it ever connected has no raw client yet.
+    this.rawFactory = undefined;
     const raw = this.raw;
+    if (!raw) {
+      return;
+    }
     raw.onconnect = () => {};
     raw.onclose = () => {};
     raw.onerror = () => {};
@@ -371,17 +413,19 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
       this.statusOverride = undefined;
 
       const raw = this.raw;
-      raw.onclose = () => {};
-      if (raw.connected) {
-        setImmediate(() => {
-          try {
-            if (raw.connected) {
-              raw.close();
+      if (raw) {
+        raw.onclose = () => {};
+        if (raw.connected) {
+          setImmediate(() => {
+            try {
+              if (raw.connected) {
+                raw.close();
+              }
+            } catch (_err) {
+              // swallow
             }
-          } catch (_err) {
-            // swallow
-          }
-        });
+          });
+        }
       }
 
       this.emit('close');
@@ -416,15 +460,37 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
     return 'OK';
   }
 
+  /**
+   * Create a fresh raw client aimed at the *same* Redis server as `src`.
+   *
+   * Bun's `RedisClient` exposes no public connection info (no `url`, host,
+   * port or options), so the target cannot be reconstructed from the instance.
+   * Its native `duplicate()` is the only reliable way to clone the target and
+   * options; we fall back to URL-based reconstruction for exotic raw clients
+   * that don't implement it. See #4582.
+   */
+  private async _duplicateRaw(src: TClient): Promise<TClient> {
+    if (typeof src.duplicate === 'function') {
+      return (await src.duplicate()) as TClient;
+    }
+    const Ctor = src.constructor as BunRedisClientConstructor<TClient>;
+    return new Ctor(src.url);
+  }
+
   duplicate(...args: any[]): IRedisClient {
-    // Bun's duplicate() is async, but IRedisClient.duplicate() is sync.
-    // We create a new RedisClient with the same URL/options instead.
-    // The raw client constructor in Bun doesn't connect until connect() or
-    // first command, so this is safe.
-    const BunRedisClient = this.raw
-      .constructor as BunRedisClientConstructor<TClient>;
-    const dup = new BunRedisClient(this.raw.url);
-    const adapter = new BunRedisAdapter(dup);
+    // Bun's duplicate() is async, but IRedisClient.duplicate() is sync. The
+    // duplicate adapter is therefore created immediately with a `rawFactory`
+    // that clones the connection target lazily (via Bun's native duplicate)
+    // on first connect. Rebuilding from `this.raw.url` is not possible because
+    // Bun never exposes the URL, which previously sent duplicates to the
+    // wrong (default) server (#4582).
+    const parentRaw = this.raw;
+    const adapter = new BunRedisAdapter<TClient>(
+      undefined as unknown as TClient,
+      {
+        rawFactory: () => this._duplicateRaw(parentRaw),
+      },
+    );
 
     // Copy registered scripts to the duplicate
     for (const [name, script] of this.scripts) {

--- a/tests/bun-redis.test.ts
+++ b/tests/bun-redis.test.ts
@@ -175,6 +175,50 @@ describe('bun redis adapter', () => {
       await dup.quit();
     });
 
+    it('duplicate() reports ready when Bun returns an already-connected client', async () => {
+      class FakeRaw {
+        connected = false;
+        onconnect: (() => void) | null = null;
+        onclose: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        async connect() {
+          this.connected = true;
+          this.onconnect?.();
+        }
+        close() {
+          this.connected = false;
+        }
+        async duplicate() {
+          const duplicate = new FakeRaw();
+          duplicate.connected = true;
+          return duplicate;
+        }
+        async send() {
+          return null;
+        }
+        async get() {
+          return null;
+        }
+        async smembers() {
+          return [];
+        }
+        async incr() {
+          return 0;
+        }
+      }
+
+      const primary = createBunRedisClient(new FakeRaw() as any);
+      await primary.connect();
+
+      const dup = primary.duplicate();
+      await dup.connect();
+
+      expect(dup.status).toBe('ready');
+
+      await primary.quit();
+      await dup.quit();
+    });
+
     it('should explicitly reconnect while an automatic reconnect is pending', async () => {
       const { client: reconnectingClient } = await createConnectedClient();
 

--- a/tests/bun-redis.test.ts
+++ b/tests/bun-redis.test.ts
@@ -128,6 +128,53 @@ describe('bun redis adapter', () => {
       await dup.quit();
     });
 
+    it('duplicate() targets the same server, not Bun default (#4582)', async () => {
+      const target = 'redis://localhost:16379';
+
+      class FakeRaw {
+        connected = false;
+        onconnect: (() => void) | null = null;
+        onclose: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        constructor(public target = 'redis://DEFAULT:6379') {}
+        async connect() {
+          this.connected = true;
+          this.onconnect?.();
+        }
+        close() {
+          this.connected = false;
+        }
+        async duplicate() {
+          // Native duplicate preserves the connection target.
+          return new FakeRaw(this.target);
+        }
+        async send() {
+          return null;
+        }
+        async get() {
+          return null;
+        }
+        async smembers() {
+          return [];
+        }
+        async incr() {
+          return 0;
+        }
+      }
+
+      const primary = createBunRedisClient(new FakeRaw(target) as any);
+      await primary.connect();
+
+      const dup = primary.duplicate();
+      await dup.connect();
+
+      expect((dup as any).raw.target).toBe(target);
+      expect((dup as any).raw.target).not.toBe('redis://DEFAULT:6379');
+
+      await primary.quit();
+      await dup.quit();
+    });
+
     it('should explicitly reconnect while an automatic reconnect is pending', async () => {
       const { client: reconnectingClient } = await createConnectedClient();
 

--- a/tests/getters.test.ts
+++ b/tests/getters.test.ts
@@ -69,13 +69,6 @@ describe('Jobs getters', () => {
   });
 
   describe('.getWorkers', () => {
-    const waitForWorkerReady = async (worker: Worker) =>
-      new Promise<void>(resolve => {
-        worker.once('ready', () => {
-          resolve();
-        });
-      });
-
     const waitForWorkers = async (
       targetQueue: Queue,
       expectedCount: number,
@@ -98,7 +91,7 @@ describe('Jobs getters', () => {
         connection,
         prefix,
       });
-      await waitForWorkerReady(worker);
+      await worker.waitUntilReady();
 
       const workers = await waitForWorkers(queue, 1);
       expect(workers).toHaveLength(1);
@@ -108,7 +101,7 @@ describe('Jobs getters', () => {
         connection,
         prefix,
       });
-      await waitForWorkerReady(worker2);
+      await worker2.waitUntilReady();
 
       const nextWorkers = await waitForWorkers(queue, 2);
       expect(nextWorkers).toHaveLength(2);
@@ -127,7 +120,7 @@ describe('Jobs getters', () => {
         prefix,
         name: 'worker1',
       });
-      await waitForWorkerReady(worker);
+      await worker.waitUntilReady();
 
       const workers = await waitForWorkers(queue, 1);
       expect(workers).toHaveLength(1);
@@ -141,7 +134,7 @@ describe('Jobs getters', () => {
         prefix,
         name: 'worker2',
       });
-      await waitForWorkerReady(worker2);
+      await worker2.waitUntilReady();
 
       const nextWorkers = await waitForWorkers(queue, 2);
       expect(nextWorkers).toHaveLength(2);
@@ -170,13 +163,13 @@ describe('Jobs getters', () => {
         connection,
         prefix,
       });
-      await waitForWorkerReady(worker);
+      await worker.waitUntilReady();
       const worker2 = new Worker(queueName2, async () => {}, {
         autorun: false,
         connection,
         prefix,
       });
-      await waitForWorkerReady(worker2);
+      await worker2.waitUntilReady();
 
       const workers = await waitForWorkers(queue, 1);
       expect(workers).toHaveLength(1);
@@ -206,7 +199,7 @@ describe('Jobs getters', () => {
           connection: localConnection,
           prefix,
         });
-        await waitForWorkerReady(worker);
+        await worker.waitUntilReady();
 
         const workers = await waitForWorkers(queue, 1);
         expect(workers).toHaveLength(1);
@@ -215,7 +208,7 @@ describe('Jobs getters', () => {
           connection: localConnection,
           prefix,
         });
-        await waitForWorkerReady(worker2);
+        await worker2.waitUntilReady();
 
         const nextWorkers = await waitForWorkers(queue, 2);
         expect(nextWorkers).toHaveLength(2);

--- a/tests/getters.test.ts
+++ b/tests/getters.test.ts
@@ -69,6 +69,13 @@ describe('Jobs getters', () => {
   });
 
   describe('.getWorkers', () => {
+    const waitForWorkerReady = async (worker: Worker) =>
+      new Promise<void>(resolve => {
+        worker.once('ready', () => {
+          resolve();
+        });
+      });
+
     const waitForWorkers = async (
       targetQueue: Queue,
       expectedCount: number,
@@ -91,7 +98,7 @@ describe('Jobs getters', () => {
         connection,
         prefix,
       });
-      await worker.waitUntilReady();
+      await waitForWorkerReady(worker);
 
       const workers = await waitForWorkers(queue, 1);
       expect(workers).toHaveLength(1);
@@ -101,7 +108,7 @@ describe('Jobs getters', () => {
         connection,
         prefix,
       });
-      await worker2.waitUntilReady();
+      await waitForWorkerReady(worker2);
 
       const nextWorkers = await waitForWorkers(queue, 2);
       expect(nextWorkers).toHaveLength(2);
@@ -120,7 +127,7 @@ describe('Jobs getters', () => {
         prefix,
         name: 'worker1',
       });
-      await worker.waitUntilReady();
+      await waitForWorkerReady(worker);
 
       const workers = await waitForWorkers(queue, 1);
       expect(workers).toHaveLength(1);
@@ -134,7 +141,7 @@ describe('Jobs getters', () => {
         prefix,
         name: 'worker2',
       });
-      await worker2.waitUntilReady();
+      await waitForWorkerReady(worker2);
 
       const nextWorkers = await waitForWorkers(queue, 2);
       expect(nextWorkers).toHaveLength(2);
@@ -163,13 +170,13 @@ describe('Jobs getters', () => {
         connection,
         prefix,
       });
-      await worker.waitUntilReady();
+      await waitForWorkerReady(worker);
       const worker2 = new Worker(queueName2, async () => {}, {
         autorun: false,
         connection,
         prefix,
       });
-      await worker2.waitUntilReady();
+      await waitForWorkerReady(worker2);
 
       const workers = await waitForWorkers(queue, 1);
       expect(workers).toHaveLength(1);
@@ -199,7 +206,7 @@ describe('Jobs getters', () => {
           connection: localConnection,
           prefix,
         });
-        await worker.waitUntilReady();
+        await waitForWorkerReady(worker);
 
         const workers = await waitForWorkers(queue, 1);
         expect(workers).toHaveLength(1);
@@ -208,7 +215,7 @@ describe('Jobs getters', () => {
           connection: localConnection,
           prefix,
         });
-        await worker2.waitUntilReady();
+        await waitForWorkerReady(worker2);
 
         const nextWorkers = await waitForWorkers(queue, 2);
         expect(nextWorkers).toHaveLength(2);

--- a/tests/getters.test.ts
+++ b/tests/getters.test.ts
@@ -69,19 +69,31 @@ describe('Jobs getters', () => {
   });
 
   describe('.getWorkers', () => {
+    const waitForWorkers = async (
+      targetQueue: Queue,
+      expectedCount: number,
+      timeout = 2000,
+    ) => {
+      const start = Date.now();
+      let workers = await targetQueue.getWorkers();
+
+      while (workers.length !== expectedCount && Date.now() - start < timeout) {
+        await delay(50);
+        workers = await targetQueue.getWorkers();
+      }
+
+      return workers;
+    };
+
     it('gets all workers for this queue only', async () => {
       const worker = new Worker(queueName, async () => {}, {
         autorun: false,
         connection,
         prefix,
       });
-      await new Promise<void>(resolve => {
-        worker.on('ready', () => {
-          resolve();
-        });
-      });
+      await worker.waitUntilReady();
 
-      const workers = await queue.getWorkers();
+      const workers = await waitForWorkers(queue, 1);
       expect(workers).toHaveLength(1);
 
       const worker2 = new Worker(queueName, async () => {}, {
@@ -89,13 +101,9 @@ describe('Jobs getters', () => {
         connection,
         prefix,
       });
-      await new Promise<void>(resolve => {
-        worker2.on('ready', () => {
-          resolve();
-        });
-      });
+      await worker2.waitUntilReady();
 
-      const nextWorkers = await queue.getWorkers();
+      const nextWorkers = await waitForWorkers(queue, 2);
       expect(nextWorkers).toHaveLength(2);
 
       const nextWorkersCount = await queue.getWorkersCount();
@@ -114,7 +122,7 @@ describe('Jobs getters', () => {
       });
       await worker.waitUntilReady();
 
-      const workers = await queue.getWorkers();
+      const workers = await waitForWorkers(queue, 1);
       expect(workers).toHaveLength(1);
 
       const workersCount = await queue.getWorkersCount();
@@ -128,7 +136,7 @@ describe('Jobs getters', () => {
       });
       await worker2.waitUntilReady();
 
-      const nextWorkers = await queue.getWorkers();
+      const nextWorkers = await waitForWorkers(queue, 2);
       expect(nextWorkers).toHaveLength(2);
 
       const nextWorkersCount = await queue.getWorkersCount();
@@ -155,29 +163,21 @@ describe('Jobs getters', () => {
         connection,
         prefix,
       });
-      await new Promise<void>(resolve => {
-        worker.on('ready', () => {
-          resolve();
-        });
-      });
+      await worker.waitUntilReady();
       const worker2 = new Worker(queueName2, async () => {}, {
         autorun: false,
         connection,
         prefix,
       });
-      await new Promise<void>(resolve => {
-        worker2.on('ready', () => {
-          resolve();
-        });
-      });
+      await worker2.waitUntilReady();
 
-      const workers = await queue.getWorkers();
+      const workers = await waitForWorkers(queue, 1);
       expect(workers).toHaveLength(1);
 
       const workersCount = await queue.getWorkersCount();
       expect(workersCount).toBe(1);
 
-      const workers2 = await queue2.getWorkers();
+      const workers2 = await waitForWorkers(queue2, 1);
       expect(workers2).toHaveLength(1);
 
       const workersCount2 = await queue2.getWorkersCount();
@@ -199,30 +199,18 @@ describe('Jobs getters', () => {
           connection: localConnection,
           prefix,
         });
-        await new Promise<void>(async resolve => {
-          worker.on('ready', () => {
-            resolve();
-          });
-          await delay(1000);
-          resolve();
-        });
+        await worker.waitUntilReady();
 
-        const workers = await queue.getWorkers();
+        const workers = await waitForWorkers(queue, 1);
         expect(workers).toHaveLength(1);
 
         const worker2 = new Worker(queueName, async () => {}, {
           connection: localConnection,
           prefix,
         });
-        await new Promise<void>(async resolve => {
-          worker2.on('ready', () => {
-            resolve();
-          });
-          await delay(1000);
-          resolve();
-        });
+        await worker2.waitUntilReady();
 
-        const nextWorkers = await queue.getWorkers();
+        const nextWorkers = await waitForWorkers(queue, 2);
         expect(nextWorkers).toHaveLength(2);
 
         await worker.close();

--- a/tests/pause.test.ts
+++ b/tests/pause.test.ts
@@ -67,7 +67,19 @@ describe('Pause', () => {
     if (processed) {
       throw new Error('should not process delayed jobs in paused queue.');
     }
-    const counts2 = await queue.getJobCounts('waiting', 'delayed');
+    const start = Date.now();
+    let counts2 = await queue.getJobCounts('waiting', 'delayed');
+    while (
+      (counts2.waiting !== 1 || counts2.delayed !== 0) &&
+      Date.now() - start < 2000
+    ) {
+      if (processed) {
+        throw new Error('should not process delayed jobs in paused queue.');
+      }
+      await delay(50);
+      counts2 = await queue.getJobCounts('waiting', 'delayed');
+    }
+
     expect(counts2).toHaveProperty('waiting', 1);
     expect(counts2).toHaveProperty('delayed', 0);
 


### PR DESCRIPTION
Fixes #4582 

Bun's RedisClient exposes no connection info (no url/host/port/options),
so rebuilding a client with `new BunRedisClient(this.raw.url)` always
fell back to Bun's default target (REDIS_URL or redis://localhost:6379).
Since Workers consume through duplicate(), they silently connected to the
wrong Redis and never picked up jobs.

Use Bun's native duplicate(), which preserves the connection target and
options, for duplicate() and the reconnect paths. duplicate() builds its
raw client lazily on first connect to bridge Bun's async duplicate() with
the synchronous IRedisClient.duplicate() contract.
