### PR TITLE
fix(worker): delegate maximumBlockTimeout to the backend (#4601)

### DIFF
--- a/python/bullmq/backend.py
+++ b/python/bullmq/backend.py
@@ -74,6 +74,17 @@ class Backend(ABC):
         """Smallest meaningful blocking timeout (in seconds) for the blocking primitive."""
 
     @property
+    def maximumBlockTimeout(self) -> float:
+        """Largest meaningful blocking timeout (in seconds) for the blocking primitive.
+
+        Defaults to the Redis-derived ceiling (10s). Backends whose blocking
+        primitive keeps the connection open and re-arms to the next due job
+        (e.g. PostgreSQL ``LISTEN``/``NOTIFY``) can override this with a much
+        larger value so an idle worker stops re-polling.
+        """
+        return 10
+
+    @property
     @abstractmethod
     def capabilities(self) -> dict:
         """Datastore capability flags (e.g. ``canBlockFor1Ms``, ``canDoubleTimeout``)."""

--- a/python/bullmq/backends/postgres_backend.py
+++ b/python/bullmq/backends/postgres_backend.py
@@ -266,7 +266,10 @@ class PostgresBackend(Backend):
         # reason to cap the block at 10s like Redis. A large ceiling lets an
         # idle worker go quiet instead of re-polling every 10s (important for
         # serverless Postgres that suspends when idle). 3600s stays well under
-        # the timer ceiling that a larger delay would overflow.
+        # the timer ceiling that a larger delay would overflow. `waitForJob`
+        # blocks purely on LISTEN/NOTIFY (no polling) for the same reason, and
+        # relies on TCP keepalive to detect (and rebuild) a dropped LISTEN
+        # connection.
         return 3600
 
     @property
@@ -777,10 +780,14 @@ class PostgresBackend(Backend):
             base_ms = min(due_in, base_ms)
 
         deadline = time.monotonic() + base_ms / 1000
-        # A NOTIFY on the shared channel wakes us instantly; a short poll of the
-        # claimable-job probe is a robust fallback (delivery of a NOTIFY that
-        # fires between waits is not guaranteed to reach a blocked reader).
-        poll = 0.25
+        # A NOTIFY on the shared channel wakes us instantly, so we simply block
+        # on the LISTEN connection for the whole window: polling the claimable
+        # -job probe on a short interval would keep the database busy for the
+        # entire (now potentially hour-long) wait, which is exactly what stops a
+        # serverless PostgreSQL from ever suspending. Robustness comes from
+        # re-probing whenever the LISTEN connection has to be re-established —
+        # a drop, which TCP keepalive surfaces as an error, is the only way a
+        # NOTIFY can be missed once we are subscribed.
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -790,20 +797,19 @@ class PostgresBackend(Backend):
                         return marker
                     return ["bullmq_jobs", self.queue_name, _now_ms() + due_in]
                 return None
-            wait = min(poll, remaining)
-            checked_waiting_job = False
             try:
-                async for notify in listen_conn.notifies(timeout=wait, stop_after=1):
+                async for notify in listen_conn.notifies(timeout=remaining, stop_after=1):
                     payload = notify.payload
                     if payload == self.queue_name:
-                        checked_waiting_job = True
                         if await self._has_waiting_job():
                             return marker
             except psycopg.Error:
+                # The LISTEN connection dropped: rebuild it, re-subscribe, and
+                # re-probe, since any NOTIFY sent meanwhile was lost with it.
                 await self.connection.reset_job_channel()
                 listen_conn = await self.connection.ensure_job_channel()
-            if not checked_waiting_job and await self._has_waiting_job():
-                return marker
+                if await self._has_waiting_job():
+                    return marker
 
     # ============================================================
     # Job schedulers (repeatable job factories)

--- a/python/bullmq/backends/postgres_backend.py
+++ b/python/bullmq/backends/postgres_backend.py
@@ -260,6 +260,16 @@ class PostgresBackend(Backend):
         return minimum_block_timeout
 
     @property
+    def maximumBlockTimeout(self) -> float:
+        # PostgreSQL LISTEN/NOTIFY keeps the connection open and re-arms the
+        # wait to the next due delayed job, so there is no cheap-reconnect
+        # reason to cap the block at 10s like Redis. A large ceiling lets an
+        # idle worker go quiet instead of re-polling every 10s (important for
+        # serverless Postgres that suspends when idle). 3600s stays well under
+        # the timer ceiling that a larger delay would overflow.
+        return 3600
+
+    @property
     def capabilities(self) -> dict:
         return _CAPABILITIES
 

--- a/python/bullmq/backends/postgres_connection.py
+++ b/python/bullmq/backends/postgres_connection.py
@@ -32,6 +32,16 @@ MIGRATION_ADVISORY_LOCK_KEY = 0x42554C4C  # 1112493644
 # Lowest supported PostgreSQL major version.
 MINIMUM_POSTGRES_VERSION = 13
 
+# libpq TCP keepalive settings applied to the dedicated LISTEN connection so a
+# silently dropped connection is detected within seconds (the OS default idle
+# time is typically two hours, far longer than a worker's block).
+_LISTEN_KEEPALIVE_PARAMS = {
+    "keepalives": 1,
+    "keepalives_idle": 10,
+    "keepalives_interval": 10,
+    "keepalives_count": 3,
+}
+
 # The shared ``.sql`` command files use native ``$1`` numbered placeholders;
 # psycopg binds ``%s``. This rewrites ``$N`` to ``%s`` (preserving occurrence
 # order and repeats) and escapes any literal ``%``.
@@ -222,7 +232,15 @@ class PostgresConnection:
         """The dedicated autocommit connection used for LISTEN/NOTIFY waits."""
         if self._listen_conn is None or self._listen_conn.closed:
             self._listen_conn = await psycopg.AsyncConnection.connect(
-                self.conninfo, autocommit=True, options=self._options
+                self.conninfo,
+                autocommit=True,
+                options=self._options,
+                # A LISTEN subscription is bound to one physical connection, and
+                # a worker may now block on it for up to an hour. Probe often so
+                # a silently dropped connection surfaces as an error (which the
+                # wait recovers from) instead of going unnoticed until the OS
+                # default keepalive idle time (typically two hours) elapses.
+                **_LISTEN_KEEPALIVE_PARAMS,
             )
             if self._application_name:
                 await self._listen_conn.execute(

--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -23,7 +23,9 @@ import traceback
 import time
 import math
 
-maximum_block_timeout = 10
+# Default ceiling (in seconds) used when a backend does not delegate its own
+# `maximumBlockTimeout`. 10 seconds is the maximum time a BZPOPMIN can block.
+default_maximum_block_timeout = 10
 # 1 millisecond is chosen because the granularity of our timestamps are milliseconds.
 # Obviously we can still process much faster than 1 job per millisecond but delays and
 # rate limits will never work with more accuracy than 1ms.
@@ -378,16 +380,28 @@ class Worker(EventEmitter):
                 return self.minimumBlockTimeout
             else:
                 block_timeout = block_delay / 1000
-            # We restrict the maximum block timeout to 10 second to avoid
-            # blocking the connection for too long in the case of reconnections
-            # reference: https://github.com/taskforcesh/bullmq/issues/1658
-            return min(block_timeout, maximum_block_timeout)
+            # We restrict the maximum block timeout to avoid blocking the
+            # connection for too long in the case of reconnections. The ceiling
+            # is backend-specific: Redis caps it at 10s (see #1658), whereas a
+            # backend that keeps the connection open and re-arms to the next due
+            # job can allow a much larger value so an idle worker stops
+            # re-polling.
+            return min(block_timeout, self.maximumBlockTimeout)
         else:
             return max(self.opts.get("drainDelay", 5), self.minimumBlockTimeout)
 
     @property
     def minimumBlockTimeout(self):
         return self.backend.minimumBlockTimeout
+
+    @property
+    def maximumBlockTimeout(self):
+        backend_maximum = getattr(self.backend, "maximumBlockTimeout", None)
+        return (
+            backend_maximum
+            if backend_maximum is not None
+            else default_maximum_block_timeout
+        )
 
     async def processJob(self, job: Job, token: str):
         try:

--- a/python/tests/postgres_backend_test.py
+++ b/python/tests/postgres_backend_test.py
@@ -1,3 +1,4 @@
+import asyncio
 import unittest
 import time
 from types import SimpleNamespace
@@ -245,6 +246,24 @@ class TestPostgresConnection(unittest.IsolatedAsyncioTestCase):
             ("tenant_a:queue:w:1",),
         )
 
+    async def test_listen_connection_enables_tcp_keepalives(self):
+        # A worker may block on the LISTEN connection for up to an hour, so a
+        # silent drop must be detected in seconds, not after the OS default
+        # keepalive idle time.
+        listen_conn = SimpleNamespace(closed=False, execute=AsyncMock())
+        connect = AsyncMock(return_value=listen_conn)
+        connection = PostgresConnection()
+
+        with patch(
+            "bullmq.backends.postgres_connection.psycopg.AsyncConnection.connect",
+            connect,
+        ):
+            await connection.listen_connection()
+
+        kwargs = connect.await_args.kwargs
+        self.assertEqual(kwargs["keepalives"], 1)
+        self.assertEqual(kwargs["keepalives_idle"], 10)
+
     async def test_set_application_name_updates_existing_listen_connection(self):
         main_cursor = SimpleNamespace(execute=AsyncMock())
         main_conn = SimpleNamespace(
@@ -292,11 +311,14 @@ class _FailingNotifiesConnection:
 
 
 class _IdleNotifiesConnection:
+    """A LISTEN connection that never receives a NOTIFY (blocks until timeout)."""
+
     def __init__(self):
         self.closed = False
 
     def notifies(self, timeout=None, stop_after=None):
         async def _iter():
+            await asyncio.sleep(timeout or 0)
             if False:
                 yield
 
@@ -316,7 +338,9 @@ class TestPostgresBackendWaitForJob(unittest.IsolatedAsyncioTestCase):
     async def test_wait_for_job_reconnects_listen_channel_after_psycopg_error(self):
         connection = _FakeWaitConnection()
         backend = PostgresBackend("queue", connection)
-        backend._has_waiting_job = AsyncMock(side_effect=[False, False, True])
+        # No claimable job when the wait starts; after the dropped LISTEN
+        # connection is rebuilt the probe finds the job whose NOTIFY was lost.
+        backend._has_waiting_job = AsyncMock(side_effect=[False, True])
         backend._next_delay_ms = AsyncMock(return_value=None)
 
         marker = await backend.waitForJob(0.2)
@@ -324,6 +348,24 @@ class TestPostgresBackendWaitForJob(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(marker, ["bullmq_jobs", "queue", 0])
         connection.reset_job_channel.assert_awaited_once()
         self.assertEqual(connection.ensure_job_channel.await_count, 2)
+
+    async def test_wait_for_job_does_not_poll_while_blocked(self):
+        # The whole point of the large Postgres `maximumBlockTimeout` is that an
+        # idle worker lets the database go quiet, so the wait must rely on
+        # LISTEN/NOTIFY only — no periodic claimable-job probing.
+        connection = SimpleNamespace(
+            schema="bullmq",
+            ensure_job_channel=AsyncMock(return_value=_IdleNotifiesConnection()),
+            reset_job_channel=AsyncMock(),
+        )
+        backend = PostgresBackend("queue", connection)
+        backend._has_waiting_job = AsyncMock(return_value=False)
+        backend._next_delay_ms = AsyncMock(return_value=None)
+
+        marker = await backend.waitForJob(0.2)
+
+        self.assertIsNone(marker)
+        self.assertEqual(backend._has_waiting_job.await_count, 1)
 
     async def test_wait_for_job_returns_future_marker_when_only_delayed_jobs_exist(self):
         connection = SimpleNamespace(

--- a/python/tests/worker_disconnect_test.py
+++ b/python/tests/worker_disconnect_test.py
@@ -238,6 +238,51 @@ class TestWorkerInitialization(unittest.TestCase):
         finally:
             asyncio.run(worker.close(force=True))
 
+    def test_worker_uses_backend_maximum_block_timeout(self):
+        backend = SimpleNamespace(
+            qualifiedName="test-queue",
+            clientName=lambda suffix=None: f"tenant_a:test-queue{suffix or ''}",
+            close=AsyncMock(),
+            capabilities={"canBlockFor1Ms": True},
+            minimumBlockTimeout=0.001,
+            maximumBlockTimeout=3600,
+        )
+
+        with patch("bullmq.worker.create_backend", return_value=backend):
+            worker = Worker(
+                "test-queue",
+                None,
+                {"backend": "postgres", "autorun": False},
+            )
+
+        try:
+            self.assertEqual(worker.maximumBlockTimeout, 3600)
+        finally:
+            asyncio.run(worker.close(force=True))
+
+    def test_worker_falls_back_to_default_maximum_block_timeout(self):
+        # Backend without a `maximumBlockTimeout` attribute (e.g. an older
+        # custom backend) must fall back to the default 10s ceiling.
+        backend = SimpleNamespace(
+            qualifiedName="test-queue",
+            clientName=lambda suffix=None: f"tenant_a:test-queue{suffix or ''}",
+            close=AsyncMock(),
+            capabilities={"canBlockFor1Ms": True},
+            minimumBlockTimeout=0.001,
+        )
+
+        with patch("bullmq.worker.create_backend", return_value=backend):
+            worker = Worker(
+                "test-queue",
+                None,
+                {"backend": "postgres", "autorun": False},
+            )
+
+        try:
+            self.assertEqual(worker.maximumBlockTimeout, 10)
+        finally:
+            asyncio.run(worker.close(force=True))
+
 
 class TestQueueInitialization(unittest.TestCase):
     def test_queue_redis_compatibility_handle_is_none_for_non_redis_backends(self):

--- a/src/classes/redis-queue-backend.ts
+++ b/src/classes/redis-queue-backend.ts
@@ -347,6 +347,15 @@ export class RedisQueueBackend extends EventEmitter implements IQueueBackend {
   }
 
   /**
+   * Largest meaningful block timeout (seconds). Capped at 10s because a
+   * `BZPOPMIN` blocked longer than this risks issues on reconnection
+   * (see #1658).
+   */
+  get maximumBlockTimeout(): number {
+    return 10;
+  }
+
+  /**
    * Interrupts the in-flight blocking wait by disconnecting the dedicated
    * blocking connection. No-op if there is none.
    */

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -45,8 +45,9 @@ import {
 } from './job-scheduler';
 import { LockManager } from './lock-manager';
 
-// 10 seconds is the maximum time a BZPOPMIN can block.
-const maximumBlockTimeout = 10;
+// 10 seconds is the maximum time a BZPOPMIN can block, so it is the default
+// ceiling used when a backend does not delegate its own `maximumBlockTimeout`.
+const defaultMaximumBlockTimeout = 10;
 
 // note: sandboxed processors would also like to define concurrency per process
 // for better resource utilization.
@@ -776,6 +777,10 @@ export class Worker<
     return this.backend.minimumBlockTimeout;
   }
 
+  get maximumBlockTimeout(): number {
+    return this.backend.maximumBlockTimeout ?? defaultMaximumBlockTimeout;
+  }
+
   private isRateLimited(): boolean {
     return this.limitUntil > Date.now();
   }
@@ -855,10 +860,13 @@ export class Worker<
       } else if (blockDelay < this.minimumBlockTimeout * 1000) {
         return this.minimumBlockTimeout;
       } else {
-        // We restrict the maximum block timeout to 10 second to avoid
-        // blocking the connection for too long in the case of reconnections
-        // reference: https://github.com/taskforcesh/bullmq/issues/1658
-        return Math.min(blockDelay / 1000, maximumBlockTimeout);
+        // We restrict the maximum block timeout to avoid blocking the
+        // connection for too long in the case of reconnections. The ceiling is
+        // backend-specific: Redis caps it at 10s (a `BZPOPMIN` blocked longer
+        // risks issues on reconnection, see #1658), whereas a backend that
+        // keeps the connection open and re-arms to the next due job can allow a
+        // much larger value so an idle worker stops re-polling.
+        return Math.min(blockDelay / 1000, this.maximumBlockTimeout);
       }
     } else {
       return Math.max(opts.drainDelay, this.minimumBlockTimeout);

--- a/src/interfaces/queue-backend.ts
+++ b/src/interfaces/queue-backend.ts
@@ -107,6 +107,19 @@ export interface IQueueBackend {
   readonly minimumBlockTimeout: number;
 
   /**
+   * Largest meaningful block timeout (in seconds) supported by the backend's
+   * blocking primitive. Used by workers to bound `waitForJob` when there are
+   * delayed jobs pending.
+   *
+   * Optional so existing custom backends keep compiling; the worker falls back
+   * to the Redis-derived default (10s) when a backend does not specify one. A
+   * backend whose blocking primitive keeps the connection open and re-arms to
+   * the next due job (e.g. PostgreSQL `LISTEN`/`NOTIFY`) can return a much
+   * larger value so an idle worker stops re-polling.
+   */
+  readonly maximumBlockTimeout?: number;
+
+  /**
    * Subscribes to normalized backend lifecycle events (`'ready'`, `'error'`,
    * `'close'`), derived from the underlying connection(s).
    */

--- a/src/postgres/pg-types.ts
+++ b/src/postgres/pg-types.ts
@@ -42,6 +42,17 @@ export interface PgNotification {
  * notifications on it — never to release/end it (the {@link PgPool} owner does).
  */
 export interface PgListenClient extends PgQueryable {
+  /**
+   * node-postgres' internal connection wrapper. Only used to reach the
+   * underlying socket so TCP keepalive can be enabled on a client that was
+   * checked out of a pool we did not configure. Optional (and defensively
+   * typed) because it is an implementation detail of `pg`.
+   */
+  connection?: {
+    stream?: {
+      setKeepAlive?(enable: boolean, initialDelay?: number): unknown;
+    };
+  };
   on(event: 'notification', listener: (msg: PgNotification) => void): this;
   on(event: 'error', listener: (err: Error) => void): this;
   on(event: 'end', listener: () => void): this;

--- a/src/postgres/postgres-connection.ts
+++ b/src/postgres/postgres-connection.ts
@@ -73,6 +73,34 @@ function loadPgModule(): PgModule {
 }
 
 /**
+ * Idle time (ms) before the first TCP keepalive probe is sent on the dedicated
+ * `LISTEN` connection. Short enough that a silently dropped connection is
+ * detected in seconds instead of the OS default (typically two hours) — which,
+ * with a large `maximumBlockTimeout`, is what a blocked worker would otherwise
+ * have to wait for.
+ */
+const LISTEN_KEEPALIVE_INITIAL_DELAY_MS = 10000;
+
+/**
+ * Best-effort: turns TCP keepalive on for an already-established client's
+ * socket. Needed for the pooled `LISTEN` client, since a user-supplied
+ * `pg.Pool` may have been created without `keepAlive` and a checked-out client
+ * inherits that configuration. Returns whether keepalive is now enabled.
+ */
+function enableSocketKeepAlive(client: PgListenClient): boolean {
+  const stream = client.connection?.stream;
+  if (!stream || typeof stream.setKeepAlive !== 'function') {
+    return false;
+  }
+  try {
+    stream.setKeepAlive(true, LISTEN_KEEPALIVE_INITIAL_DELAY_MS);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Owns the PostgreSQL connection resources for a single backend:
  *
  * - a `pg.Pool` for regular, short-lived queries, and
@@ -137,6 +165,24 @@ export class PostgresConnection extends EventEmitter {
    */
   private listenClientIsStandalone = false;
 
+  /**
+   * Whether TCP keepalive is known to be enabled on the dedicated `LISTEN`
+   * connection. Only then can a silently dropped connection be detected (as a
+   * socket `'error'`) and rebuilt, which is the premise of the backend's large
+   * {@link PostgresQueueBackend.maximumBlockTimeout}; when it is not, the
+   * backend falls back to a conservative block ceiling instead.
+   */
+  private listenClientKeepAlive: boolean;
+
+  /**
+   * The last `application_name` applied to the `LISTEN` client (via
+   * {@link setListenClientName}). Re-applied whenever that client is rebuilt: a
+   * fresh connection starts unnamed, which would otherwise silently drop the
+   * worker / QueueEvents from `getWorkers()` / `getQueueEvents()` for the rest
+   * of its lifetime.
+   */
+  private listenClientName: string | undefined;
+
   constructor(connection: PostgresConnectionOptions) {
     super();
 
@@ -148,6 +194,12 @@ export class PostgresConnection extends EventEmitter {
       this.migrateOnConnect = false;
       this.pgModule = undefined;
       this.listenClientConfig = undefined;
+      // A user-supplied pool decides its own `keepAlive`; when it is off we try
+      // to enable it on the checked-out LISTEN socket (see getListenClient).
+      this.listenClientKeepAlive = Boolean(
+        (connection as unknown as { options?: { keepAlive?: boolean } }).options
+          ?.keepAlive,
+      );
     } else {
       const pg = loadPgModule();
       const {
@@ -193,6 +245,8 @@ export class PostgresConnection extends EventEmitter {
       // Keep the means to build a dedicated LISTEN connection on demand.
       this.pgModule = pg;
       this.listenClientConfig = resolvedConfig;
+      // We build the LISTEN client ourselves, always with keepAlive enabled.
+      this.listenClientKeepAlive = true;
     }
 
     // The pool emits 'error' for idle clients that drop; surface it but never
@@ -272,23 +326,72 @@ export class PostgresConnection extends EventEmitter {
             // unnoticed until the next poll — which, with a large
             // `maximumBlockTimeout`, could be up to an hour away.
             keepAlive: true,
-            keepAliveInitialDelayMillis: 10000,
+            keepAliveInitialDelayMillis: LISTEN_KEEPALIVE_INITIAL_DELAY_MS,
           });
           await client.connect();
           client.on('error', err => this.handleListenClientError(client, err));
+          this.listenClientKeepAlive = true;
           this.listenClientIsStandalone = true;
           this.listenClient = client;
+          await this.applyListenClientName(client);
           return client;
         } else {
           const client = await this.pool.connect();
           client.on('error', err => this.handleListenClientError(client, err));
+          // The pool is the user's, so its clients may have been created
+          // without `keepAlive`; enable it on this socket so a silent drop is
+          // still detected. If that is not possible the connection reports no
+          // keepalive and the backend caps its block timeout conservatively.
+          this.listenClientKeepAlive =
+            this.listenClientKeepAlive || enableSocketKeepAlive(client);
           this.listenClientIsStandalone = false;
           this.listenClient = client;
+          await this.applyListenClientName(client);
           return client;
         }
       })();
     }
     return this.listenClientPromise;
+  }
+
+  /**
+   * Whether TCP keepalive is enabled on the dedicated `LISTEN` connection, so a
+   * silently dropped connection is detected (and the client rebuilt) instead of
+   * lingering unnoticed. Consulted by the backend when deciding how long a
+   * worker may block.
+   */
+  get hasListenClientKeepAlive(): boolean {
+    return this.listenClientKeepAlive;
+  }
+
+  /**
+   * Sets the `application_name` of the dedicated `LISTEN` connection — the
+   * PostgreSQL analogue of Redis `CLIENT SETNAME` — and remembers it so it is
+   * re-applied to any client rebuilt after a drop.
+   */
+  async setListenClientName(name: string): Promise<void> {
+    this.listenClientName = name;
+    const client = await this.getListenClient();
+    await client.query(`SELECT set_config('application_name', $1, false)`, [
+      name,
+    ]);
+  }
+
+  /**
+   * Re-applies the remembered {@link listenClientName} to a freshly established
+   * `LISTEN` client. Best-effort: discovery must never break the client.
+   */
+  private async applyListenClientName(client: PgListenClient): Promise<void> {
+    if (!this.listenClientName) {
+      return;
+    }
+    try {
+      await client.query(`SELECT set_config('application_name', $1, false)`, [
+        this.listenClientName,
+      ]);
+    } catch {
+      // Discovery is best-effort; leave the connection unnamed.
+    }
   }
 
   /**

--- a/src/postgres/postgres-connection.ts
+++ b/src/postgres/postgres-connection.ts
@@ -264,15 +264,24 @@ export class PostgresConnection extends EventEmitter {
     if (!this.listenClientPromise) {
       this.listenClientPromise = (async () => {
         if (this.pgModule && this.listenClientConfig) {
-          const client = new this.pgModule.Client(this.listenClientConfig);
+          const client = new this.pgModule.Client({
+            ...this.listenClientConfig,
+            // A LISTEN subscription is bound to one physical connection. Enable
+            // TCP keepalive so a silently dropped connection surfaces as a
+            // socket `'error'` (and is then rebuilt below) instead of going
+            // unnoticed until the next poll — which, with a large
+            // `maximumBlockTimeout`, could be up to an hour away.
+            keepAlive: true,
+            keepAliveInitialDelayMillis: 10000,
+          });
           await client.connect();
-          client.on('error', err => this.emitError(err));
+          client.on('error', err => this.handleListenClientError(client, err));
           this.listenClientIsStandalone = true;
           this.listenClient = client;
           return client;
         } else {
           const client = await this.pool.connect();
-          client.on('error', err => this.emitError(err));
+          client.on('error', err => this.handleListenClientError(client, err));
           this.listenClientIsStandalone = false;
           this.listenClient = client;
           return client;
@@ -280,6 +289,45 @@ export class PostgresConnection extends EventEmitter {
       })();
     }
     return this.listenClientPromise;
+  }
+
+  /**
+   * Handles a fatal error on the dedicated `LISTEN` client.
+   *
+   * A `LISTEN` subscription lives on one specific physical connection: once that
+   * connection drops, the memoized client is dead and every re-`LISTEN` issued
+   * on it is silently lost — so a blocked worker would stop receiving NOTIFYs
+   * until its next poll. Invalidate the memo (and tear the dead client down) so
+   * the next {@link getListenClient} establishes a fresh connection, and emit
+   * `'listenerinvalidated'` so subscribed backends re-`LISTEN` and wake any
+   * in-flight blocking wait (which is parked on the now-dead client).
+   *
+   * Guarded so a stale error from an already-replaced client — or one racing an
+   * in-progress {@link close} (which owns teardown) — does not disturb the
+   * current client; the error is still forwarded either way.
+   */
+  private handleListenClientError(client: PgListenClient, err: Error): void {
+    if (this.listenClient === client && !this.closing) {
+      const wasStandalone = this.listenClientIsStandalone;
+      this.listenClient = undefined;
+      this.listenClientPromise = undefined;
+      // Drop orphaned notification listeners from in-flight waits; keep the
+      // 'error' listener so a follow-up error from the dying client is still
+      // swallowed via `emitError` rather than crashing the process.
+      client.removeAllListeners('notification');
+      try {
+        if (wasStandalone) {
+          void (client as PgClient).end().catch((): undefined => undefined);
+        } else {
+          // Destroy (rather than return) the broken pooled client.
+          (client as PgPoolClient).release(true);
+        }
+      } catch {
+        // Best-effort teardown of an already-broken client.
+      }
+      this.emit('listenerinvalidated');
+    }
+    this.emitError(err);
   }
 
   /**

--- a/src/postgres/postgres-queue-backend.ts
+++ b/src/postgres/postgres-queue-backend.ts
@@ -383,12 +383,11 @@ export class PostgresQueueBackend
     // PostgreSQL analogue of Redis `CLIENT SETNAME`. This is the long-lived
     // connection a worker / QueueEvents holds, so it appears (under this name)
     // in pg_stat_activity and is therefore discoverable by getWorkers /
-    // getQueueEvents via getClientList.
+    // getQueueEvents via getClientList. The connection remembers the name and
+    // re-applies it whenever it has to rebuild the LISTEN client (a fresh
+    // connection would otherwise start unnamed, i.e. undiscoverable).
     await this.connection.waitUntilReady();
-    const client = await this.connection.getListenClient();
-    await client.query(`SELECT set_config('application_name', $1, false)`, [
-      name,
-    ]);
+    await this.connection.setListenClientName(name);
   }
 
   /**
@@ -406,9 +405,15 @@ export class PostgresQueueBackend
    * instead of re-polling every 10s (important for serverless Postgres that
    * suspends when idle). 3600s stays well under the 32-bit `setTimeout` ms
    * ceiling (~24.8 days) that a larger delay would overflow.
+   *
+   * This relies on a dropped LISTEN connection being *detected* (TCP keepalive)
+   * and rebuilt; when keepalive could not be enabled — a user-supplied
+   * `pg.Pool` configured without it, whose checked-out client we could not
+   * adjust — a silent drop would go unnoticed for the whole block, so the
+   * ceiling stays at the conservative Redis-like 10s instead.
    */
   get maximumBlockTimeout(): number {
-    return 3600;
+    return this.connection.hasListenClientKeepAlive ? 3600 : 10;
   }
 
   forQueue(queueName: string, _prefix?: string): IQueueBackend {

--- a/src/postgres/postgres-queue-backend.ts
+++ b/src/postgres/postgres-queue-backend.ts
@@ -310,6 +310,19 @@ export class PostgresQueueBackend
       this.connection.on('error', err => this.emit('error', err));
       this.connection.on('ready', () => this.emit('ready'));
       this.connection.on('close', () => this.emit('close'));
+
+      // When the shared LISTEN client drops, the connection rebuilds it and
+      // emits `'listenerinvalidated'`. Re-issue our LISTENs on the fresh client
+      // and wake any in-flight wait (parked on the now-dead client) so the
+      // worker loop re-enters waitForJob/readEvents and re-subscribes. Only the
+      // connection-owning backend blocks (and thus LISTENs); non-owning
+      // `forQueue` siblings never do.
+      this.connection.on('listenerinvalidated', () => {
+        this.listening = false;
+        this.listeningEvents = false;
+        this.cancelWait?.();
+        this.cancelEventWait?.();
+      });
     }
   }
 
@@ -384,6 +397,18 @@ export class PostgresQueueBackend
    */
   get minimumBlockTimeout(): number {
     return 0.001;
+  }
+
+  /**
+   * PostgreSQL `LISTEN`/`NOTIFY` keeps the connection open and re-arms the wait
+   * to the next due delayed job, so there is no cheap-reconnect reason to cap
+   * the block at 10s like Redis. A large ceiling lets an idle worker go quiet
+   * instead of re-polling every 10s (important for serverless Postgres that
+   * suspends when idle). 3600s stays well under the 32-bit `setTimeout` ms
+   * ceiling (~24.8 days) that a larger delay would overflow.
+   */
+  get maximumBlockTimeout(): number {
+    return 3600;
   }
 
   forQueue(queueName: string, _prefix?: string): IQueueBackend {

--- a/tests/postgres-listen-client-recovery.test.ts
+++ b/tests/postgres-listen-client-recovery.test.ts
@@ -1,0 +1,172 @@
+import { EventEmitter } from 'events';
+import { describe, expect, it, vi } from 'vitest';
+import { PostgresConnection } from '../src/postgres/postgres-connection';
+import { PostgresQueueBackend } from '../src/postgres/postgres-queue-backend';
+
+/**
+ * DB-independent unit tests for the dedicated `LISTEN` client recovery path
+ * (the latent risk uncovered while delegating `maximumBlockTimeout`).
+ *
+ * A `LISTEN` subscription lives on one specific connection. If that connection
+ * drops silently, the memoized client is dead and every re-`LISTEN` on it is
+ * lost — so a worker could stop receiving NOTIFYs until its next poll. With the
+ * Postgres `maximumBlockTimeout` now up to an hour, that window is far too long,
+ * so a dropped LISTEN client must be detected (keepAlive) and rebuilt.
+ *
+ * These drive the logic with fakes (no `pg`, no database).
+ */
+
+class FakeStandaloneClient extends EventEmitter {
+  connect = vi.fn().mockResolvedValue(undefined);
+  query = vi.fn().mockResolvedValue({ rows: [] });
+  end = vi.fn().mockResolvedValue(undefined);
+
+  constructor(public readonly config: any) {
+    super();
+  }
+}
+
+/**
+ * Builds a `PostgresConnection` instance wired to a fake `pg` module so the
+ * standalone `LISTEN` client path can be exercised without a real database.
+ */
+function makeStandaloneConnection(): {
+  connection: PostgresConnection;
+  createdClients: FakeStandaloneClient[];
+} {
+  const connection = Object.create(
+    PostgresConnection.prototype,
+  ) as PostgresConnection;
+  EventEmitter.call(connection);
+
+  const createdClients: FakeStandaloneClient[] = [];
+  const anyConn = connection as any;
+  class ClientCtor extends FakeStandaloneClient {
+    constructor(config: any) {
+      super(config);
+      createdClients.push(this);
+    }
+  }
+  anyConn.pgModule = { Client: ClientCtor };
+  anyConn.listenClientConfig = { connectionString: 'postgres://fake/db' };
+  anyConn.listenClientPromise = undefined;
+  anyConn.listenClient = undefined;
+  anyConn.listenClientIsStandalone = false;
+  anyConn.closing = undefined;
+
+  return { connection, createdClients };
+}
+
+describe('PostgresConnection LISTEN client recovery', () => {
+  it('enables TCP keepAlive on the dedicated standalone LISTEN client', async () => {
+    const { connection, createdClients } = makeStandaloneConnection();
+
+    await connection.getListenClient();
+
+    expect(createdClients).toHaveLength(1);
+    expect(createdClients[0].config).toMatchObject({ keepAlive: true });
+  });
+
+  it('invalidates the memoized client and rebuilds it after a fatal error', async () => {
+    const { connection, createdClients } = makeStandaloneConnection();
+
+    const first = await connection.getListenClient();
+    expect(createdClients).toHaveLength(1);
+
+    // The dedicated connection drops (surfaced as a socket 'error').
+    first.emit('error', new Error('connection terminated unexpectedly'));
+
+    // The broken standalone client is torn down...
+    expect(
+      (first as unknown as FakeStandaloneClient).end,
+    ).toHaveBeenCalledTimes(1);
+
+    // ...and the next request establishes a brand new client.
+    const second = await connection.getListenClient();
+    expect(createdClients).toHaveLength(2);
+    expect(second).not.toBe(first);
+  });
+
+  it('emits "listenerinvalidated" when the LISTEN client dies', async () => {
+    const { connection } = makeStandaloneConnection();
+    const onInvalidated = vi.fn();
+    connection.on('listenerinvalidated', onInvalidated);
+
+    const client = await connection.getListenClient();
+    client.emit('error', new Error('boom'));
+
+    expect(onInvalidated).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a stale error from an already-replaced client', async () => {
+    const { connection, createdClients } = makeStandaloneConnection();
+
+    const first = await connection.getListenClient();
+    first.emit('error', new Error('first drop'));
+    const second = await connection.getListenClient();
+    expect(createdClients).toHaveLength(2);
+
+    const onInvalidated = vi.fn();
+    connection.on('listenerinvalidated', onInvalidated);
+
+    // A late error from the already-discarded first client must not touch the
+    // current (second) client's memo.
+    first.emit('error', new Error('late duplicate drop'));
+
+    expect(onInvalidated).not.toHaveBeenCalled();
+    const third = await connection.getListenClient();
+    expect(third).toBe(second);
+    expect(createdClients).toHaveLength(2);
+  });
+
+  it('does not invalidate while the connection is closing', async () => {
+    const { connection, createdClients } = makeStandaloneConnection();
+
+    const client = await connection.getListenClient();
+    (connection as any).closing = Promise.resolve();
+
+    const onInvalidated = vi.fn();
+    connection.on('listenerinvalidated', onInvalidated);
+
+    client.emit('error', new Error('drop during close'));
+
+    expect(onInvalidated).not.toHaveBeenCalled();
+    // The in-flight close() owns teardown, so the error handler must not end it.
+    expect(
+      (client as unknown as FakeStandaloneClient).end,
+    ).not.toHaveBeenCalled();
+  });
+});
+
+describe('PostgresQueueBackend LISTEN client recovery', () => {
+  it('re-subscribes and wakes the blocking wait when the LISTEN client is invalidated', () => {
+    const connection = new EventEmitter() as unknown as PostgresConnection;
+    (connection as any).schema = 'bullmq';
+
+    const backend = new PostgresQueueBackend(
+      connection,
+      'test-queue',
+      {} as any,
+      true,
+    );
+
+    const anyBackend = backend as any;
+    anyBackend.listening = true;
+    anyBackend.listeningEvents = true;
+    const cancelWait = vi.fn();
+    const cancelEventWait = vi.fn();
+    anyBackend.cancelWait = cancelWait;
+    anyBackend.cancelEventWait = cancelEventWait;
+
+    connection.emit('listenerinvalidated');
+
+    // Flags reset so the next ensureListening/ensureListeningEvents re-issues
+    // LISTEN on the freshly rebuilt client...
+    expect(anyBackend.listening).toBe(false);
+    expect(anyBackend.listeningEvents).toBe(false);
+    // ...and any in-flight wait (parked on the dead client) is woken so the
+    // worker loop re-enters waitForJob/readEvents.
+    expect(cancelWait).toHaveBeenCalledTimes(1);
+    expect(cancelEventWait).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/postgres-listen-client-recovery.test.ts
+++ b/tests/postgres-listen-client-recovery.test.ts
@@ -57,6 +57,39 @@ function makeStandaloneConnection(): {
   return { connection, createdClients };
 }
 
+/**
+ * Builds a `PostgresConnection` wired to a fake user-supplied `pg.Pool`, whose
+ * checked-out client exposes (or not) an underlying socket.
+ */
+function makePooledConnection({ withSocket = true } = {}): {
+  connection: PostgresConnection;
+  socket: { setKeepAlive: ReturnType<typeof vi.fn> };
+} {
+  const connection = Object.create(
+    PostgresConnection.prototype,
+  ) as PostgresConnection;
+  EventEmitter.call(connection);
+
+  const socket = { setKeepAlive: vi.fn() };
+  class FakePoolClient extends EventEmitter {
+    query = vi.fn().mockResolvedValue({ rows: [] });
+    release = vi.fn();
+    connection = withSocket ? { stream: socket } : undefined;
+  }
+
+  const anyConn = connection as any;
+  anyConn.pgModule = undefined;
+  anyConn.listenClientConfig = undefined;
+  anyConn.listenClientPromise = undefined;
+  anyConn.listenClient = undefined;
+  anyConn.listenClientIsStandalone = false;
+  anyConn.listenClientKeepAlive = false;
+  anyConn.closing = undefined;
+  anyConn.pool = { connect: async () => new FakePoolClient() };
+
+  return { connection, socket };
+}
+
 describe('PostgresConnection LISTEN client recovery', () => {
   it('enables TCP keepAlive on the dedicated standalone LISTEN client', async () => {
     const { connection, createdClients } = makeStandaloneConnection();
@@ -65,6 +98,40 @@ describe('PostgresConnection LISTEN client recovery', () => {
 
     expect(createdClients).toHaveLength(1);
     expect(createdClients[0].config).toMatchObject({ keepAlive: true });
+    expect(connection.hasListenClientKeepAlive).toBe(true);
+  });
+
+  it('enables TCP keepAlive on a client checked out of a user-supplied pool', async () => {
+    const { connection, socket } = makePooledConnection();
+
+    await connection.getListenClient();
+
+    expect(socket.setKeepAlive).toHaveBeenCalledWith(true, expect.any(Number));
+    expect(connection.hasListenClientKeepAlive).toBe(true);
+  });
+
+  it('reports no keepalive when a pooled client socket cannot be adjusted', async () => {
+    const { connection } = makePooledConnection({ withSocket: false });
+
+    await connection.getListenClient();
+
+    // The backend must then fall back to a conservative block timeout.
+    expect(connection.hasListenClientKeepAlive).toBe(false);
+  });
+
+  it('re-applies the LISTEN client name after the client is rebuilt', async () => {
+    const { connection, createdClients } = makeStandaloneConnection();
+
+    await connection.setListenClientName('worker-name');
+    const first = await connection.getListenClient();
+    first.emit('error', new Error('drop'));
+
+    const second = (await connection.getListenClient()) as FakeStandaloneClient;
+    expect(createdClients).toHaveLength(2);
+    expect(second.query).toHaveBeenCalledWith(
+      `SELECT set_config('application_name', $1, false)`,
+      ['worker-name'],
+    );
   });
 
   it('invalidates the memoized client and rebuilds it after a fatal error', async () => {
@@ -168,5 +235,30 @@ describe('PostgresQueueBackend LISTEN client recovery', () => {
     // worker loop re-enters waitForJob/readEvents.
     expect(cancelWait).toHaveBeenCalledTimes(1);
     expect(cancelEventWait).toHaveBeenCalledTimes(1);
+  });
+
+  it('caps maximumBlockTimeout when the LISTEN connection has no keepalive', () => {
+    const connection = new EventEmitter() as unknown as PostgresConnection;
+    (connection as any).schema = 'bullmq';
+    (connection as any).listenClientKeepAlive = true;
+    Object.defineProperty(connection, 'hasListenClientKeepAlive', {
+      get() {
+        return (this as any).listenClientKeepAlive;
+      },
+    });
+
+    const backend = new PostgresQueueBackend(
+      connection,
+      'test-queue',
+      {} as any,
+      true,
+    );
+
+    expect(backend.maximumBlockTimeout).toBe(3600);
+
+    // Without keepalive a silent drop could go unnoticed for the whole block,
+    // so the ceiling falls back to the conservative Redis-like 10s.
+    (connection as any).listenClientKeepAlive = false;
+    expect(backend.maximumBlockTimeout).toBe(10);
   });
 });

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1321,6 +1321,61 @@ describe('workers', () => {
           await worker.close();
         });
       });
+
+      describe('when blockDelay exceeds the backend maximumBlockTimeout', () => {
+        it("caps the block timeout at the backend's maximumBlockTimeout", async () => {
+          const worker = new Worker(queueName, NoopProc, {
+            connection,
+            prefix,
+            autorun: false,
+          });
+          await worker.waitUntilReady();
+
+          // A blockUntil far enough in the future that blockDelay clearly
+          // exceeds any backend ceiling (100 days). The result must be the
+          // backend-delegated maximum: 10s on Redis, larger on Postgres.
+          const farFuture = Date.now() + 100 * 24 * 60 * 60 * 1000;
+          expect(worker['getBlockTimeout'](farFuture)).toBe(
+            worker.maximumBlockTimeout,
+          );
+
+          await worker.close();
+        });
+      });
+    });
+  });
+
+  describe('when reading maximumBlockTimeout', () => {
+    it('delegates to the backend value', async () => {
+      const worker = new Worker(queueName, NoopProc, {
+        connection,
+        prefix,
+        autorun: false,
+      });
+      await worker.waitUntilReady();
+
+      const backend = worker.getBackend();
+      sandbox.stub(backend, 'maximumBlockTimeout').get(() => 1234);
+
+      expect(worker.maximumBlockTimeout).toBe(1234);
+
+      await worker.close();
+    });
+
+    it('falls back to the default (10s) when the backend does not specify one', async () => {
+      const worker = new Worker(queueName, NoopProc, {
+        connection,
+        prefix,
+        autorun: false,
+      });
+      await worker.waitUntilReady();
+
+      const backend = worker.getBackend();
+      sandbox.stub(backend, 'maximumBlockTimeout').get(() => undefined);
+
+      expect(worker.maximumBlockTimeout).toBe(10);
+
+      await worker.close();
     });
   });
 


### PR DESCRIPTION
maximumBlockTimeout` was a Redis-derived module constant (10s, the BZPOPMIN
ceiling) applied on the backend-shared getBlockTimeout path. On the PostgreSQL
backend this forced an idle worker to re-poll every 10s whenever any delayed
job existed, preventing a serverless Postgres from ever suspending.