### PR TITLE
fix(worker): coerce worker name to string before backend calls

### DIFF
--- a/elixir/lib/bullmq/worker.ex
+++ b/elixir/lib/bullmq/worker.ex
@@ -1360,6 +1360,15 @@ defmodule BullMQ.Worker do
     end
   end
 
+  # The worker's registration `name` is an atom (or nil). It is also forwarded to
+  # the backend as data (e.g. the Postgres `application_name` and `move_to_active`
+  # parameters), which must be a binary — passing a raw atom raises a
+  # `DBConnection.EncodeError` on the Postgres backend. Coerce to a string so both
+  # the Redis and Postgres backends accept it.
+  defp name_as_string(nil), do: nil
+  defp name_as_string(name) when is_binary(name), do: name
+  defp name_as_string(name), do: to_string(name)
+
   @impl true
   def terminate(_reason, state) do
     cleanup(state)
@@ -1383,7 +1392,7 @@ defmodule BullMQ.Worker do
       lock_duration: state.lock_duration,
       max_stalled_count: state.max_stalled_count,
       limiter: state.limiter,
-      name: state.name,
+      name: name_as_string(state.name),
       queue_name: state.queue_name,
       prefix: state.prefix,
       telemetry: state.telemetry,
@@ -1469,7 +1478,7 @@ defmodule BullMQ.Worker do
     opts = [
       lock_duration: ctx.lock_duration,
       limiter: ctx.limiter,
-      name: ctx.name && Atom.to_string(ctx.name)
+      name: name_as_string(ctx.name)
     ]
 
     case Backend.move_to_active(ctx.backend, ctx.token, opts) do
@@ -1816,7 +1825,7 @@ defmodule BullMQ.Worker do
     [
       lock_duration: ctx.lock_duration,
       fetch_next: true,
-      name: ctx.name,
+      name: name_as_string(ctx.name),
       attempts: get_job_opt(job, :attempts, "attempts", 0),
       limiter: ctx.limiter,
       remove_on_complete: ctx.remove_on_complete,
@@ -1837,7 +1846,7 @@ defmodule BullMQ.Worker do
     script_opts = [
       lock_duration: state.lock_duration,
       limiter: state.limiter,
-      name: state.name && Atom.to_string(state.name)
+      name: name_as_string(state.name)
     ]
 
     case Backend.move_to_active(state.backend, token, script_opts) do
@@ -2437,7 +2446,7 @@ defmodule BullMQ.Worker do
     [
       lock_duration: state.lock_duration,
       fetch_next: true,
-      name: state.name,
+      name: name_as_string(state.name),
       attempts: get_job_opt(job, :attempts, "attempts", 0),
       limiter: state.limiter,
       remove_on_complete: state.remove_on_complete || %{"count" => -1},

--- a/elixir/test/bullmq/backends/postgres_integration_test.exs
+++ b/elixir/test/bullmq/backends/postgres_integration_test.exs
@@ -115,8 +115,12 @@ defmodule BullMQ.Backends.PostgresIntegrationTest do
 
   defp eventually(fun, retries \\ 50, sleep_ms \\ 100) do
     cond do
-      fun.() -> true
-      retries <= 0 -> false
+      fun.() ->
+        true
+
+      retries <= 0 ->
+        false
+
       true ->
         Process.sleep(sleep_ms)
         eventually(fun, retries - 1, sleep_ms)

--- a/elixir/test/bullmq/backends/postgres_integration_test.exs
+++ b/elixir/test/bullmq/backends/postgres_integration_test.exs
@@ -75,6 +75,54 @@ defmodule BullMQ.Backends.PostgresIntegrationTest do
     Worker.close(worker)
   end
 
+  # Regression: a worker registered with an atom `name` must still process jobs on
+  # the Postgres backend. The worker forwards its `name` to the backend as a SQL
+  # parameter (application_name / move_to_completed_fetch). A raw atom raised
+  # `DBConnection.EncodeError: expected a binary, got <atom>` inside the spawned
+  # autonomous worker while completing-and-fetching the next job — the jobs then
+  # stayed stuck in "active". We assert on the final job STATE (not the
+  # on_completed callback, which can fire before the crashing move). Multiple jobs
+  # ensure the complete-and-fetch-next path (which carries `name`) is exercised.
+  # See `name_as_string/1` in BullMQ.Worker.
+  test "worker with an atom name completes jobs (name coerced to a string for the backend)",
+       %{conn: conn, queue: queue} do
+    {:ok, worker} =
+      Worker.start_link(
+        queue: queue,
+        connection: conn,
+        name: :"named_worker_#{System.unique_integer([:positive])}",
+        processor: fn job -> {:ok, job.data["value"] * 2} end
+      )
+
+    job_ids =
+      for i <- 1..3 do
+        {:ok, job} = Queue.add(queue, "double", %{value: i}, connection: conn)
+        job.id
+      end
+
+    # Poll until all jobs settle. Without the fix the autonomous workers crash and
+    # the jobs remain "active" forever, so this eventually fails.
+    assert eventually(fn ->
+             Enum.all?(job_ids, fn id ->
+               Queue.get_job_state(queue, id, connection: conn) == {:ok, "completed"}
+             end)
+           end),
+           "expected all jobs to reach \"completed\"; got " <>
+             inspect(Enum.map(job_ids, &Queue.get_job_state(queue, &1, connection: conn)))
+
+    Worker.close(worker)
+  end
+
+  defp eventually(fun, retries \\ 50, sleep_ms \\ 100) do
+    cond do
+      fun.() -> true
+      retries <= 0 -> false
+      true ->
+        Process.sleep(sleep_ms)
+        eventually(fun, retries - 1, sleep_ms)
+    end
+  end
+
   test "worker processes a bulk batch", %{conn: conn, queue: queue} do
     test_pid = self()
 


### PR DESCRIPTION
The worker's registration `name` (an atom) was forwarded to the backend as a
SQL parameter (application_name / move_to_completed_fetch). On the Postgres
backend a raw atom raised DBConnection.EncodeError inside the spawned autonomous
worker, leaving jobs stuck in "active". Normalize name to a binary at all call
sites. Adds a Postgres integration regression test (named worker completing
multiple jobs).