### PR TITLE
test(stalled): add script integration test [elixir]

### DIFF
--- a/elixir/lib/bullmq/scripts.ex
+++ b/elixir/lib/bullmq/scripts.ex
@@ -1412,8 +1412,7 @@ defmodule BullMQ.Scripts do
 
     timestamp = Keyword.get(opts, :timestamp, System.system_time(:millisecond))
 
-    max_check_time =
-      Keyword.get(opts, :stalled_interval, Keyword.get(opts, :max_check_time, 30_000))
+    max_check_time = Keyword.get(opts, :stalled_interval, 30_000)
 
     args = [
       # ARGV[1] max stalled count

--- a/elixir/lib/bullmq/scripts.ex
+++ b/elixir/lib/bullmq/scripts.ex
@@ -1390,27 +1390,38 @@ defmodule BullMQ.Scripts do
           script_result()
   def move_stalled_jobs_to_wait(conn, ctx, max_stalled_count, opts \\ []) do
     keys = [
+      # KEYS[1] stalled
       Keys.stalled(ctx),
+      # KEYS[2] wait
       Keys.wait(ctx),
+      # KEYS[3] active
       Keys.active(ctx),
-      Keys.failed(ctx),
+      # KEYS[4] stalled-check
       Keys.stalled_check(ctx),
+      # KEYS[5] meta
       Keys.meta(ctx),
+      # KEYS[6] paused
       Keys.paused(ctx),
+      # KEYS[7] marker
       Keys.marker(ctx),
+      # KEYS[8] event stream
       Keys.events(ctx),
+      # KEYS[9] repeat
       Keys.repeat(ctx)
     ]
 
     timestamp = Keyword.get(opts, :timestamp, System.system_time(:millisecond))
+    max_check_time = Keyword.get(opts, :max_check_time, 30_000)
 
     args = [
-      # ARGV[1] prefix:queueName
-      Keys.key(ctx),
-      # ARGV[2] max stalled count
+      # ARGV[1] max stalled count
       max_stalled_count,
+      # ARGV[2] queue.toKey('') — prefix:queueName with trailing colon
+      Keys.key(ctx) <> ":",
       # ARGV[3] timestamp
-      timestamp
+      timestamp,
+      # ARGV[4] max check time
+      max_check_time
     ]
 
     execute(conn, :move_stalled_jobs_to_wait, keys, args)

--- a/elixir/lib/bullmq/scripts.ex
+++ b/elixir/lib/bullmq/scripts.ex
@@ -1411,6 +1411,7 @@ defmodule BullMQ.Scripts do
     ]
 
     timestamp = Keyword.get(opts, :timestamp, System.system_time(:millisecond))
+
     max_check_time =
       Keyword.get(opts, :stalled_interval, Keyword.get(opts, :max_check_time, 30_000))
 

--- a/elixir/test/bullmq/integration_test.exs
+++ b/elixir/test/bullmq/integration_test.exs
@@ -692,8 +692,8 @@ defmodule BullMQ.IntegrationTest do
       {:ok, _} = Redix.command(conn, ["HSET", Keys.job(ctx, "job-2"), "name", "test"])
       {:ok, _} = Redix.command(conn, ["SET", Keys.lock(ctx, "job-2"), "token", "PX", 30_000])
 
-      # Phase 1 only marks lock-less active jobs into the stalled set (grace
-      # period) and returns []. It also arms the stalled-check mutex.
+      # Phase 1 marks all active jobs into the stalled set (grace period) and
+      # returns []. It also arms the stalled-check mutex.
       t1 = System.system_time(:millisecond)
 
       assert {:ok, first} =

--- a/elixir/test/bullmq/integration_test.exs
+++ b/elixir/test/bullmq/integration_test.exs
@@ -675,6 +675,65 @@ defmodule BullMQ.IntegrationTest do
       {:ok, last_check} = Redix.command(conn, ["GET", Keys.stalled_check(ctx)])
       assert String.to_integer(last_check) == now
     end
+
+    @tag :integration
+    test "move_stalled_jobs_to_wait reclaims lock-less jobs and sets stalled-check TTL (#4587)",
+         %{conn: conn} do
+      queue_name = "test-stalled-recover-#{System.unique_integer([:positive])}"
+      ctx = Keys.context(@test_prefix, queue_name)
+
+      # job-1: active with no lock -> genuinely stalled, must be reclaimed.
+      # job-2: active holding a valid lock -> must NOT be reclaimed. This also
+      # guards ARGV[2] (queue prefix): the script derives job-2's lock key as
+      # `<ARGV[2]><jobId>:lock`, so a missing trailing colon would look up the
+      # wrong key, see no lock and wrongly reclaim the running job.
+      {:ok, _} = Redix.command(conn, ["RPUSH", Keys.active(ctx), "job-1", "job-2"])
+      {:ok, _} = Redix.command(conn, ["HSET", Keys.job(ctx, "job-1"), "name", "test"])
+      {:ok, _} = Redix.command(conn, ["HSET", Keys.job(ctx, "job-2"), "name", "test"])
+      {:ok, _} = Redix.command(conn, ["SET", Keys.lock(ctx, "job-2"), "token", "PX", 30_000])
+
+      # Phase 1 only marks lock-less active jobs into the stalled set (grace
+      # period) and returns []. It also arms the stalled-check mutex.
+      t1 = System.system_time(:millisecond)
+
+      assert {:ok, first} =
+               Scripts.move_stalled_jobs_to_wait(conn, ctx, 5,
+                 timestamp: t1,
+                 max_check_time: 5_000
+               )
+
+      assert first == []
+
+      # The stalled-check mutex must carry a positive TTL. With the previous
+      # wrapper, ARGV[4] (max check time) was never sent, so `SET ... PX <nil>`
+      # errored (or left the key with no expiry), silently breaking every
+      # future stalled check.
+      {:ok, pttl} = Redix.command(conn, ["PTTL", Keys.stalled_check(ctx)])
+      assert pttl > 0 and pttl <= 5_000
+
+      {:ok, stalled_members} = Redix.command(conn, ["SMEMBERS", Keys.stalled(ctx)])
+      assert Enum.sort(stalled_members) == ["job-1", "job-2"]
+
+      # Clear the mutex so the next check runs (simulates the interval elapsing).
+      {:ok, _} = Redix.command(conn, ["DEL", Keys.stalled_check(ctx)])
+
+      # Phase 2: the lock-less job-1 is reclaimed to wait; the locked job-2
+      # stays active.
+      assert {:ok, reclaimed} =
+               Scripts.move_stalled_jobs_to_wait(conn, ctx, 5,
+                 timestamp: System.system_time(:millisecond),
+                 max_check_time: 5_000
+               )
+
+      assert reclaimed == ["job-1"]
+
+      {:ok, wait_list} = Redix.command(conn, ["LRANGE", Keys.wait(ctx), 0, -1])
+      assert "job-1" in wait_list
+
+      {:ok, active_list} = Redix.command(conn, ["LRANGE", Keys.active(ctx), 0, -1])
+      assert active_list == ["job-2"]
+      refute "job-1" in active_list
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/elixir/test/bullmq/integration_test.exs
+++ b/elixir/test/bullmq/integration_test.exs
@@ -699,7 +699,7 @@ defmodule BullMQ.IntegrationTest do
       assert {:ok, first} =
                Scripts.move_stalled_jobs_to_wait(conn, ctx, 5,
                  timestamp: t1,
-                 max_check_time: 5_000
+                 stalled_interval: 5_000
                )
 
       assert first == []
@@ -722,7 +722,7 @@ defmodule BullMQ.IntegrationTest do
       assert {:ok, reclaimed} =
                Scripts.move_stalled_jobs_to_wait(conn, ctx, 5,
                  timestamp: System.system_time(:millisecond),
-                 max_check_time: 5_000
+                 stalled_interval: 5_000
                )
 
       assert reclaimed == ["job-1"]


### PR DESCRIPTION

The Elixir wrapper passed an extra `failed` key (shifting stalled-check
and every subsequent key), swapped ARGV[1]/ARGV[2], and never sent
ARGV[4] max_check_time. The script then ran `SET stalled-check ts PX nil`,
which errors — and since the worker runs the check fire-and-forget, the
error was swallowed and stalled jobs were never reclaimed.

Send the canonical 9 KEYS and 4 ARGV, using `Keys.key(ctx) <> ":"` for the
queue prefix so job/lock keys resolve correctly, and default max_check_time
to 30_000. Adds an integration regression test.

