### PR TITLE
feat(postgres): forward :ssl option to Postgrex connection

### DIFF
--- a/elixir/lib/bullmq/backends/postgres/connection.ex
+++ b/elixir/lib/bullmq/backends/postgres/connection.ex
@@ -18,6 +18,12 @@ defmodule BullMQ.Backends.Postgres.Connection do
     * `:hostname`/`:port`/`:database`/`:username`/`:password` — discrete opts.
     * `:schema` — the namespace for all queues (default `"bullmq"`).
     * `:pool_size` — pool size (default `10`).
+    * `:ssl` — SSL options forwarded to `Postgrex`. Accepts `true`, `false`, or a
+      keyword list such as `[verify: :verify_none]` or
+      `[verify: :verify_peer, cacertfile: "…"]`. Required when the server enforces
+      SSL (e.g. AWS RDS with `rds.force_ssl=1`). When omitted, an `sslmode` in the
+      `:url` query (`require`/`verify-ca`/`verify-full`) enables SSL with
+      `verify: :verify_none`; pass `:ssl` explicitly for certificate verification.
     * `:skip_version_check` — bypass the minimum-server-version assertion.
     * `:skip_migrations` — do not run migrations (assume already applied).
   """
@@ -108,9 +114,13 @@ defmodule BullMQ.Backends.Postgres.Connection do
   defp notif_name(name), do: :"#{name}_pg_notifications"
 
   # -- opts building --
-  defp build_postgrex_opts(opts, schema) do
+  @doc false
+  # Exposed for testing; builds the keyword list passed to Postgrex.
+  def build_postgrex_opts(opts, schema) do
+    url = Keyword.get(opts, :url)
+
     base =
-      case Keyword.get(opts, :url) do
+      case url do
         nil ->
           [
             hostname: Keyword.get(opts, :hostname, "localhost"),
@@ -134,8 +144,35 @@ defmodule BullMQ.Backends.Postgres.Connection do
         Postgrex.query!(conn, "SET search_path TO #{quoted}", [])
       end
     )
+    |> put_ssl(resolve_ssl(opts, url))
     |> Enum.reject(fn {_k, v} -> is_nil(v) end)
   end
+
+  # Explicit `:ssl` wins; otherwise fall back to the URL's `sslmode`.
+  defp resolve_ssl(opts, url) do
+    case Keyword.fetch(opts, :ssl) do
+      {:ok, ssl} -> ssl
+      :error -> ssl_from_url(url)
+    end
+  end
+
+  defp ssl_from_url(nil), do: nil
+
+  defp ssl_from_url(url) do
+    with query when is_binary(query) <- URI.parse(url).query,
+         mode when mode in ["require", "verify-ca", "verify-full"] <-
+           URI.decode_query(query)["sslmode"] do
+      # Encrypt the connection. Certificate verification requires a cacertfile,
+      # so URL-driven SSL uses verify_none; pass `:ssl` explicitly to verify.
+      [verify: :verify_none]
+    else
+      _ -> nil
+    end
+  end
+
+  # nil means "not configured" — leave Postgrex opts untouched (no SSL).
+  defp put_ssl(pg_opts, nil), do: pg_opts
+  defp put_ssl(pg_opts, ssl), do: Keyword.put(pg_opts, :ssl, ssl)
 
   defp parse_url(url) do
     uri = URI.parse(url)

--- a/elixir/lib/bullmq/backends/postgres/connection.ex
+++ b/elixir/lib/bullmq/backends/postgres/connection.ex
@@ -164,7 +164,8 @@ defmodule BullMQ.Backends.Postgres.Connection do
             ssl
         end
 
-      :error -> ssl_from_url(url)
+      :error ->
+        ssl_from_url(url)
     end
   end
 

--- a/elixir/lib/bullmq/backends/postgres/connection.ex
+++ b/elixir/lib/bullmq/backends/postgres/connection.ex
@@ -20,10 +20,9 @@ defmodule BullMQ.Backends.Postgres.Connection do
     * `:pool_size` — pool size (default `10`).
     * `:ssl` — SSL options forwarded to `Postgrex`. Accepts `true`, `false`, or a
       keyword list such as `[verify: :verify_none]` or
-      `[verify: :verify_peer, cacertfile: "…"]`. Required when the server enforces
-      SSL (e.g. AWS RDS with `rds.force_ssl=1`). When omitted, an `sslmode` in the
-      `:url` query (`require`/`verify-ca`/`verify-full`) enables SSL with
-      `verify: :verify_none`; pass `:ssl` explicitly for certificate verification.
+      `[verify: :verify_peer, cacertfile: "…"]`. When omitted, `sslmode=require`
+      in the `:url` enables SSL with `verify: :verify_none`. The `verify-ca` and
+      `verify-full` modes require explicit `:ssl` certificate verification options.
     * `:skip_version_check` — bypass the minimum-server-version assertion.
     * `:skip_migrations` — do not run migrations (assume already applied).
   """
@@ -151,7 +150,20 @@ defmodule BullMQ.Backends.Postgres.Connection do
   # Explicit `:ssl` wins; otherwise fall back to the URL's `sslmode`.
   defp resolve_ssl(opts, url) do
     case Keyword.fetch(opts, :ssl) do
-      {:ok, ssl} -> ssl
+      {:ok, ssl} ->
+        case sslmode_from_url(url) do
+          mode when mode in ["verify-ca", "verify-full"] ->
+            unless Keyword.keyword?(ssl) and Keyword.get(ssl, :verify) == :verify_peer do
+              raise ArgumentError,
+                    "sslmode=#{mode} requires explicit :ssl options with verify: :verify_peer"
+            end
+
+            ssl
+
+          _ ->
+            ssl
+        end
+
       :error -> ssl_from_url(url)
     end
   end
@@ -159,15 +171,24 @@ defmodule BullMQ.Backends.Postgres.Connection do
   defp ssl_from_url(nil), do: nil
 
   defp ssl_from_url(url) do
-    with query when is_binary(query) <- URI.parse(url).query,
-         mode when mode in ["require", "verify-ca", "verify-full"] <-
-           URI.decode_query(query)["sslmode"] do
-      # Encrypt the connection. Certificate verification requires a cacertfile,
-      # so URL-driven SSL uses verify_none; pass `:ssl` explicitly to verify.
-      [verify: :verify_none]
-    else
-      _ -> nil
+    case sslmode_from_url(url) do
+      "require" ->
+        [verify: :verify_none]
+
+      mode when mode in ["verify-ca", "verify-full"] ->
+        raise ArgumentError,
+              "sslmode=#{mode} requires explicit :ssl options with verify: :verify_peer"
+
+      _ ->
+        nil
     end
+  end
+
+  defp sslmode_from_url(nil), do: nil
+
+  defp sslmode_from_url(url) do
+    query = URI.parse(url).query
+    is_binary(query) && URI.decode_query(query)["sslmode"]
   end
 
   # nil means "not configured" — leave Postgrex opts untouched (no SSL).

--- a/elixir/test/bullmq/backends/postgres/connection_test.exs
+++ b/elixir/test/bullmq/backends/postgres/connection_test.exs
@@ -1,0 +1,82 @@
+defmodule BullMQ.Backends.Postgres.ConnectionTest do
+  @moduledoc """
+  Unit tests for `BullMQ.Backends.Postgres.Connection.build_postgrex_opts/2`.
+
+  These do not require a running PostgreSQL instance — they assert how caller
+  options (notably `:ssl`) are translated into the keyword list handed to
+  `Postgrex`.
+  """
+  use ExUnit.Case, async: true
+
+  alias BullMQ.Backends.Postgres.Connection
+
+  describe "build_postgrex_opts/2 SSL handling" do
+    test "omits :ssl when not provided (backward compatible)" do
+      opts = Connection.build_postgrex_opts([hostname: "localhost"], "bullmq")
+      refute Keyword.has_key?(opts, :ssl)
+    end
+
+    test "forwards an explicit :ssl keyword list to Postgrex" do
+      opts =
+        Connection.build_postgrex_opts(
+          [hostname: "localhost", ssl: [verify: :verify_none]],
+          "bullmq"
+        )
+
+      assert Keyword.get(opts, :ssl) == [verify: :verify_none]
+    end
+
+    test "forwards :ssl true" do
+      opts = Connection.build_postgrex_opts([hostname: "localhost", ssl: true], "bullmq")
+      assert Keyword.get(opts, :ssl) == true
+    end
+
+    test "forwards :ssl false explicitly" do
+      opts = Connection.build_postgrex_opts([hostname: "localhost", ssl: false], "bullmq")
+      assert Keyword.get(opts, :ssl) == false
+    end
+
+    test "explicit :ssl works with the :url form too" do
+      opts =
+        Connection.build_postgrex_opts(
+          [url: "postgres://u:p@host:5432/db", ssl: [verify: :verify_none]],
+          "bullmq"
+        )
+
+      assert Keyword.get(opts, :ssl) == [verify: :verify_none]
+    end
+
+    test "derives SSL from the URL sslmode when :ssl is not given" do
+      for mode <- ["require", "verify-ca", "verify-full"] do
+        opts =
+          Connection.build_postgrex_opts(
+            [url: "postgres://u:p@host:5432/db?sslmode=#{mode}"],
+            "bullmq"
+          )
+
+        assert Keyword.get(opts, :ssl) == [verify: :verify_none],
+               "expected sslmode=#{mode} to enable SSL"
+      end
+    end
+
+    test "does not enable SSL for sslmode=disable" do
+      opts =
+        Connection.build_postgrex_opts(
+          [url: "postgres://u:p@host:5432/db?sslmode=disable"],
+          "bullmq"
+        )
+
+      refute Keyword.has_key?(opts, :ssl)
+    end
+
+    test "explicit :ssl takes precedence over the URL sslmode" do
+      opts =
+        Connection.build_postgrex_opts(
+          [url: "postgres://u:p@host:5432/db?sslmode=require", ssl: false],
+          "bullmq"
+        )
+
+      assert Keyword.get(opts, :ssl) == false
+    end
+  end
+end

--- a/elixir/test/bullmq/backends/postgres/connection_test.exs
+++ b/elixir/test/bullmq/backends/postgres/connection_test.exs
@@ -46,8 +46,8 @@ defmodule BullMQ.Backends.Postgres.ConnectionTest do
       assert Keyword.get(opts, :ssl) == [verify: :verify_none]
     end
 
-    test "derives SSL from the URL sslmode when :ssl is not given" do
-      for mode <- ["require", "verify-ca", "verify-full"] do
+    test "derives SSL from URL sslmode=require when :ssl is not given" do
+      for mode <- ["require"] do
         opts =
           Connection.build_postgrex_opts(
             [url: "postgres://u:p@host:5432/db?sslmode=#{mode}"],
@@ -57,6 +57,42 @@ defmodule BullMQ.Backends.Postgres.ConnectionTest do
         assert Keyword.get(opts, :ssl) == [verify: :verify_none],
                "expected sslmode=#{mode} to enable SSL"
       end
+    end
+
+    test "requires explicit :ssl options for URL certificate verification modes" do
+      for mode <- ["verify-ca", "verify-full"] do
+        assert_raise ArgumentError,
+                     "sslmode=#{mode} requires explicit :ssl options with verify: :verify_peer",
+                     fn ->
+                       Connection.build_postgrex_opts(
+                         [url: "postgres://host:5432/db?sslmode=#{mode}"],
+                         "bullmq"
+                       )
+                     end
+      end
+    end
+
+    test "accepts verification modes with explicit certificate verification options" do
+      ssl = [verify: :verify_peer, cacertfile: "/path/to/ca.pem"]
+
+      opts =
+        Connection.build_postgrex_opts(
+          [url: "postgres://host:5432/db?sslmode=verify-full", ssl: ssl],
+          "bullmq"
+        )
+
+      assert Keyword.get(opts, :ssl) == ssl
+    end
+
+    test "rejects verification modes with explicit non-verifying SSL options" do
+      assert_raise ArgumentError,
+                   "sslmode=verify-ca requires explicit :ssl options with verify: :verify_peer",
+                   fn ->
+                     Connection.build_postgrex_opts(
+                       [url: "postgres://host:5432/db?sslmode=verify-ca", ssl: true],
+                       "bullmq"
+                     )
+                   end
     end
 
     test "does not enable SSL for sslmode=disable" do


### PR DESCRIPTION
The Postgres backend built its Postgrex options from scratch and only kept
hostname/port/database/username/password (+ pool_size/types/after_connect),
silently dropping any :ssl option and ignoring sslmode in the connection URL.
This made it impossible to connect to servers that require encryption
(e.g. AWS RDS with rds.force_ssl=1), which rejected the connection with
"no pg_hba.conf entry ... no encryption".

build_postgrex_opts/2 now:
- forwards an explicit :ssl option (true | false | keyword list such as
  [verify: :verify_none]) to Postgrex;
- falls back to the URL's sslmode (require/verify-ca/verify-full) with
  verify: :verify_none when :ssl is not provided;
- lets an explicit :ssl take precedence over the URL sslmode.

Behavior is unchanged when neither :ssl nor an SSL sslmode is set, so existing
non-SSL configurations are unaffected. Documents :ssl in the moduledoc and adds
DB-free unit tests for the option building.