### PR TITLE
feat(job): add DelayedError and Job.moveToDelayed for processor-controlled delays [python]

### DIFF
--- a/python/bullmq/__init__.py
+++ b/python/bullmq/__init__.py
@@ -16,4 +16,4 @@ from bullmq.job_scheduler import JobScheduler
 from bullmq.abort_controller import AbortController, AbortSignal, AbortError
 from bullmq.queue_events import QueueEvents
 from bullmq.queue_events_producer import QueueEventsProducer
-from bullmq.custom_errors import WaitingChildrenError, UnrecoverableError
+from bullmq.custom_errors import WaitingChildrenError, UnrecoverableError, DelayedError

--- a/python/bullmq/custom_errors/__init__.py
+++ b/python/bullmq/custom_errors/__init__.py
@@ -1,2 +1,3 @@
+from bullmq.custom_errors.delayed_error import DelayedError
 from bullmq.custom_errors.unrecoverable_error import UnrecoverableError
 from bullmq.custom_errors.waiting_children_error import WaitingChildrenError

--- a/python/bullmq/custom_errors/delayed_error.py
+++ b/python/bullmq/custom_errors/delayed_error.py
@@ -1,0 +1,3 @@
+class DelayedError(Exception):
+    "Raised when job is moved to delayed from inside the processor"
+    pass

--- a/python/bullmq/custom_errors/waiting_children_error.py
+++ b/python/bullmq/custom_errors/waiting_children_error.py
@@ -1,3 +1,3 @@
 class WaitingChildrenError(Exception):
-    "Raised when job is moved to waiting-children"
+    "Raised when job is moved to waiting-children from inside the processor"
     pass

--- a/python/bullmq/job.py
+++ b/python/bullmq/job.py
@@ -278,6 +278,22 @@ class Job:
             elif self.opts.get("stackTraceLimit"):
                 self.stacktrace = self.stacktrace[-(stackTraceLimit-1):stackTraceLimit]
 
+    async def moveToDelayed(self, timestamp: int, token: str):
+        """
+        Moves the job to the delay set. Only allowed while the job is active, i.e.
+        called from inside a processor, and a DelayedError must be raised afterwards
+        so that the worker does not try to complete or fail the job.
+
+        @param timestamp: timestamp when the job should be moved back to "wait"
+        @param token: token to check job is locked by current worker
+        """
+        now = round(time.time() * 1000)
+        delay = timestamp - now if timestamp > now else 0
+
+        await self.backend.moveToDelayed(self.id, now, delay, token, {"skipAttempt": True})
+
+        self.delay = delay
+
     async def moveToWaitingChildren(self, token, opts:dict) -> bool | None:
         return await self.backend.moveToWaitingChildren(self.id, token, opts)
 

--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -5,7 +5,7 @@ from redis.exceptions import (
     ConnectionError as RedisConnectionError,
     TimeoutError as RedisTimeoutError,
 )
-from bullmq.custom_errors import UnrecoverableError, WaitingChildrenError
+from bullmq.custom_errors import DelayedError, UnrecoverableError, WaitingChildrenError
 from bullmq.backends import RedisBackend, create_backend
 from bullmq.event_emitter import EventEmitter
 from bullmq.job import Job
@@ -419,7 +419,7 @@ class Worker(EventEmitter):
                 job.returnvalue = result
                 job.attemptsMade = job.attemptsMade + 1
             self.emit("completed", job, result)
-        except WaitingChildrenError:
+        except (DelayedError, WaitingChildrenError):
             return
         except Exception as err:
             try:

--- a/python/tests/test_imports.py
+++ b/python/tests/test_imports.py
@@ -19,6 +19,11 @@ class TestImports(unittest.TestCase):
         from bullmq import WaitingChildrenError
         self.assertIs(WaitingChildrenError, bullmq.custom_errors.WaitingChildrenError)
 
+    def test_delayed_error_importable_from_package_root(self):
+        """Ensure DelayedError can be imported directly from bullmq."""
+        from bullmq import DelayedError
+        self.assertIs(DelayedError, bullmq.custom_errors.DelayedError)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/worker_test.py
+++ b/python/tests/worker_test.py
@@ -6,7 +6,7 @@ https://bbc.github.io/cloudfit-public-docs/asyncio/testing.html
 
 from asyncio import Future
 import redis.asyncio as redis
-from bullmq import Queue, Worker, Job, WaitingChildrenError
+from bullmq import Queue, Worker, Job, DelayedError, WaitingChildrenError
 from bullmq.worker import getCompleted
 from uuid import uuid4
 from enum import Enum
@@ -883,6 +883,133 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(jobs, [])
         self.assertEqual(pending, set())
+
+    async def test_move_to_delayed_from_processor(self):
+        queue = Queue(queueName, {"prefix": prefix})
+        job = await queue.add("test", {"foo": "bar"})
+
+        delayed = Future()
+        failed_events = []
+
+        async def process(job: Job, token: str):
+            await job.moveToDelayed(round(time.time() * 1000) + 3000, token)
+            delayed.set_result(None)
+            raise DelayedError()
+
+        worker = Worker(queueName, process, {"prefix": prefix})
+        worker.on("failed", lambda job, err: failed_events.append(err))
+        worker.on("error", lambda *args: failed_events.append(args))
+
+        await delayed
+        # give the worker a chance to react to the DelayedError
+        await asyncio.sleep(0.3)
+
+        is_delayed = await job.isDelayed()
+        self.assertEqual(is_delayed, True)
+
+        counts = await queue.getJobCounts("delayed", "active", "failed", "completed")
+        self.assertEqual(counts.get("delayed"), 1)
+        self.assertEqual(counts.get("active"), 0)
+        self.assertEqual(counts.get("failed"), 0)
+        self.assertEqual(counts.get("completed"), 0)
+        self.assertEqual(failed_events, [])
+
+        await worker.close(force=True)
+        await queue.close()
+
+    async def test_move_to_delayed_in_one_step_keeping_current_step(self):
+        queue = Queue(queueName, {"prefix": prefix})
+
+        class Step(int, Enum):
+            Initial = 1
+            Second = 2
+            Finish = 3
+
+        delay = 200
+        processed_ids = []
+
+        async def process(job: Job, token: str):
+            processed_ids.append(job.id)
+            step = job.data.get("step")
+            if step == Step.Initial:
+                await job.moveToDelayed(round(time.time() * 1000) + delay, token)
+                await job.updateData({"step": Step.Second})
+                raise DelayedError()
+            elif step == Step.Second:
+                await job.updateData({"step": Step.Finish})
+                return Step.Finish
+            else:
+                raise Exception("invalid step")
+
+        worker = Worker(queueName, process, {"prefix": prefix})
+
+        error_events = []
+        failed_events = []
+        worker.on("error", lambda *args: error_events.append(args))
+        worker.on("failed", lambda job, err: failed_events.append(err))
+
+        completed_events = Future()
+        worker.on("completed", lambda job, result: completed_events.set_result(None))
+
+        start = round(time.time() * 1000)
+        job = await queue.add("test", {"step": Step.Initial})
+
+        await completed_events
+
+        elapse = round(time.time() * 1000) - start
+        self.assertGreater(elapse, delay)
+
+        # The very same job is re-processed, no new job is created.
+        self.assertEqual(processed_ids, [job.id, job.id])
+
+        completed_job = await Job.fromId(queue, job.id)
+        self.assertEqual(completed_job.returnvalue, Step.Finish)
+        self.assertEqual(completed_job.data, {"step": Step.Finish})
+        # skipAttempt: moving to delayed manually does not consume an attempt.
+        self.assertEqual(completed_job.attemptsMade, 1)
+        self.assertEqual(completed_job.attemptsStarted, 2)
+
+        self.assertEqual(failed_events, [])
+        self.assertEqual(error_events, [])
+
+        await worker.close()
+        await queue.close()
+
+    async def test_delayed_error_without_moving_job_does_not_finish_job(self):
+        # DelayedError only tells the worker to walk away; it is the
+        # moveToDelayed call that parks the job. Without it the job stays
+        # active and is left to the stalled checker, it is never completed
+        # nor failed behind our back.
+        queue = Queue(queueName, {"prefix": prefix})
+        job = await queue.add("test", {"foo": "bar"})
+
+        processed = Future()
+        events = []
+
+        async def process(job: Job, token: str):
+            processed.set_result(None)
+            raise DelayedError()
+
+        worker = Worker(queueName, process, {"prefix": prefix})
+        worker.on("completed", lambda job, result: events.append("completed"))
+        worker.on("failed", lambda job, err: events.append("failed"))
+
+        await processed
+        await asyncio.sleep(0.5)
+
+        self.assertEqual(events, [])
+
+        counts = await queue.getJobCounts("active", "delayed", "failed", "completed")
+        self.assertEqual(counts.get("active"), 1)
+        self.assertEqual(counts.get("delayed"), 0)
+        self.assertEqual(counts.get("failed"), 0)
+        self.assertEqual(counts.get("completed"), 0)
+
+        state = await job.getState()
+        self.assertEqual(state, "active")
+
+        await worker.close(force=True)
+        await queue.close()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Port Impact Checklist

- [x] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?
- [ ] **Rust** – does this change need to be ported or documented in the Rust library?
- [ ] **.NET** – does this change need to be ported or documented in the .NET library?

Python-only: Node.js is unchanged, this brings the Python port up to the existing Node behaviour.

### Why

In Node a processor can re-park its own active job, which is the documented way to wait for something without burning an attempt or spawning a second job ([Process Step Jobs](https://docs.bullmq.io/patterns/process-step-jobs)):

```ts
await job.moveToDelayed(Date.now() + 1000, token);
throw new DelayedError();
```

The Python port already has everything underneath this:

- the `moveToDelayed` Lua script is bundled (`moveToDelayed-12.lua`),
- `Backend.moveToDelayed` is declared abstract and implemented by both `RedisBackend` and `PostgresBackend`,
- `Scripts.moveToDelayedArgs` already supports `skipAttempt`,
- `Worker.processJob` already has the "processor moved the job itself, walk away" arm for `WaitingChildrenError`.

What is missing is the public surface: there is no `DelayedError` and no `Job.moveToDelayed`, so the pattern is unreachable from Python. The only way to defer work today is to add a *new* delayed job and carry the state across yourself.

### How

Four small pieces, each mirroring the Node implementation:

1. `bullmq/custom_errors/delayed_error.py` – `DelayedError`, in the style of the neighbouring `WaitingChildrenError` / `UnrecoverableError`, re-exported from `bullmq` and `bullmq.custom_errors`.
2. `Job.moveToDelayed(timestamp, token)` – computes `now` / `delay` and calls `self.backend.moveToDelayed(..., {"skipAttempt": True})`, same as `Job.moveToDelayed` in `src/classes/job.ts`. `skipAttempt` means a manual delay does not consume an attempt. (Node also calls `recordJobMetrics('delayed')` there; the Python port has no metrics recording, so there is nothing to mirror.)
3. `Worker.processJob` – `except WaitingChildrenError` becomes `except (DelayedError, WaitingChildrenError)`. Node's `handleFailed` treats `DelayedError`, `WaitingError` and `WaitingChildrenError` identically, so `DelayedError` is unconditional here too: it tells the worker not to complete or fail the job, it is the `moveToDelayed` call that parks it.
4. Tests, ported from the Node suite.

### Additional Notes

**Tests** (`python/tests/worker_test.py`, plus a re-export check in `test_imports.py`):

- `test_move_to_delayed_from_processor` – processor moves the job and raises `DelayedError`: the job lands in the delayed set, `active`/`failed`/`completed` stay 0, and no `failed` or `error` event is emitted.
- `test_move_to_delayed_in_one_step_keeping_current_step` – port of the Node case of the same name (`tests/worker.test.ts`, "when moving job to delayed in one step"): the **same job id** is processed twice, `updateData` written before the delay is visible in the second pass, and `attemptsMade == 1` with `attemptsStarted == 2`, which is what `skipAttempt` buys.
- `test_delayed_error_without_moving_job_does_not_finish_job` – guards the semantics from point 3: raising `DelayedError` without calling `moveToDelayed` leaves the job active for the stalled checker; it is never quietly completed or failed.

All three fail without the `worker.py` change, so they actually pin the behaviour down.

**Verification**

- Full Python suite against Redis 7.2 locally: `173 passed, 9 subtests passed`.
- The three new tests also pass against the Postgres backend (`BULLMQ_TEST_BACKEND=postgres`), since `PostgresBackend.moveToDelayed` already honours `skipAttempt`.
- The three new tests also pass with `BULLMQ_TEST_PREFIX={b}` (the DragonflyDB CI configuration).
- Reverting the `worker.py` change (back to `except WaitingChildrenError:`) makes all three new tests fail, so they do pin the behaviour rather than passing incidentally.
- `flake8 ./python --select=E9,F63,F7,F82` clean.
- Node suite per `contributing.md` (`yarn && yarn test`), unaffected but run anyway: `824 passed | 3 skipped (41 files)`.

**One note on timing:** if a v6 release is in flight for the Python package and this is easier to take there, I am happy to retarget it at `next` (or whatever branch you prefer) - it is small and applies cleanly either way.

