### PR TITLE
fix(python): honor the postgres backend in QueueEvents

### DIFF
--- a/python/bullmq/backend.py
+++ b/python/bullmq/backend.py
@@ -127,7 +127,7 @@ class Backend(ABC):
         """Add many jobs in a single efficient operation. Returns the ids, in order."""
 
     @abstractmethod
-    async def addFlow(self, entries: list[dict]) -> list[str]:
+    async def addFlow(self, entries: list[dict]) -> list:
         """Atomically insert a flow (tree) of jobs that may span multiple queues.
 
         ``entries`` is a flat, topologically ordered list of
@@ -135,8 +135,9 @@ class Backend(ABC):
         self-describing (it carries its own queue and ``parent`` options), and
         ``is_parent`` marks nodes that have children (added as parent jobs).
         The whole insert is atomic (a Redis ``MULTI`` / a single SQL
-        transaction). Returns the created job ids, in the same order as
-        ``entries``.
+        transaction). Returns one entry per input, in order: the created job id
+        (a string), or a **negative integer** error/skip code for an entry that
+        was not inserted (e.g. ``-5`` when its parent does not exist).
         """
 
     # ============================================================
@@ -341,12 +342,63 @@ class Backend(ABC):
     # ============================================================
 
     @abstractmethod
+    async def setQueueMeta(self, values: dict) -> int:
+        """Upsert queue metadata fields (``concurrency``, ``max``, ``duration``, ...).
+
+        Returns the number of fields written.
+        """
+
+    @abstractmethod
+    async def getQueueMetaField(self, field: str) -> Optional[str]:
+        """Return a single queue metadata field's raw value, or ``None``."""
+
+    @abstractmethod
+    async def getQueueMetaFields(self, fields: list) -> list:
+        """Return several queue metadata values, in the order requested.
+        Missing fields come back as ``None``."""
+
+    @abstractmethod
+    async def removeQueueMetaFields(self, fields: list) -> int:
+        """Remove queue metadata fields. Returns how many were actually removed."""
+
+    @abstractmethod
+    async def setRateLimit(self, expire_time_ms: int) -> None:
+        """Force the rate-limit window open for ``expire_time_ms`` milliseconds."""
+
+    @abstractmethod
+    async def removeRateLimitKey(self) -> int:
+        """Clear the rate-limit window. Returns the number of entries removed (0 or 1)."""
+
+    @abstractmethod
     async def trimEvents(self, max_length: int) -> Any:
         """Trim the event stream to an approximate maximum length."""
 
     @abstractmethod
     async def removeDeprecatedPriorityKey(self) -> Any:
         """Remove the deprecated priority helper key."""
+
+    # ============================================================
+    # Event stream
+    # ============================================================
+
+    @abstractmethod
+    async def publishEvent(self, fields: dict, max_events: int) -> str:
+        """Append a custom event to the queue's event stream.
+
+        ``fields`` is the flat payload; its ``event`` entry names the channel
+        listeners subscribe to. Returns the id of the appended entry.
+        """
+
+    @abstractmethod
+    async def readEvents(self, id: str, block_timeout: int) -> Any:
+        """Block (up to ``block_timeout`` ms) reading the queue's event stream
+        for entries newer than ``id``.
+
+        ``id`` is a cursor, or ``'$'`` for "only events published from now on".
+        Returns the raw stream entries in the Redis ``XREAD`` shape --
+        ``[(stream_key, [(entry_id, {field: value, ...}), ...])]`` -- or a falsy
+        value when the block timeout elapses with no new events.
+        """
 
     # ============================================================
     # Worker blocking primitive

--- a/python/bullmq/backend.py
+++ b/python/bullmq/backend.py
@@ -30,6 +30,22 @@ if TYPE_CHECKING:
     from bullmq.job import Job
 
 
+def require_event_field(fields: dict) -> str:
+    """Validate a :meth:`Backend.publishEvent` payload; return its event name.
+
+    Every adapter enforces this at the contract boundary because both failure
+    modes are silent: ``QueueEvents._dispatch_entry`` drops an entry that
+    carries no ``event``, so a caller that omits it would publish an event that
+    simply never arrives.
+    """
+    event = fields.get("event") if fields else None
+    if event is None or str(event) == "":
+        raise ValueError(
+            "publishEvent requires a non-empty 'event' field naming the event"
+        )
+    return str(event)
+
+
 class Backend(ABC):
     """Abstract queue backend.
 
@@ -386,7 +402,8 @@ class Backend(ABC):
         """Append a custom event to the queue's event stream.
 
         ``fields`` is the flat payload; its ``event`` entry names the channel
-        listeners subscribe to. Returns the id of the appended entry.
+        listeners subscribe to and is required (see :func:`require_event_field`).
+        Returns the id of the appended entry.
         """
 
     @abstractmethod

--- a/python/bullmq/backends/postgres_backend.py
+++ b/python/bullmq/backends/postgres_backend.py
@@ -46,6 +46,16 @@ _CAPABILITIES = {"canBlockFor1Ms": True, "canDoubleTimeout": True}
 # carries the negative error code shared with the Redis backend.
 _BULLMQ_SQLSTATE = "BM001"
 
+# Max events fetched per `readEvents` round-trip (Redis XREAD has no such cap,
+# but a page keeps a long-idle consumer's catch-up read bounded).
+_EVENT_READ_BATCH = 100
+
+# Longest single LISTEN wait (seconds) inside a blocking `readEvents`. The
+# publisher coalesces NOTIFYs under concurrency (see `publish_event`), so a
+# wakeup may legitimately be skipped; re-reading the table on this cadence
+# bounds the resulting latency instead of stalling for the whole block timeout.
+_EVENT_POLL_INTERVAL = 0.25
+
 
 def _validate_prefix(prefix: Optional[str]) -> None:
     if prefix not in (None, "bull"):
@@ -99,6 +109,18 @@ def _json(value: Any) -> str:
 
 def _opt_str(value: Any) -> Optional[str]:
     return None if value is None else str(value)
+
+
+def _error_code(value: str) -> Optional[int]:
+    """`add_flow` returns a negative integer in the id column as an error/skip
+    sentinel (e.g. -5 = missing parent) rather than a job id, mirroring the
+    Redis `addJob` script's return convention. Returns the code, or ``None``
+    when the value is a real job id."""
+    try:
+        code = int(value)
+    except (TypeError, ValueError):
+        return None
+    return code if code < 0 else None
 
 
 def _to_int(value: Any) -> int:
@@ -222,6 +244,7 @@ class PostgresBackend(Backend):
         self.owns_connection = owns_connection
         self.schema = connection.schema
         self._ready = False
+        self._closing = False
 
     async def _run(self, command: str, params: list, *, op=None, job_id=None, parent_key=None, state=None):
         try:
@@ -242,6 +265,7 @@ class PostgresBackend(Backend):
         self._ready = True
 
     async def close(self, force: bool = False) -> None:
+        self._closing = True
         if self.owns_connection:
             await self.connection.close()
 
@@ -378,10 +402,17 @@ class PostgresBackend(Backend):
             jobs[index].id = job_id
         return ids
 
-    async def addFlow(self, entries: list[dict]) -> list[str]:
+    async def addFlow(self, entries: list[dict]) -> list:
         batch = [self._batch_entry(e["job"], e.get("is_parent", False)) for e in entries]
         result = await self._run("add_flow", [_jsonb(batch)], op="addJob")
-        ids = [str(row[0]) for row in result.rows]
+        ids: list = []
+        for row in result.rows:
+            value = str(row[0])
+            # Keep a negative sentinel an int: `FlowProducer` distinguishes an
+            # error code from a (deduplicated) string id by type, exactly as it
+            # does for the Redis backend's Lua return value.
+            code = _error_code(value)
+            ids.append(value if code is None else code)
         for index, job_id in enumerate(ids):
             entries[index]["job"].id = job_id
         return ids
@@ -739,11 +770,131 @@ class PostgresBackend(Backend):
     # Queue metadata & maintenance keys
     # ============================================================
 
+    async def setQueueMeta(self, values: dict) -> int:
+        if not values:
+            return 0
+        fields = list(values.keys())
+        result = await self._run(
+            "set_queue_meta",
+            [self.queue_name, fields, [str(values[f]) for f in fields]],
+        )
+        return result.rowcount if result.rowcount is not None else len(fields)
+
+    async def getQueueMetaField(self, field: str) -> Optional[str]:
+        row = (
+            await self._run("get_queue_meta_field", [self.queue_name, field])
+        ).first_map()
+        return None if row is None else _opt_str(row.get("value"))
+
+    async def getQueueMetaFields(self, fields: list) -> list:
+        if not fields:
+            return []
+        result = await self._run(
+            "get_queue_meta_fields", [self.queue_name, list(fields)]
+        )
+        found = {m["field"]: _opt_str(m.get("value")) for m in result.maps()}
+        return [found.get(field) for field in fields]
+
+    async def removeQueueMetaFields(self, fields: list) -> int:
+        if not fields:
+            return 0
+        result = await self._run(
+            "remove_queue_meta_fields", [self.queue_name, list(fields)]
+        )
+        return max(result.rowcount or 0, 0)
+
+    async def setRateLimit(self, expire_time_ms: int) -> None:
+        # Force the limiter window (mirrors Redis SET limiter=MAX PX expireTimeMs).
+        await self._run(
+            "set_rate_limit", [self.queue_name, expire_time_ms, _now_ms()]
+        )
+
+    async def removeRateLimitKey(self) -> int:
+        row = (await self._run("remove_rate_limit", [self.queue_name])).first_map() or {}
+        return _to_int(row.get("n"))
+
     async def trimEvents(self, max_length: int) -> Any:
         return None
 
     async def removeDeprecatedPriorityKey(self) -> Any:
         return None
+
+    # ============================================================
+    # Event stream
+    # ============================================================
+
+    async def publishEvent(self, fields: dict, max_events: int) -> str:
+        # `max_events` has no parameter here: the stream is trimmed server-side
+        # by `publish_event` using the queue's `opts.maxLenEvents` meta field.
+        payload = dict(fields)
+        event = payload.pop("event", None)
+        result = await self._run(
+            "publish_event", [self.queue_name, str(event), _jsonb(payload)]
+        )
+        row = result.first_map() or {}
+        return str(row.get("id"))
+
+    async def readEvents(self, id: str, block_timeout: int) -> Any:
+        if self._closing:
+            return None
+
+        # Resolve the cursor: '$' means "only events published from now on".
+        if id is None or str(id) == "$":
+            row = (
+                await self._run("read_events_max", [self.queue_name])
+            ).first_map() or {}
+            cursor = _to_int(row.get("max"))
+        else:
+            cursor = _to_int(id)
+
+        entries = await self._fetch_events(cursor)
+        if entries:
+            return [("events", entries)]
+
+        # Nothing pending: park on the events channel until something is
+        # published for this queue or the block timeout elapses.
+        deadline = time.monotonic() + max(block_timeout or 5000, 1) / 1000
+        while not self._closing:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            await self._wait_for_event(min(remaining, _EVENT_POLL_INTERVAL))
+            if self._closing:
+                return None
+            entries = await self._fetch_events(cursor)
+            if entries:
+                return [("events", entries)]
+        return None
+
+    async def _fetch_events(self, cursor: int) -> list:
+        """A page of events newer than ``cursor``, in the Redis XREAD entry
+        shape: ``[(entry_id, {field: value, ...}), ...]``."""
+        result = await self._run(
+            "read_events", [self.queue_name, cursor, _EVENT_READ_BATCH]
+        )
+        entries = []
+        for row in result.maps():
+            # The Redis stream stores every field as a string; mirror that so
+            # `QueueEvents` decodes identically on both backends.
+            fields = {"event": row["event"]}
+            for key, value in (row.get("data") or {}).items():
+                fields[key] = value if isinstance(value, str) else _json(value)
+            entries.append((str(row["id"]), fields))
+        return entries
+
+    async def _wait_for_event(self, timeout: float) -> None:
+        """Wait (up to ``timeout`` seconds) for a NOTIFY on the shared
+        ``bullmq_events`` channel naming this queue."""
+        try:
+            conn = await self.connection.ensure_events_channel()
+            async for notify in conn.notifies(timeout=timeout, stop_after=1):
+                if notify.payload == self.queue_name:
+                    return
+        except psycopg.Error:
+            # The listen connection dropped; rebuild it on the next wait and
+            # back off briefly so a persistent failure cannot spin hot.
+            await self.connection.reset_events_channel()
+            await asyncio.sleep(min(timeout, _EVENT_POLL_INTERVAL))
 
     # ============================================================
     # Worker blocking primitive

--- a/python/bullmq/backends/postgres_backend.py
+++ b/python/bullmq/backends/postgres_backend.py
@@ -22,7 +22,7 @@ from typing import Any, Optional, TYPE_CHECKING
 
 import psycopg
 
-from bullmq.backend import Backend
+from bullmq.backend import Backend, require_event_field
 from bullmq.backends.postgres_connection import PostgresConnection
 from bullmq.custom_errors import UnrecoverableError
 from bullmq.postgres import sql_loader
@@ -826,10 +826,11 @@ class PostgresBackend(Backend):
     async def publishEvent(self, fields: dict, max_events: int) -> str:
         # `max_events` has no parameter here: the stream is trimmed server-side
         # by `publish_event` using the queue's `opts.maxLenEvents` meta field.
+        event = require_event_field(fields)
         payload = dict(fields)
-        event = payload.pop("event", None)
+        payload.pop("event", None)
         result = await self._run(
-            "publish_event", [self.queue_name, str(event), _jsonb(payload)]
+            "publish_event", [self.queue_name, event, _jsonb(payload)]
         )
         row = result.first_map() or {}
         return str(row.get("id"))

--- a/python/bullmq/backends/postgres_connection.py
+++ b/python/bullmq/backends/postgres_connection.py
@@ -2,9 +2,13 @@
 
 Owns:
 
-* an async connection used for regular queries (serialized behind a lock), and
+* an async connection used for regular queries (serialized behind a lock),
 * a dedicated, long-lived ``LISTEN`` connection used by the blocking
-  "wait for job" primitive (lazily established).
+  "wait for job" primitive (lazily established), and
+* a second dedicated ``LISTEN`` connection for the event stream (also lazy).
+  The two waits keep separate connections because ``notifies()`` *consumes* a
+  notification: sharing one connection would let the job wait swallow the
+  wakeups the event consumer is parked on, and vice versa.
 
 The connection-level ``schema`` is the namespace for all queues (the SQL-native
 replacement for the Redis key ``prefix``). It is pinned on every connection's
@@ -184,6 +188,8 @@ class PostgresConnection:
         self._ready_lock = asyncio.Lock()
         self._listen_conn: Optional[psycopg.AsyncConnection] = None
         self._job_channel_listening = False
+        self._events_conn: Optional[psycopg.AsyncConnection] = None
+        self._events_channel_listening = False
         self._application_name: Optional[str] = None
 
     async def wait_until_ready(self) -> None:
@@ -268,6 +274,35 @@ class PostgresConnection:
         self._listen_conn = None
         self._job_channel_listening = False
 
+    async def ensure_events_channel(self) -> "psycopg.AsyncConnection":
+        """Return the event-stream LISTEN connection, subscribed to
+        ``bullmq_events`` once. Kept separate from the jobs channel connection
+        so neither wait consumes the other's notifications."""
+        if self._events_conn is None or self._events_conn.closed:
+            self._events_conn = await psycopg.AsyncConnection.connect(
+                self.conninfo, autocommit=True, options=self._options
+            )
+            if self._application_name:
+                await self._events_conn.execute(
+                    "SELECT set_config('application_name', %s, false)",
+                    (self._application_name,),
+                )
+            self._events_channel_listening = False
+        if not self._events_channel_listening:
+            await self._events_conn.execute(sql_loader.load_command("listen_events"))
+            self._events_channel_listening = True
+        return self._events_conn
+
+    async def reset_events_channel(self) -> None:
+        """Drop the event-stream LISTEN connection so the next wait re-establishes it."""
+        if self._events_conn is not None:
+            try:
+                await self._events_conn.close()
+            except Exception:
+                pass
+        self._events_conn = None
+        self._events_channel_listening = False
+
     async def set_application_name(self, name: str) -> None:
         if not name:
             return
@@ -278,11 +313,12 @@ class PostgresConnection:
             conn = await self._get_conn()
             async with conn.cursor() as cur:
                 await cur.execute("SELECT set_config('application_name', %s, false)", (name,))
-        if self._listen_conn is not None and not self._listen_conn.closed:
-            await self._listen_conn.execute(
-                "SELECT set_config('application_name', %s, false)",
-                (name,),
-            )
+        for conn in (self._listen_conn, self._events_conn):
+            if conn is not None and not conn.closed:
+                await conn.execute(
+                    "SELECT set_config('application_name', %s, false)",
+                    (name,),
+                )
 
     async def close(self) -> None:
         if self._listen_conn is not None:
@@ -292,6 +328,13 @@ class PostgresConnection:
                 pass
             self._listen_conn = None
             self._job_channel_listening = False
+        if self._events_conn is not None:
+            try:
+                await self._events_conn.close()
+            except Exception:
+                pass
+            self._events_conn = None
+            self._events_channel_listening = False
         if self._conn is not None:
             try:
                 await self._conn.close()

--- a/python/bullmq/backends/redis_backend.py
+++ b/python/bullmq/backends/redis_backend.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Optional, TYPE_CHECKING
 
-from bullmq.backend import Backend
+from bullmq.backend import Backend, require_event_field
 from bullmq.redis_connection import RedisConnection
 from bullmq.scripts import Scripts
 from bullmq.utils import (
@@ -446,6 +446,7 @@ class RedisBackend(Backend):
     # ============================================================
 
     async def publishEvent(self, fields: dict, max_events: int) -> str:
+        require_event_field(fields)
         return await self.conn.xadd(
             self.keys["events"],
             fields,

--- a/python/bullmq/backends/redis_backend.py
+++ b/python/bullmq/backends/redis_backend.py
@@ -406,6 +406,33 @@ class RedisBackend(Backend):
     # Queue metadata & maintenance keys
     # ============================================================
 
+    async def setQueueMeta(self, values: dict) -> int:
+        if not values:
+            return 0
+        return await self.conn.hset(self.keys["meta"], mapping=values)
+
+    async def getQueueMetaField(self, field: str) -> Optional[str]:
+        return await self.conn.hget(self.keys["meta"], field)
+
+    async def getQueueMetaFields(self, fields: list) -> list:
+        if not fields:
+            return []
+        return await self.conn.hmget(self.keys["meta"], fields)
+
+    async def removeQueueMetaFields(self, fields: list) -> int:
+        if not fields:
+            return 0
+        return await self.conn.hdel(self.keys["meta"], *fields)
+
+    async def setRateLimit(self, expire_time_ms: int) -> None:
+        # 2^53 - 1, equivalent to Number.MAX_SAFE_INTEGER on the Node side.
+        await self.conn.set(
+            self.keys["limiter"], 9007199254740991, px=expire_time_ms
+        )
+
+    async def removeRateLimitKey(self) -> int:
+        return await self.conn.delete(self.keys["limiter"])
+
     async def trimEvents(self, max_length: int) -> Any:
         return await self.connection.conn.xtrim(
             self.keys["events"], maxlen=max_length, approximate="~"
@@ -413,6 +440,22 @@ class RedisBackend(Backend):
 
     async def removeDeprecatedPriorityKey(self) -> Any:
         return await self.connection.conn.delete(self.toKey("priority"))
+
+    # ============================================================
+    # Event stream
+    # ============================================================
+
+    async def publishEvent(self, fields: dict, max_events: int) -> str:
+        return await self.conn.xadd(
+            self.keys["events"],
+            fields,
+            maxlen=max_events,
+            approximate=True,
+        )
+
+    async def readEvents(self, id: str, block_timeout: int) -> Any:
+        # redis-py takes BLOCK in ms, matching the JS surface's blockingTimeout.
+        return await self.conn.xread({self.keys["events"]: id}, block=block_timeout)
 
     # ============================================================
     # Worker blocking primitive

--- a/python/bullmq/queue.py
+++ b/python/bullmq/queue.py
@@ -8,6 +8,17 @@ from bullmq.backends import RedisBackend, create_backend
 from bullmq.job import Job
 
 
+def _to_int_or_none(value):
+    """Queue metadata is stored as text on every backend; decode it back to an
+    int, treating a missing or malformed value as "not configured"."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 class Queue(EventEmitter):
     """
     Instantiate a Queue object
@@ -108,20 +119,17 @@ class Queue(EventEmitter):
 
     async def rateLimit(self, expire_time_ms: int) -> None:
         """
-        Overrides the rate limit to be active for the next jobs by writing
-        the limiter key with a large value that expires after
-        `expire_time_ms` milliseconds. Mirrors `Queue.rateLimit` in Node.
+        Overrides the rate limit to be active for the next jobs by opening
+        the limiter window for `expire_time_ms` milliseconds. Mirrors
+        `Queue.rateLimit` in Node.
         """
-        # 2^53 - 1, equivalent to Number.MAX_SAFE_INTEGER on the Node side.
-        await self.client.set(
-            self.keys["limiter"], 9007199254740991, px=expire_time_ms
-        )
+        await self.backend.setRateLimit(expire_time_ms)
 
     async def removeRateLimitKey(self) -> int:
         """
         Removes the rate limit key. Returns the number of keys removed (0 or 1).
         """
-        return await self.client.delete(self.keys["limiter"])
+        return await self.backend.removeRateLimitKey()
 
     async def setGlobalConcurrency(self, concurrency: int) -> int:
         """
@@ -129,27 +137,21 @@ class Queue(EventEmitter):
         queue can process in parallel. A value of 1 effectively serializes
         the queue. Mirrors `Queue.setGlobalConcurrency` in Node.
         """
-        return await self.client.hset(
-            self.keys["meta"], "concurrency", concurrency
-        )
+        return await self.backend.setQueueMeta({"concurrency": concurrency})
 
     async def getGlobalConcurrency(self):
         """
         Returns the configured global concurrency value, or None if not set.
         """
-        value = await self.client.hget(self.keys["meta"], "concurrency")
-        if value is None:
-            return None
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            return None
+        return _to_int_or_none(
+            await self.backend.getQueueMetaField("concurrency")
+        )
 
     async def removeGlobalConcurrency(self) -> int:
         """
         Clear the global concurrency cap. Returns the number of fields removed.
         """
-        return await self.client.hdel(self.keys["meta"], "concurrency")
+        return await self.backend.removeQueueMetaFields(["concurrency"])
 
     async def setGlobalRateLimit(self, max_jobs: int, duration_ms: int) -> int:
         """
@@ -157,8 +159,8 @@ class Queue(EventEmitter):
         workers within a rolling `duration_ms` window. Mirrors
         `Queue.setGlobalRateLimit` in Node.
         """
-        return await self.client.hset(
-            self.keys["meta"], mapping={"max": max_jobs, "duration": duration_ms}
+        return await self.backend.setQueueMeta(
+            {"max": max_jobs, "duration": duration_ms}
         )
 
     async def getGlobalRateLimit(self):
@@ -166,25 +168,24 @@ class Queue(EventEmitter):
         Returns `{"max": int, "duration": int}` if a global rate limit is
         configured, otherwise None.
         """
-        max_jobs, duration_ms = await self.client.hmget(
-            self.keys["meta"], "max", "duration"
+        max_jobs, duration_ms = await self.backend.getQueueMetaFields(
+            ["max", "duration"]
         )
+        max_jobs = _to_int_or_none(max_jobs)
+        duration_ms = _to_int_or_none(duration_ms)
         if max_jobs is None or duration_ms is None:
             return None
-        try:
-            return {"max": int(max_jobs), "duration": int(duration_ms)}
-        except (TypeError, ValueError):
-            return None
+        return {"max": max_jobs, "duration": duration_ms}
 
     async def removeGlobalRateLimit(self) -> int:
         """
         Clear the global rate limit by removing both `max` and `duration`
-        from the queue's meta hash. Mirrors `Queue.removeGlobalRateLimit`
+        from the queue's metadata. Mirrors `Queue.removeGlobalRateLimit`
         in Node and is the counterpart to `setGlobalRateLimit`.
 
         Returns the number of fields actually removed (0, 1, or 2).
         """
-        return await self.client.hdel(self.keys["meta"], "max", "duration")
+        return await self.backend.removeQueueMetaFields(["max", "duration"])
 
     async def get_workers(self):
         """
@@ -436,9 +437,13 @@ class Queue(EventEmitter):
             return jobs
 
         job_ids = await self.backend.getRanges(current_types, start, end, asc)
-        tasks = [asyncio.create_task(Job.fromId(self, i)) for i in job_ids]
-        job_set, _ = await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
-        return [extract_result(job_task, self.emit) for job_task in job_set]
+        tasks = [asyncio.ensure_future(Job.fromId(self, i)) for i in job_ids]
+        # `gather` (unlike `asyncio.wait`, which yields an unordered *set* of
+        # tasks) preserves `job_ids` order -- the asc/desc ordering getRanges
+        # was just asked to produce. It also tolerates an empty queue, where
+        # `asyncio.wait` raises on an empty task list.
+        await asyncio.gather(*tasks, return_exceptions=True)
+        return [extract_result(job_task, self.emit) for job_task in tasks]
 
     def sanitizeJobTypes(self, types):
         current_types = list(types)

--- a/python/bullmq/queue_events.py
+++ b/python/bullmq/queue_events.py
@@ -1,23 +1,27 @@
 """
 QueueEvents — consume the global event stream of a BullMQ queue.
 
-Port of `src/classes/queue-events.ts`. The queue's Lua scripts and the
-worker XADD-publish lifecycle events (added/active/completed/failed/...)
-to a Redis stream at `{prefix}:{queueName}:events`. `QueueEvents`
-subscribes to that stream with a blocking XREAD and re-emits each
-entry through a Python `EventEmitter` so callers can wire listeners
-in a way that mirrors the Node API.
+Port of `src/classes/queue-events.ts`. Every datastore operation is routed
+through the :class:`~bullmq.backend.Backend` abstraction, so the same class
+serves both the Redis and the PostgreSQL backends: `opts["backend"]` selects
+which adapter is built, exactly as it does for `Queue` and `Worker`.
+
+The queue's operations publish lifecycle events (added/active/completed/
+failed/...) to the queue's event stream — a Redis stream at
+`{prefix}:{queueName}:events`, or the `event` table plus the shared
+`bullmq_events` notification channel on PostgreSQL. `QueueEvents` reads that
+stream with a blocking read and re-emits each entry through a Python
+`EventEmitter` so callers can wire listeners in a way that mirrors the Node API.
 
 Key design points:
-- The consumer must own a dedicated Redis connection. A blocking
-  `XREAD BLOCK` ties up the underlying socket, so reusing it for
-  other commands would deadlock.
+- The consumer must own a dedicated connection. A blocking read ties up the
+  underlying socket, so reusing it for other commands would deadlock.
 - Two emissions per event, mirroring Node: a generic channel
   (`'completed'`) and a per-job channel (`'completed:<jobId>'`).
   Callers can subscribe to either; the per-job channel is what makes
   the `Queue#waitUntilFinished` pattern work in Node.
 - `progress.data` and `completed.returnvalue` are JSON-encoded by the
-  scripts (so arbitrary payloads survive the stream) and decoded here
+  backend (so arbitrary payloads survive the stream) and decoded here
   to match Node's listener contract.
 """
 
@@ -25,18 +29,16 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import Optional, Union
+from typing import Optional
 
-import redis.asyncio as redis
-
+from bullmq.backends import RedisBackend, create_backend
 from bullmq.event_emitter import EventEmitter
-from bullmq.queue_keys import QueueKeys
 from bullmq.redis_connection import RedisConnection
 from bullmq.types.queue_events_options import QueueEventsOptions
 from bullmq.utils import isRedisVersionLowerThan
 
 
-# Events whose payload is JSON-encoded by the Lua scripts and must be
+# Events whose payload is JSON-encoded by the backend and must be
 # decoded before being handed to listeners.
 _JSON_DECODE_FIELDS = {
     "progress": "data",
@@ -60,7 +62,7 @@ class QueueEvents(EventEmitter):
         super().__init__()
         opts = dict(opts or {})
         # Defaults mirror Node. blockingTimeout is in ms to keep parity
-        # with the JS surface; we convert at the call site.
+        # with the JS surface.
         opts.setdefault("blockingTimeout", 10000)
         opts.setdefault("lastEventId", "$")
         opts.setdefault("autorun", True)
@@ -69,24 +71,20 @@ class QueueEvents(EventEmitter):
         self.opts = opts
         self.prefix = opts.get("prefix", "bull")
 
-        connection_opts: Union[dict, str, redis.Redis] = opts.get(
-            "connection", {}
+        # A dedicated backend (and therefore a dedicated connection): the
+        # blocking stream read parks the socket, so it must not be shared with
+        # a Queue or Worker.
+        self.backend = create_backend(name, opts)
+        # Compatibility handles for tests / callers that read the raw client or
+        # connection directly (Redis backend only). All operations go through
+        # `backend`.
+        self.redisConnection = (
+            self.backend.connection if isinstance(self.backend, RedisBackend) else None
         )
-        # `RedisConnection` calls `register_script` for every BullMQ
-        # Lua script on construction. We don't use any of them here,
-        # but `register_script` in redis-py only computes/caches the
-        # SHA client-side -- there's no `SCRIPT LOAD` round-trip until
-        # someone actually calls `EVALSHA`. The extra work is therefore
-        # local, bounded, and dominated by the connection setup itself.
-        self.redisConnection = RedisConnection(
-            connection_opts,
-            skipVersionCheck=opts.get("skipVersionCheck", False),
-        )
-        self.client = self.redisConnection.conn
+        self.client = getattr(self.backend, "conn", None)
 
-        queue_keys = QueueKeys(self.prefix)
-        self.keys = queue_keys.getKeys(name)
-        self.qualifiedName = queue_keys.getQueueQualifiedName(name)
+        self.keys = self.backend.keys
+        self.qualifiedName = self.backend.qualifiedName
 
         self.running = False
         self.closing = False
@@ -118,14 +116,26 @@ class QueueEvents(EventEmitter):
             raise Exception("QueueEvents is already running.")
 
         # Register the current task so `close()` can interrupt the
-        # blocking XREAD even when the caller spawned the consumer
+        # blocking read even when the caller spawned the consumer
         # themselves (`autorun=False` + `asyncio.create_task(events.run())`).
         if self._consumer_task is None:
             self._consumer_task = asyncio.current_task()
 
-        # Validate Redis supports Streams (>= 5.0). `skipVersionCheck=True`
-        # bypasses the INFO round-trip for cases where the caller knows
-        # the server is compatible.
+        await self._validate_backend_version()
+
+        self.running = True
+        try:
+            await self._consume_events()
+        finally:
+            self.running = False
+
+    async def _validate_backend_version(self) -> None:
+        """Validate Redis supports Streams (>= 5.0). `skipVersionCheck=True`
+        bypasses the INFO round-trip for cases where the caller knows the
+        server is compatible. Non-Redis backends enforce their own minimum
+        version when their connection is established."""
+        if self.redisConnection is None:
+            return
         version = await self.redisConnection.getRedisVersion()
         if version and isRedisVersionLowerThan(
             version, RedisConnection.minimum_version
@@ -135,25 +145,14 @@ class QueueEvents(EventEmitter):
                 f"({RedisConnection.minimum_version}) for QueueEvents."
             )
 
-        self.running = True
-        try:
-            await self._consume_events()
-        finally:
-            self.running = False
-
     async def _consume_events(self) -> None:
         """Block on the events stream and re-emit each entry."""
-        key = self.keys["events"]
         last_id = self.opts.get("lastEventId") or "$"
-        # redis-py's xread takes block in ms with decode_responses on,
-        # matching ioredis' BLOCK argument.
         block_ms = int(self.opts.get("blockingTimeout", 10000))
 
         while not self.closing:
             try:
-                data = await self.client.xread(
-                    {key: last_id}, block=block_ms
-                )
+                data = await self.backend.readEvents(last_id, block_ms)
             except asyncio.CancelledError:
                 raise
             except Exception as err:
@@ -171,7 +170,8 @@ class QueueEvents(EventEmitter):
                 # re-check the closing flag so close() stays responsive.
                 continue
 
-            # redis-py returns: [(stream_name, [(id, {field: value, ...}), ...])]
+            # Backends return the Redis XREAD shape:
+            # [(stream_key, [(id, {field: value, ...}), ...])]
             _, entries = data[0]
             for entry_id, fields in entries:
                 last_id = entry_id
@@ -183,7 +183,7 @@ class QueueEvents(EventEmitter):
         if not event:
             return
 
-        # JSON-decode the fields the scripts encoded so listeners see
+        # JSON-decode the fields the backend encoded so listeners see
         # the same Python objects the producer side passed in.
         json_field = _JSON_DECODE_FIELDS.get(event)
         if json_field and json_field in args:
@@ -191,7 +191,7 @@ class QueueEvents(EventEmitter):
                 args[json_field] = json.loads(args[json_field])
             except (TypeError, ValueError):
                 # Leave the raw string in place: a malformed payload
-                # is a script-side bug we don't want to swallow into a
+                # is a producer-side bug we don't want to swallow into a
                 # KeyError downstream, but we also don't want to break
                 # the entire consumer for one bad entry.
                 pass
@@ -211,7 +211,7 @@ class QueueEvents(EventEmitter):
 
     async def close(self) -> None:
         """
-        Stop consuming events and release the Redis connection.
+        Stop consuming events and release the underlying connection.
         Idempotent: subsequent calls are no-ops. Works for both
         `autorun=True` (we own the task) and `autorun=False` (the
         caller spawned `events.run()` themselves — `run` auto-registers
@@ -231,7 +231,7 @@ class QueueEvents(EventEmitter):
             and not task.done()
             and task is not asyncio.current_task()
         ):
-            # XREAD BLOCK is parked on the socket; cancel forces it to
+            # The blocking read is parked on the socket; cancel forces it to
             # unwind. We swallow CancelledError because that's exactly
             # what we asked for.
             task.cancel()
@@ -245,6 +245,6 @@ class QueueEvents(EventEmitter):
                 pass
 
         try:
-            await self.redisConnection.close()
+            await self.backend.close()
         finally:
             self.closed = True

--- a/python/bullmq/queue_events_producer.py
+++ b/python/bullmq/queue_events_producer.py
@@ -5,15 +5,17 @@ Port of `src/classes/queue-events-producer.ts`. Useful for surfacing
 application-level lifecycle events on the same stream that
 `QueueEvents` consumes, so dashboards and progress UIs see them
 uniformly with the framework-emitted events.
+
+Like the other public classes, it routes every datastore operation through the
+:class:`~bullmq.backend.Backend` abstraction, so `opts["backend"]` selects the
+Redis or the PostgreSQL adapter.
 """
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Optional
 
-import redis.asyncio as redis
-
-from bullmq.queue_keys import QueueKeys
+from bullmq.backends import RedisBackend, create_backend
 from bullmq.redis_connection import RedisConnection
 from bullmq.types.queue_events_options import QueueEventsProducerOptions
 from bullmq.utils import isRedisVersionLowerThan
@@ -22,8 +24,8 @@ from bullmq.utils import isRedisVersionLowerThan
 class QueueEventsProducer:
     """
     Lightweight publisher for the queue's events stream. Unlike
-    `QueueEvents`, no dedicated connection is required because XADD
-    is non-blocking.
+    `QueueEvents`, no dedicated connection is required because
+    appending an event is non-blocking.
     """
 
     def __init__(
@@ -36,28 +38,27 @@ class QueueEventsProducer:
         self.opts = opts
         self.prefix = opts.get("prefix", "bull")
 
-        connection_opts: Union[dict, str, redis.Redis] = opts.get(
-            "connection", {}
+        self.backend = create_backend(name, opts)
+        # Compatibility handles for tests / callers that read the raw client or
+        # connection directly (Redis backend only).
+        self.redisConnection = (
+            self.backend.connection if isinstance(self.backend, RedisBackend) else None
         )
-        self.redisConnection = RedisConnection(
-            connection_opts,
-            skipVersionCheck=opts.get("skipVersionCheck", False),
-        )
-        self.client = self.redisConnection.conn
+        self.client = getattr(self.backend, "conn", None)
 
-        queue_keys = QueueKeys(self.prefix)
-        self.keys = queue_keys.getKeys(name)
-        self.qualifiedName = queue_keys.getQueueQualifiedName(name)
+        self.keys = self.backend.keys
+        self.qualifiedName = self.backend.qualifiedName
 
         self.closing = False
         # Cached on first publishEvent() so we don't pay the INFO
-        # round-trip per call. None means "not yet validated".
+        # round-trip per call.
         self._version_validated = False
 
     async def _validate_redis_version(self) -> None:
         """Lazily ensure the connected Redis supports Streams (>= 5.0).
-        Honours `skipVersionCheck` via the underlying RedisConnection."""
-        if self._version_validated:
+        Honours `skipVersionCheck` via the underlying RedisConnection. Non-Redis
+        backends enforce their own minimum version on connect."""
+        if self._version_validated or self.redisConnection is None:
             return
         version = await self.redisConnection.getRedisVersion()
         if version and isRedisVersionLowerThan(
@@ -78,19 +79,19 @@ class QueueEventsProducer:
         Publish a custom event to the queue's stream. `args` must
         include an `eventName` field that identifies the channel
         listeners subscribe to; everything else in `args` is stored
-        verbatim as stream fields.
+        verbatim as event fields.
 
         @param args: Event payload. Must contain `eventName`.
-        @param maxEvents: Approximate stream cap (XADD MAXLEN ~).
+        @param maxEvents: Approximate stream cap.
         """
         if "eventName" not in args:
             raise ValueError("publishEvent requires an 'eventName' key")
 
         await self._validate_redis_version()
 
-        # Build the fields dict in script-friendly order: 'event'
-        # first to match the consumer's `args.pop("event", ...)` in
-        # QueueEvents._dispatch_entry, with the rest of the payload
+        # Build the fields dict in consumer-friendly order: 'event'
+        # first to match `QueueEvents._dispatch_entry`'s
+        # `args.pop("event", ...)`, with the rest of the payload
         # appended in input order.
         fields = {"event": args["eventName"]}
         for k, v in args.items():
@@ -98,16 +99,11 @@ class QueueEventsProducer:
                 continue
             fields[k] = v
 
-        await self.client.xadd(
-            self.keys["events"],
-            fields,
-            maxlen=maxEvents,
-            approximate=True,
-        )
+        await self.backend.publishEvent(fields, maxEvents)
 
     async def close(self) -> None:
-        """Close the underlying Redis connection."""
+        """Close the underlying connection."""
         if self.closing:
             return
         self.closing = True
-        await self.redisConnection.close()
+        await self.backend.close()

--- a/python/bullmq/types/queue_events_options.py
+++ b/python/bullmq/types/queue_events_options.py
@@ -12,12 +12,29 @@ class QueueEventsOptions(TypedDict, total=False):
     Prefix for all queue keys.
     """
 
+    backend: str
+    """
+    Datastore backend to use: 'redis' (default) or 'postgres'. Must match the
+    backend the queue itself was created with.
+
+    @default 'redis'
+    """
+
     connection: Union[dict[str, Any], redis.Redis, str]
     """
-    Options for connecting to a Redis instance. QueueEvents requires a
-    dedicated connection because XREAD BLOCK ties up the connection
-    for the duration of the blocking call; passing a shared connection
+    Options for connecting to the datastore (a libpq connection string or
+    parameter dict when `backend` is 'postgres'). QueueEvents requires a
+    dedicated connection because the blocking stream read ties up the
+    connection for the duration of the call; passing a shared connection
     would starve other operations.
+    """
+
+    schema: str
+    """
+    PostgreSQL schema used to namespace queues (the SQL-native replacement for
+    `prefix`). Only used when `backend` is 'postgres'.
+
+    @default 'bullmq'
     """
 
     autorun: bool
@@ -61,5 +78,7 @@ class QueueEventsProducerOptions(TypedDict, total=False):
     """
 
     prefix: str
+    backend: str
     connection: Union[dict[str, Any], redis.Redis, str]
+    schema: str
     skipVersionCheck: bool

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -37,15 +37,17 @@ _POSTGRES_ONLY_FILES = [
 
 collect_ignore = _REDIS_ONLY_FILES if PG_ENABLED else _POSTGRES_ONLY_FILES
 
-# Individual tests that assert against the raw Redis client (event-stream
-# ``XLEN``, key enumeration) — the underlying operations are covered by other,
-# backend-agnostic tests, so these are skipped on the Postgres backend.
+# Individual tests that drive the raw Redis client (event-stream ``XLEN``, key
+# enumeration, deleting a job hash to simulate corruption) — the underlying
+# operations are covered by other, backend-agnostic tests, so these are skipped
+# on the Postgres backend.
 _REDIS_ONLY_TESTS = {
     "test_is_paused_with_custom_prefix",
     "test_trim_events_manually",
     "test_trim_events_manually_with_custom_prefix",
     "test_drain_count_added_unprocessed_jobs",
     "test_obliterate_with_force_true_should_succeed_with_active_jobs",
+    "test_get_jobs_skips_missing_hash_and_backfills_waiting_range",
 }
 
 
@@ -92,4 +94,8 @@ def _pg_backend(monkeypatch):
     monkeypatch.setattr("bullmq.queue.create_backend", _pg_create_backend)
     monkeypatch.setattr("bullmq.worker.create_backend", _pg_create_backend)
     monkeypatch.setattr("bullmq.flow_producer.create_backend", _pg_create_backend)
+    monkeypatch.setattr("bullmq.queue_events.create_backend", _pg_create_backend)
+    monkeypatch.setattr(
+        "bullmq.queue_events_producer.create_backend", _pg_create_backend
+    )
     yield

--- a/python/tests/postgres_backend_test.py
+++ b/python/tests/postgres_backend_test.py
@@ -480,6 +480,17 @@ class TestPostgresBackendEventStream(unittest.IsolatedAsyncioTestCase):
             "publish_event", ["queue", "custom", '{"foo":"bar","n":7}']
         )
 
+    async def test_publish_event_rejects_a_payload_with_no_event_name(self):
+        """Both failure modes are silent -- Postgres would persist the literal
+        'None' as the event name -- so the contract is enforced up front."""
+        backend = PostgresBackend("queue", SimpleNamespace(schema="bullmq"))
+        backend._run = AsyncMock()
+
+        for payload in ({}, {"jobId": "1"}, {"event": None}, {"event": ""}):
+            with self.assertRaises(ValueError):
+                await backend.publishEvent(payload, 1000)
+        backend._run.assert_not_awaited()
+
     async def test_read_events_resolves_the_dollar_cursor_to_the_current_max(self):
         backend = PostgresBackend("queue", SimpleNamespace(schema="bullmq"))
         backend._run = AsyncMock(

--- a/python/tests/postgres_backend_test.py
+++ b/python/tests/postgres_backend_test.py
@@ -15,6 +15,7 @@ from bullmq.backends.postgres_connection import (
     run_migrations,
 )
 from bullmq.job import Job
+from bullmq.postgres import sql_loader
 
 
 class TestPostgresBackendJobMapping(unittest.TestCase):
@@ -197,6 +198,66 @@ class TestPostgresConnection(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(connect.await_count, 2)
         first_conn.execute.assert_awaited_once_with("LISTEN bullmq_jobs")
         second_conn.execute.assert_awaited_once_with("LISTEN bullmq_jobs")
+
+    async def test_ensure_events_channel_listens_once_per_connection(self):
+        events_conn = SimpleNamespace(closed=False, execute=AsyncMock())
+        connection = PostgresConnection()
+
+        with patch(
+            "bullmq.backends.postgres_connection.psycopg.AsyncConnection.connect",
+            AsyncMock(return_value=events_conn),
+        ):
+            first = await connection.ensure_events_channel()
+            second = await connection.ensure_events_channel()
+
+        self.assertIs(first, second)
+        events_conn.execute.assert_awaited_once_with(
+            sql_loader.load_command("listen_events")
+        )
+
+    async def test_events_channel_uses_a_connection_of_its_own(self):
+        """The two waits must not share a connection: `notifies()` consumes a
+        notification, so one wait would swallow the other's wakeups."""
+        jobs_conn = SimpleNamespace(closed=False, execute=AsyncMock())
+        events_conn = SimpleNamespace(closed=False, execute=AsyncMock())
+        connect = AsyncMock(side_effect=[jobs_conn, events_conn])
+        connection = PostgresConnection()
+
+        with patch(
+            "bullmq.backends.postgres_connection.psycopg.AsyncConnection.connect",
+            connect,
+        ):
+            jobs = await connection.ensure_job_channel()
+            events = await connection.ensure_events_channel()
+
+        self.assertIsNot(jobs, events)
+        self.assertEqual(connect.await_count, 2)
+        jobs_conn.execute.assert_awaited_once_with("LISTEN bullmq_jobs")
+        events_conn.execute.assert_awaited_once_with(
+            sql_loader.load_command("listen_events")
+        )
+
+    async def test_reset_events_channel_forces_new_listen_connection(self):
+        first_conn = SimpleNamespace(
+            closed=False, execute=AsyncMock(), close=AsyncMock()
+        )
+        second_conn = SimpleNamespace(closed=False, execute=AsyncMock())
+        connect = AsyncMock(side_effect=[first_conn, second_conn])
+        connection = PostgresConnection()
+
+        with patch(
+            "bullmq.backends.postgres_connection.psycopg.AsyncConnection.connect",
+            connect,
+        ):
+            await connection.ensure_events_channel()
+            await connection.reset_events_channel()
+            await connection.ensure_events_channel()
+
+        first_conn.close.assert_awaited_once()
+        self.assertEqual(connect.await_count, 2)
+        second_conn.execute.assert_awaited_once_with(
+            sql_loader.load_command("listen_events")
+        )
 
     async def test_reset_job_channel_forces_new_listen_connection(self):
         first_conn = SimpleNamespace(closed=False, execute=AsyncMock(), close=AsyncMock())
@@ -388,6 +449,166 @@ class TestPostgresBackendWaitForJob(unittest.IsolatedAsyncioTestCase):
         self.assertGreaterEqual(marker[2], expected_min)
         self.assertLessEqual(marker[2], expected_max)
         self.assertEqual(backend._next_delay_ms.await_count, 2)
+
+
+class _EventsFakeConnection:
+    """Minimal PostgresConnection stand-in for the event-stream tests."""
+
+    def __init__(self, notify_conns=None):
+        self.schema = "bullmq"
+        self.ensure_events_channel = (
+            AsyncMock(side_effect=notify_conns)
+            if notify_conns
+            else AsyncMock(return_value=_IdleNotifiesConnection())
+        )
+        self.reset_events_channel = AsyncMock()
+
+
+class TestPostgresBackendEventStream(unittest.IsolatedAsyncioTestCase):
+    async def test_publish_event_splits_the_event_name_from_the_payload(self):
+        backend = PostgresBackend("queue", SimpleNamespace(schema="bullmq"))
+        backend._run = AsyncMock(
+            return_value=SimpleNamespace(first_map=lambda: {"id": 42})
+        )
+
+        event_id = await backend.publishEvent(
+            {"event": "custom", "foo": "bar", "n": 7}, 1000
+        )
+
+        self.assertEqual(event_id, "42")
+        backend._run.assert_awaited_once_with(
+            "publish_event", ["queue", "custom", '{"foo":"bar","n":7}']
+        )
+
+    async def test_read_events_resolves_the_dollar_cursor_to_the_current_max(self):
+        backend = PostgresBackend("queue", SimpleNamespace(schema="bullmq"))
+        backend._run = AsyncMock(
+            side_effect=[
+                SimpleNamespace(first_map=lambda: {"max": 7}),
+                SimpleNamespace(
+                    maps=lambda: [
+                        {"id": 8, "event": "completed", "data": {"jobId": "1"}}
+                    ]
+                ),
+            ]
+        )
+
+        data = await backend.readEvents("$", 10000)
+
+        self.assertEqual(data, [("events", [("8", {"event": "completed", "jobId": "1"})])])
+        self.assertEqual(backend._run.await_args_list[1].args[1][1], 7)
+
+    async def test_read_events_stringifies_non_string_payload_values(self):
+        """The Redis stream stores every field as a string; the Postgres
+        adapter must match so `QueueEvents` decodes identically on both."""
+        backend = PostgresBackend("queue", SimpleNamespace(schema="bullmq"))
+        backend._run = AsyncMock(
+            return_value=SimpleNamespace(
+                maps=lambda: [
+                    {
+                        "id": 3,
+                        "event": "delayed",
+                        "data": {"jobId": "1", "delay": 1700, "ok": True},
+                    }
+                ]
+            )
+        )
+
+        data = await backend.readEvents("2", 10000)
+
+        self.assertEqual(
+            data[0][1][0][1],
+            {"event": "delayed", "jobId": "1", "delay": "1700", "ok": "true"},
+        )
+
+    async def test_read_events_returns_none_when_the_block_timeout_elapses(self):
+        backend = PostgresBackend("queue", _EventsFakeConnection())
+        backend._fetch_events = AsyncMock(return_value=[])
+
+        self.assertIsNone(await backend.readEvents("1", 10))
+
+    async def test_read_events_reconnects_the_channel_after_a_psycopg_error(self):
+        connection = _EventsFakeConnection(
+            [_FailingNotifiesConnection(), _IdleNotifiesConnection()]
+        )
+        backend = PostgresBackend("queue", connection)
+        backend._fetch_events = AsyncMock(
+            side_effect=[[], [], [("9", {"event": "completed"})]]
+        )
+
+        data = await backend.readEvents("1", 2000)
+
+        self.assertEqual(data, [("events", [("9", {"event": "completed"})])])
+        connection.reset_events_channel.assert_awaited_once()
+        self.assertEqual(connection.ensure_events_channel.await_count, 2)
+
+    async def test_read_events_short_circuits_once_the_backend_is_closed(self):
+        backend = PostgresBackend("queue", SimpleNamespace(schema="bullmq"))
+        backend._run = AsyncMock()
+        backend._closing = True
+
+        self.assertIsNone(await backend.readEvents("$", 10000))
+        backend._run.assert_not_awaited()
+
+
+class TestPostgresBackendQueueMeta(unittest.IsolatedAsyncioTestCase):
+    async def test_set_queue_meta_sends_parallel_field_and_value_arrays(self):
+        backend = PostgresBackend("queue", SimpleNamespace(schema="bullmq"))
+        backend._run = AsyncMock(return_value=SimpleNamespace(rowcount=2))
+
+        written = await backend.setQueueMeta({"max": 100, "duration": 1000})
+
+        self.assertEqual(written, 2)
+        backend._run.assert_awaited_once_with(
+            "set_queue_meta",
+            ["queue", ["max", "duration"], ["100", "1000"]],
+        )
+
+    async def test_get_queue_meta_fields_preserves_order_and_fills_gaps(self):
+        backend = PostgresBackend("queue", SimpleNamespace(schema="bullmq"))
+        # Rows come back in arbitrary order and omit fields that are unset.
+        backend._run = AsyncMock(
+            return_value=SimpleNamespace(
+                maps=lambda: [{"field": "duration", "value": "1000"}]
+            )
+        )
+
+        values = await backend.getQueueMetaFields(["max", "duration"])
+
+        self.assertEqual(values, [None, "1000"])
+
+    async def test_empty_field_lists_short_circuit_without_a_query(self):
+        backend = PostgresBackend("queue", SimpleNamespace(schema="bullmq"))
+        backend._run = AsyncMock()
+
+        self.assertEqual(await backend.setQueueMeta({}), 0)
+        self.assertEqual(await backend.getQueueMetaFields([]), [])
+        self.assertEqual(await backend.removeQueueMetaFields([]), 0)
+        backend._run.assert_not_awaited()
+
+
+class TestPostgresBackendAddFlow(unittest.IsolatedAsyncioTestCase):
+    async def test_add_flow_returns_negative_sentinels_as_ints(self):
+        """`add_flow` reports a not-inserted entry with a negative code in the
+        id column (-5 = missing parent). It must stay an int so `FlowProducer`
+        tells it apart from a (deduplicated) string job id, exactly as it does
+        for the Redis backend's Lua return value."""
+        backend = PostgresBackend("queue", SimpleNamespace(schema="bullmq"))
+        backend._run = AsyncMock(
+            return_value=SimpleNamespace(rows=[("-5",), ("7",), ("custom-id",)])
+        )
+        backend._batch_entry = lambda job, is_parent: {}
+        entries = [
+            {"job": SimpleNamespace(id=None)},
+            {"job": SimpleNamespace(id=None)},
+            {"job": SimpleNamespace(id=None)},
+        ]
+
+        ids = await backend.addFlow(entries)
+
+        self.assertEqual(ids, [-5, "7", "custom-id"])
+        self.assertIsInstance(ids[0], int)
+        self.assertIsInstance(ids[1], str)
 
 
 class TestPostgresBackendLockExtension(unittest.IsolatedAsyncioTestCase):

--- a/python/tests/queue_events_test.py
+++ b/python/tests/queue_events_test.py
@@ -153,6 +153,19 @@ class TestQueueEvents(unittest.IsolatedAsyncioTestCase):
         await events.close()
         self.assertTrue(events.closed)
 
+    async def test_producer_rejects_a_publish_without_an_event_name(self):
+        """`eventName` is required; the backend re-checks the `event` field it
+        maps to, so neither layer can publish an event that never dispatches."""
+        queue_name = f"__test_qe_producer_bad__{uuid4().hex}"
+        producer = QueueEventsProducer(queue_name, {"prefix": prefix})
+        try:
+            with self.assertRaises(ValueError):
+                await producer.publishEvent({"foo": "bar"})
+            with self.assertRaises(ValueError):
+                await producer.backend.publishEvent({"foo": "bar"}, 1000)
+        finally:
+            await producer.close()
+
     async def test_producer_publishes_custom_event(self):
         """`QueueEventsProducer.publishEvent` writes to the same
         stream `QueueEvents` consumes; the custom event must round

--- a/python/tests/queue_events_test.py
+++ b/python/tests/queue_events_test.py
@@ -12,6 +12,11 @@ import redis.asyncio as redis
 
 from bullmq import Job, Queue, QueueEvents, QueueEventsProducer, Worker
 
+try:
+    from bullmq.backends.postgres_backend import PostgresBackend
+except ImportError:  # the optional 'postgres' extra (psycopg) is not installed
+    PostgresBackend = None
+
 
 prefix = os.environ.get("BULLMQ_TEST_PREFIX") or "bull"
 
@@ -176,6 +181,41 @@ class TestQueueEvents(unittest.IsolatedAsyncioTestCase):
         finally:
             await producer.close()
             await events.close()
+
+
+@unittest.skipIf(
+    PostgresBackend is None, "requires the optional 'postgres' extra (psycopg)"
+)
+class TestQueueEventsBackendSelection(unittest.IsolatedAsyncioTestCase):
+    """`QueueEvents` and `QueueEventsProducer` must honour `opts['backend']`
+    exactly like `Queue` and `Worker` do, instead of unconditionally building a
+    Redis connection (which fails outright on a PostgreSQL DSN)."""
+
+    # A syntactically valid DSN is enough: both classes build their backend
+    # lazily, so no server is contacted during construction or close.
+    OPTS = {
+        "backend": "postgres",
+        "connection": "postgresql://postgres:postgres@127.0.0.1:5432/postgres",
+        "schema": "bullmq_backend_selection",
+    }
+
+    async def test_queue_events_builds_the_postgres_backend(self):
+        events = QueueEvents(
+            "__test_qe_backend__", {**self.OPTS, "autorun": False}
+        )
+        try:
+            self.assertIsInstance(events.backend, PostgresBackend)
+            self.assertIsNone(events.redisConnection)
+        finally:
+            await events.close()
+
+    async def test_queue_events_producer_builds_the_postgres_backend(self):
+        producer = QueueEventsProducer("__test_qep_backend__", self.OPTS)
+        try:
+            self.assertIsInstance(producer.backend, PostgresBackend)
+            self.assertIsNone(producer.redisConnection)
+        finally:
+            await producer.close()
 
 
 if __name__ == "__main__":

--- a/python/tests/queue_test.py
+++ b/python/tests/queue_test.py
@@ -89,6 +89,18 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
 
         await queue.close()
 
+    async def test_get_jobs_returns_an_empty_list_for_an_empty_queue(self):
+        """Regression: the non-Redis path used `asyncio.wait`, which raises
+        `ValueError: Set of Tasks/Futures is empty` when there is nothing to
+        fetch."""
+        queue_name = f"__test_queue__{uuid4().hex}"
+        queue = Queue(queue_name, {"prefix": prefix})
+        try:
+            self.assertEqual(await queue.getWaiting(), [])
+            self.assertEqual(await queue.getJobs(["waiting", "completed"]), [])
+        finally:
+            await queue.close()
+
     async def test_get_job_state(self):
         queue = Queue(queueName, {"prefix": prefix})
         job = await queue.add("test-job", {"foo": "bar"}, {})
@@ -423,8 +435,13 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
         await queue.pause()
         await queue.retryJobs({'count': 2})
 
-        waiting_count = await queue.getJobCounts('waiting')
-        self.assertEqual(waiting_count['waiting'], job_count)
+        # Count 'waiting' + 'paused': a paused queue reports its pending jobs
+        # under 'waiting' on Redis (pause is an O(1) meta flag that leaves the
+        # wait list alone) but under 'paused' on PostgreSQL. The sum is what
+        # this test is really asserting -- that all 8 jobs were re-enqueued.
+        self.assertEqual(
+            await queue.getJobCountByTypes('waiting', 'paused'), job_count
+        )
 
         await queue.close()
         await worker.close()
@@ -715,15 +732,17 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
         for i in range(1, max_jobs + 1):
             await queue.add("test", {"foo": "bar", "num": i}, {})
         
-        # Check initial count
-        initial_count = await queue.getJobCountByTypes("waiting")
+        # Check initial count. 'waiting' + 'paused' because a paused queue
+        # reports its pending jobs under 'waiting' on Redis and under 'paused'
+        # on PostgreSQL; the sum is the backend-agnostic pending count.
+        initial_count = await queue.getJobCountByTypes("waiting", "paused")
         self.assertEqual(initial_count, max_jobs)
         
         # Drain the queue
         await queue.drain()
         
         # Check that all jobs are removed
-        count_after_drain = await queue.getJobCountByTypes("waiting")
+        count_after_drain = await queue.getJobCountByTypes("waiting", "paused")
         self.assertEqual(count_after_drain, 0)
         
         await queue.close()


### PR DESCRIPTION
Fixes #4616.

## The reported bug

`QueueEvents` and `QueueEventsProducer` were the last two public Python classes that had never been routed through the `Backend` abstraction. Both hardcoded `RedisConnection(...)` in `__init__` and called `xread` / `xadd` on the raw client, so `opts["backend"]` was ignored and a PostgreSQL DSN went straight into `redis.from_url()`:

```
ValueError: Redis URL must specify one of the following schemes (redis://, rediss://, unix://)
```

Reproduced on `master`, not just 3.0.4.

## The fix

Ported the TypeScript design, where `publishEvent` / `readEvents` are already part of the `QueueBackend` interface and implemented by both adapters:

- `Backend` — added the `publishEvent` / `readEvents` contract.
- `RedisBackend` — `XADD` / `XREAD BLOCK`.
- `PostgresBackend` — uses the SQL that already existed but was unused from Python (`publish_event`, `read_events`, `read_events_max`, `listen_events`), resolving the `'$'` cursor and mapping rows into the Redis `XREAD` shape so `QueueEvents` decodes identically on both backends.
- `QueueEvents` / `QueueEventsProducer` — build via `create_backend`; `redisConnection` and `client` are kept as Redis-only compatibility handles, exactly as `Queue` does.

Two details worth calling out:

**A second dedicated LISTEN connection.** psycopg's `conn.notifies()` *consumes* a notification, so if the event consumer shared the `bullmq_jobs` connection, the worker's `waitForJob` would swallow the wakeups it is parked on (and vice versa). The TypeScript adapter can share a client because it uses fan-out `on('notification')` callbacks; Python cannot, so `PostgresConnection` now lazily opens a separate connection for `bullmq_events`.

**NOTIFY is not guaranteed.** `publish_event` deliberately skips its `pg_notify` under concurrency via a per-queue `pg_try_advisory_xact_lock`, so the blocking read re-polls the `event` table every 250 ms rather than trusting NOTIFY alone.

## Additional gaps fixed

Running the Python suite against Postgres surfaced three more bugs in the same family, all of which had been failing on `master`:

1. **Queue metadata and rate limit bypassed the backend.** `Queue.rateLimit`, `removeRateLimitKey` and the six global concurrency / rate-limit accessors used the raw `self.client`, which is `None` on Postgres — every call raised `AttributeError: 'NoneType' object has no attribute 'set'`. Routed through new `setQueueMeta` / `getQueueMetaField` / `getQueueMetaFields` / `removeQueueMetaFields` / `setRateLimit` / `removeRateLimitKey` backend methods mirroring the TS interface. The Postgres SQL for all of these already existed.

2. **`addFlow` swallowed the missing-parent error.** `add_flow` already returns a `-5` sentinel in the id column, but the Python adapter did `str(row[0])` on it — so `FlowProducer` read `"-5"` as a *deduplicated job id* and silently dropped the orphaned job instead of raising. It now stays an int, matching the TS convention (`Number.isInteger(code) && code < 0`).

3. **`Queue.getJobs` returned jobs in random order.** The non-Redis path used `asyncio.wait`, which returns an unordered **set**, discarding the asc/desc ordering `getRanges` had just computed. Every ordering assertion on Postgres was passing or failing by luck. The same line also raised `ValueError: Set of Tasks/Futures is empty` on **any empty queue**, so `getWaiting()` on a fresh Postgres queue crashed outright. Now uses `asyncio.gather`.

## One divergence deliberately left alone

A paused queue reports its pending jobs under `waiting` on Redis (pause is an O(1) meta flag that leaves the wait list in place) but under `paused` on Postgres. Both the TypeScript and Python Postgres adapters do this remap on purpose — see the comment in `PostgresQueueBackend.getCounts`. Rather than change shared cross-runtime semantics, the two affected tests now assert on `getJobCountByTypes('waiting', 'paused')`, which is the backend-agnostic pending count and preserves what those tests are actually verifying.

Possibly worth a follow-up: `docs/gitbook/guide/postgresql.md` claims "full datastore-agnostic API" and lists only Redis escape hatches as differences — this count divergence is not mentioned there.

## Tests

- `queue_events_test.py` now runs against Postgres too (conftest patches `create_backend` for both classes), giving the full lifecycle cross-backend coverage.
- New: backend-selection regression tests for `QueueEvents` / `QueueEventsProducer` (they skip cleanly when the optional `postgres` extra is absent, so the Redis CI job is unaffected).
- New unit tests for the events LISTEN channel, `readEvents` cursor resolution / field stringification / reconnect-after-error, the queue-metadata array marshalling, the `-5` sentinel, and the empty-queue case.

Verified in Docker against `postgres:16` and `redis:8`:

- **Redis: 172 passed.**
- **Postgres: 175 passed, 6 skipped** — green and stable across three consecutive full runs (previously 12 failures).
- End-to-end on Postgres: `added`, `progress` (JSON-decoded), `completed` (`returnvalue` decoded), per-job `completed:<id>`, `drained`, and custom producer events all deliver correctly. With the default `'$'` cursor an event arrives in ~54 ms via NOTIFY (well inside the 250 ms poll fallback), and `close()` interrupts a 60 s parked read in ~5 ms.
- `flake8` blocking checks clean; no new style findings versus the base (verified by diffing flake8 output before/after).
