### PR TITLE
fix(types): accept null retry strategy

### DIFF
--- a/src/interfaces/redis-options.ts
+++ b/src/interfaces/redis-options.ts
@@ -16,7 +16,7 @@ export interface RedisOptions extends BaseOptions {
   keyPrefix?: string;
   enableOfflineQueue?: boolean;
   maxRetriesPerRequest?: number | null;
-  retryStrategy?: (times: number) => number | void | null;
+  retryStrategy?: ((times: number) => number | void | null) | null;
   lazyConnect?: boolean;
   tls?: any;
   [key: string]: any;


### PR DESCRIPTION
### Port Impact Checklist

- [ ] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?
- [ ] **Rust** – does this change need to be ported or documented in the Rust library?
- [ ] **.NET** – does this change need to be ported or documented in the .NET library?

### Why

ioredis v6 permits `retryStrategy` itself to be `null`. BullMQ's narrower declaration rejects otherwise valid ioredis v6 `RedisOptions` objects.

Fixes #4595.

### How

Allow `null` at the outer `retryStrategy` property level while preserving the existing callback return type.

### Tests

Validated the declaration against the ioredis v6 type reported in #4595. The change is type-only.