### PR TITLE
feat: make maximumBlockTimeout a backend capability

### DIFF
--- a/src/classes/redis-queue-backend.ts
+++ b/src/classes/redis-queue-backend.ts
@@ -347,6 +347,15 @@ export class RedisQueueBackend extends EventEmitter implements IQueueBackend {
   }
 
   /**
+   * Longest block timeout (seconds) to ask `BZPOPMIN` for. Kept at 10s so a
+   * dropped connection is noticed quickly.
+   * reference: https://github.com/taskforcesh/bullmq/issues/1658
+   */
+  get maximumBlockTimeout(): number {
+    return 10;
+  }
+
+  /**
    * Interrupts the in-flight blocking wait by disconnecting the dedicated
    * blocking connection. No-op if there is none.
    */

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -45,8 +45,11 @@ import {
 } from './job-scheduler';
 import { LockManager } from './lock-manager';
 
-// 10 seconds is the maximum time a BZPOPMIN can block.
-const maximumBlockTimeout = 10;
+/**
+ * Used when a backend does not set its own maximum. Matches the Redis backend,
+ * so third-party backends keep the behaviour they had before.
+ */
+const DEFAULT_MAXIMUM_BLOCK_TIMEOUT = 10;
 
 // note: sandboxed processors would also like to define concurrency per process
 // for better resource utilization.
@@ -776,6 +779,10 @@ export class Worker<
     return this.backend.minimumBlockTimeout;
   }
 
+  get maximumBlockTimeout(): number {
+    return this.backend.maximumBlockTimeout ?? DEFAULT_MAXIMUM_BLOCK_TIMEOUT;
+  }
+
   private isRateLimited(): boolean {
     return this.limitUntil > Date.now();
   }
@@ -855,10 +862,9 @@ export class Worker<
       } else if (blockDelay < this.minimumBlockTimeout * 1000) {
         return this.minimumBlockTimeout;
       } else {
-        // We restrict the maximum block timeout to 10 second to avoid
-        // blocking the connection for too long in the case of reconnections
-        // reference: https://github.com/taskforcesh/bullmq/issues/1658
-        return Math.min(blockDelay / 1000, maximumBlockTimeout);
+        // The limit belongs to the backend: Redis must not block for long,
+        // while PostgreSQL's LISTEN-based wait can.
+        return Math.min(blockDelay / 1000, this.maximumBlockTimeout);
       }
     } else {
       return Math.max(opts.drainDelay, this.minimumBlockTimeout);

--- a/src/interfaces/queue-backend.ts
+++ b/src/interfaces/queue-backend.ts
@@ -107,6 +107,15 @@ export interface IQueueBackend {
   readonly minimumBlockTimeout: number;
 
   /**
+   * Longest block timeout (in seconds) supported by the backend's blocking
+   * primitive. Used by workers to bound `waitForJob` when the next delayed job
+   * is due further away than this.
+   *
+   * Optional: backends that do not set it fall back to 10 seconds.
+   */
+  readonly maximumBlockTimeout?: number;
+
+  /**
    * Subscribes to normalized backend lifecycle events (`'ready'`, `'error'`,
    * `'close'`), derived from the underlying connection(s).
    */

--- a/src/postgres/postgres-queue-backend.ts
+++ b/src/postgres/postgres-queue-backend.ts
@@ -386,6 +386,19 @@ export class PostgresQueueBackend
     return 0.001;
   }
 
+  /**
+   * `LISTEN`/`NOTIFY` has no protocol limit, and {@link waitForJob} already
+   * shortens its timer to the next due delayed job, so a long wait never delays
+   * a scheduled job. Waiting an hour instead of re-polling every 10s is what
+   * lets an idle serverless database suspend.
+   *
+   * Must stay finite: {@link waitForJob} passes this to `setTimeout`, which
+   * fires immediately beyond ~24.8 days.
+   */
+  get maximumBlockTimeout(): number {
+    return 3600;
+  }
+
   forQueue(queueName: string, _prefix?: string): IQueueBackend {
     // The namespace is the connection's schema, shared by all queues, so a
     // sibling backend only needs a different queue name. BullMQ's per-queue

--- a/tests/postgres-queue-backend.test.ts
+++ b/tests/postgres-queue-backend.test.ts
@@ -29,4 +29,16 @@ describe('PostgresQueueBackend', () => {
     ]);
     expect(failed).toEqual(['job-2', 'job-3']);
   });
+
+  it('allows a far longer block than the Redis BZPOPMIN cap', () => {
+    const backend = Object.create(
+      PostgresQueueBackend.prototype,
+    ) as PostgresQueueBackend;
+
+    // Longer waits are safe: waitForJob shortens its timer to the next due
+    // delayed job anyway.
+    expect(backend.maximumBlockTimeout).toBeGreaterThan(10);
+    // But it must fit in setTimeout, which fires immediately beyond ~24.8 days.
+    expect(backend.maximumBlockTimeout * 1000).toBeLessThan(2 ** 31 - 1);
+  });
 });

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1321,6 +1321,67 @@ describe('workers', () => {
           await worker.close();
         });
       });
+
+      describe('when blockUntil is further away than the backend allows', () => {
+        it('caps the block timeout at the backend maximum', async () => {
+          const worker = new Worker(queueName, NoopProc, {
+            connection,
+            prefix,
+            autorun: false,
+          });
+          await worker.waitUntilReady();
+
+          expect(worker.maximumBlockTimeout).toBe(10);
+          expect(worker['getBlockTimeout'](Date.now() + 60_000)).toBe(
+            worker.maximumBlockTimeout,
+          );
+
+          await worker.close();
+        });
+
+        it('blocks for the whole delay when the backend allows longer waits', async () => {
+          const worker = new Worker(queueName, NoopProc, {
+            connection,
+            prefix,
+            autorun: false,
+          });
+          await worker.waitUntilReady();
+
+          // A backend that can wait an hour (like PostgreSQL) should wait out
+          // the delay instead of waking every 10s to find nothing due.
+          Object.defineProperty(worker['backend'], 'maximumBlockTimeout', {
+            configurable: true,
+            get: () => 3600,
+          });
+
+          expect(
+            worker['getBlockTimeout'](Date.now() + 60_000),
+          ).toBeGreaterThan(59);
+
+          await worker.close();
+        });
+
+        it('falls back to 10s for a backend that declares no maximum', async () => {
+          const worker = new Worker(queueName, NoopProc, {
+            connection,
+            prefix,
+            autorun: false,
+          });
+          await worker.waitUntilReady();
+
+          // The member is optional, so third-party backends keep compiling and
+          // keep their previous behaviour.
+          Object.defineProperty(worker['backend'], 'maximumBlockTimeout', {
+            configurable: true,
+            get: () => undefined,
+          });
+
+          expect(worker.maximumBlockTimeout).toBe(10);
+          expect(worker['getBlockTimeout'](Date.now() + 60_000)).toBe(10);
+
+          await worker.close();
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## Problem

`maximumBlockTimeout` is a constant in `Worker`, set to `10` because that is the
longest a Redis `BZPOPMIN` can block. It is applied on a path **every backend shares**.

Postgres blocks on `LISTEN`/`NOTIFY`, which has no such limit. Any pending delayed
job puts the worker on that path, so an idle worker queries the database every 10
seconds forever. On serverless Postgres, which sleeps when idle, this alone keeps it awake.

`minimumBlockTimeout` is already backend-owned. The maximum is not.

## Change

Move the limit onto `IQueueBackend`, next to `minimumBlockTimeout`.

| Backend | `maximumBlockTimeout` |
| :-- | :-- |
| Redis | `10`, unchanged, no user impact |
| Postgres | `3600` |
| Not set | falls back to `10` in the worker |

The member is **optional**, so custom backends outside this repo keep compiling.

 **Scope:** this removes one source of idle traffic, not all of it. The stalled-job checker polls every `stalledInterval` (default 30s) whether or not anything is  active, roughly 2,880 queries a day, which is enough on its own to keep a serverless instance awake. Different timer, different call, not addressed here.

## Why a longer wait is safe on Postgres

* `waitForJob` already shortens its timer to the next due delayed job, and *only*
  ever shortens it, so a larger cap cannot push a scheduled job out.
* Every path that adds or re-dates a delayed job fires `pg_notify`, so a job
  created mid-wait still wakes the worker.
* The cap must stay **finite**. `waitForJob` passes it straight to `setTimeout`,
  which fires immediately past ~24.8 days. A test guards this.

## Tests

| Suite | Result |
| :-- | :-- |
| `tests/postgres` | 39 / 39 |
| `test:adapter-conformance` | 66 / 66 |
| default suite | 808 passing |

Failures in `child-pool`, `script_loader` and `sandboxed_process` are pre-existing
on my machine (Windows: child processes and path handling), and identical on clean
`master`.

## Known follow-up

Raising the cap does not create a bug, but it **stops hiding one**. A dead `LISTEN`
client is currently masked by the 10s timer. The worker wakes, runs `moveToActive`
on a pool connection, and jobs keep flowing by de facto polling. At `3600` that same
dead connection stalls the queue for up to an hour.

Nothing replaces a dead client today. `listenClientPromise` is memoized and cleared
only in `close()`, and `ensureListening` re-issues `LISTEN` on that same client.

I have a branch that fixes this, with a test that kills the LISTEN backend via
`pg_terminate_backend` and fails without the fix. Happy to open it as a follow-up,
or fold it in here.

## Ports

Python (`python/bullmq/worker.py:26`) and Elixir (`elixir/lib/bullmq/worker.ex`)
carry the same constant and the same asymmetry. Happy to port if wanted.

Closes #4601