### PR TITLE
fix(worker): store failed reasons without extra JSON encoding [python]

### DIFF
--- a/python/bullmq/backends/postgres_backend.py
+++ b/python/bullmq/backends/postgres_backend.py
@@ -441,8 +441,7 @@ class PostgresBackend(Backend):
         remove_all, keep_age, keep_count = _normalize_keep(remove_on_fail)
         finished_on = _now_ms()
         stacktrace = (fields_to_update or {}).get("stacktrace")
-        # The Redis backend stores the reason JSON-encoded (a quoted string).
-        reason = json.dumps(str(failed_reason), separators=(",", ":"))
+        reason = str(failed_reason)
         opts = getattr(getattr(job, "queue", None), "opts", {}) or {}
         if fetch_next:
             lock_duration = opts.get("lockDuration", 30000)

--- a/python/bullmq/scripts.py
+++ b/python/bullmq/scripts.py
@@ -716,7 +716,11 @@ class Scripts:
 
     def moveToFinishedArgs(self, job: Job, val: Any, propVal: str, shouldRemove, target, token: str,
         fetchNext=True, fields_to_update = None) -> list[Any] | None:
-        transformed_value = json.dumps(val, separators=(',', ':'), allow_nan=False)
+        transformed_value = (
+            val
+            if propVal == 'failedReason'
+            else json.dumps(val, separators=(',', ':'), allow_nan=False)
+        )
         timestamp = round(time.time() * 1000)
         metricsKey = self.toKey('metrics:' + target)
 

--- a/python/tests/postgres_backend_test.py
+++ b/python/tests/postgres_backend_test.py
@@ -1,6 +1,7 @@
 import unittest
 import time
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, patch
 
 import psycopg
@@ -66,6 +67,38 @@ class TestPostgresBackendJobMapping(unittest.TestCase):
 
         self.assertEqual(backend.clientName(), "tenant_a:queue")
         self.assertEqual(backend.clientName(":w:worker"), "tenant_a:queue:w:worker")
+
+
+class TestPostgresBackendFailedReason(unittest.IsolatedAsyncioTestCase):
+    async def test_move_to_failed_keeps_failed_reason_as_raw_text(self):
+        backend = PostgresBackend(
+            "queue", cast(PostgresConnection, SimpleNamespace(schema="bull"))
+        )
+        backend._run = AsyncMock(return_value=SimpleNamespace())
+        backend._collect_metrics = AsyncMock()
+        job = cast(
+            Job,
+            SimpleNamespace(
+                id="job-1",
+                queue=SimpleNamespace(opts={}),
+            ),
+        )
+        failed_reason = '{"code":"E_FAIL","message":"你好 🌍"}'
+
+        await backend.moveToFailed(
+            job,
+            failed_reason,
+            False,
+            "token",
+            fetch_next=False,
+            fields_to_update={"stacktrace": "[]"},
+        )
+
+        call = backend._run.await_args
+        self.assertIsNotNone(call)
+        assert call is not None
+        params = call.args[1]
+        self.assertEqual(params[3], failed_reason)
 
 
 class _FakeCursor:

--- a/python/tests/worker_test.py
+++ b/python/tests/worker_test.py
@@ -27,7 +27,10 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
 
     async def asyncTearDown(self):
         connection = redis.Redis(host='localhost')
-        await connection.flushdb()
+        try:
+            await connection.flushdb()
+        finally:
+            await connection.aclose()
 
     async def test_process_jobs(self):
         queue = Queue(queueName, {"prefix": prefix})
@@ -224,35 +227,58 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         await queue.close()
 
     async def test_process_jobs_fail(self):
-        queue = Queue(queueName, {"prefix": prefix})
-        data = {"foo": "bar"}
-        job = await queue.add("test-job", data, {"removeOnComplete": False})
+        failure_messages = [
+            "Failed",
+            'quoted "value" and backslash \\',
+            "Unicode: 你好 🌍",
+            '{"code":"E_FAIL","retryable":false}',
+        ]
 
-        failedReason = "Failed"
+        for failedReason in failure_messages:
+            with self.subTest(failedReason=failedReason):
+                test_queue_name = f"__failed_reason_protocol__{uuid4().hex}"
+                queue = Queue(test_queue_name, {"prefix": prefix})
+                worker = None
+                try:
+                    data = {"foo": "bar"}
+                    job = await queue.add("test-job", data, {"removeOnComplete": False})
 
-        async def process(job: Job, token: str):
-            print("Processing job", job)
-            raise Exception(failedReason)
+                    async def process(job: Job, token: str):
+                        print("Processing job", job)
+                        raise Exception(failedReason)
 
-        worker = Worker(queueName, process, {"prefix": prefix})
+                    worker = Worker(test_queue_name, process, {"prefix": prefix})
+                    processing = Future()
+                    worker.on("failed", lambda job, result: processing.set_result(None))
 
-        processing = Future()
-        worker.on("failed", lambda job, result: processing.set_result(None))
+                    await processing
 
-        await processing
+                    failedJob = await Job.fromId(queue, job.id)
+                    self.assertIsNotNone(failedJob)
+                    assert failedJob is not None
+                    storedFailedReason = None
+                    if queue.redisConnection is not None:
+                        connection = redis.Redis(host="localhost", decode_responses=True)
+                        try:
+                            storedFailedReason = await connection.hget(
+                                queue.toKey(job.id), "failedReason"
+                            )
+                        finally:
+                            await connection.aclose()
 
-        failedJob = await Job.fromId(queue, job.id)
-
-        self.assertEqual(failedJob.id, job.id)
-        self.assertEqual(failedJob.attemptsMade, 1)
-        self.assertEqual(failedJob.data, data)
-        self.assertEqual(failedJob.failedReason, f'"{failedReason}"')
-        self.assertEqual(len(failedJob.stacktrace), 1)
-        self.assertEqual(failedJob.returnvalue, None)
-        self.assertNotEqual(failedJob.finishedOn, None)
-
-        await worker.close()
-        await queue.close()
+                    self.assertEqual(failedJob.id, job.id)
+                    self.assertEqual(failedJob.attemptsMade, 1)
+                    self.assertEqual(failedJob.data, data)
+                    self.assertEqual(failedJob.failedReason, failedReason)
+                    if queue.redisConnection is not None:
+                        self.assertEqual(storedFailedReason, failedReason)
+                    self.assertEqual(len(failedJob.stacktrace), 1)
+                    self.assertEqual(failedJob.returnvalue, None)
+                    self.assertNotEqual(failedJob.finishedOn, None)
+                finally:
+                    if worker is not None:
+                        await worker.close()
+                    await queue.close()
 
     async def test_process_renews_lock(self):
         queue = Queue(queueName, {"prefix": prefix})


### PR DESCRIPTION
### Port Impact Checklist

- [x] **Python** – this change is limited to the Python worker and backends.
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?
- [ ] **Rust** – does this change need to be ported or documented in the Rust library?
- [ ] **.NET** – does this change need to be ported or documented in the .NET library?

### Why

The Python worker currently JSON-encodes `failedReason` before sending it through the completion script. Redis then stores values such as `Failed` as `"Failed"`, and quotes, backslashes, Unicode, and JSON-looking messages gain an extra layer of escaping. The PostgreSQL backend applies the same extra encoding.

That differs from the Node worker contract, which stores `err.message` as raw text. It also means callers must decode Python failure messages differently from failures written by other BullMQ clients.

Fixes #4596

The regression test was first run against the unmodified implementation: all four failure-message subtests failed because stored values gained JSON delimiters and escaping (`4 failed, 1 passed`); for example, `Failed` was read back as `"Failed"`.

### How

- Keep `failedReason` as raw text in `Scripts.moveToFinishedArgs` while preserving the existing JSON serialization for completed `returnvalue` values.
- Pass PostgreSQL failure reasons as parameterized raw text instead of a JSON string literal.
- Cover plain text, quotes and backslashes, Unicode, and JSON-looking messages through the Redis worker path.
- Assert that the PostgreSQL backend sends the unchanged failure text to its SQL call.

The change stays at the failure-reason serialization boundary. It does not change job states, locks, retries, completion values, or removal behavior.

### Additional Notes (Optional)

Validated with the full Python test suite (`169 passed`) and Python lint/compile checks.
