### PR TITLE
feat(queue): add getOldestJobTimestamp getter

### DIFF
--- a/src/classes/queue-getters.ts
+++ b/src/classes/queue-getters.ts
@@ -322,6 +322,22 @@ export class QueueGetters<
   }
 
   /**
+   * Returns the ready-timestamp (ms since epoch) of the oldest pending job
+   * across the "wait" state, every priority level currently populated in
+   * the "prioritized" state, and any "delayed" job whose delay has already
+   * elapsed. A job's ready-timestamp is when its `timestamp + delay` has
+   * elapsed, i.e. when it became eligible to run.
+   *
+   * Unlike {@link getCountsPerPriority}, callers don't need to know which
+   * priority levels are in use: the backend discovers them on the fly.
+   *
+   * @returns the timestamp, or null if there are no matching pending jobs.
+   */
+  async getOldestJobTimestamp(): Promise<number | null> {
+    return this.backend.getOldestJobTimestamp();
+  }
+
+  /**
    * Returns the number of jobs in waiting or paused statuses.
    */
   getWaitingCount(): Promise<number> {

--- a/src/classes/redis-queue-backend.ts
+++ b/src/classes/redis-queue-backend.ts
@@ -1345,6 +1345,16 @@ export class RedisQueueBackend extends EventEmitter implements IQueueBackend {
     return await this.execCommand(client, 'getCountsPerPriority', args);
   }
 
+  async getOldestJobTimestamp(): Promise<number | null> {
+    const client = await this.queue.client;
+
+    const result = await this.execCommand(client, 'getOldestJobTimestamp', [
+      this.queue.keys[''],
+    ]);
+
+    return result === null ? null : Number(result);
+  }
+
   protected getDependencyCountsArgs(
     jobId: string,
     types: string[],

--- a/src/commands/getOldestJobTimestamp-1.lua
+++ b/src/commands/getOldestJobTimestamp-1.lua
@@ -1,0 +1,88 @@
+--[[
+  Get the ready-timestamp (ms since epoch) of the oldest pending job across
+  the 'wait' list, every priority level currently populated in the
+  'prioritized' zset, and any 'delayed' job whose delay has already elapsed.
+
+  A job's "ready timestamp" is when its timestamp + delay elapses, i.e. when
+  it becomes eligible to run. For a job that is not yet due, this is a
+  timestamp in the future, so callers computing an "age" from it should clamp
+  to zero rather than treating it as overdue.
+
+  The 'prioritized' zset is scored by priority first (see
+  getPriorityScore.lua: score = priority * 0x100000000 + counter), not by
+  age, so its head/tail don't reveal the oldest job overall - a low-priority
+  job can sit indefinitely behind a stream of fresher high-priority ones.
+  Rather than requiring the caller to know which priority levels are in use
+  (as getCountsPerPriority does) or scanning the whole zset, this walks it
+  one populated priority band at a time: ZRANGEBYSCORE jumps straight to the
+  next band in use (skipping any unused ones in between), and since scores
+  within a band are ascending by insertion order, that same result is
+  already that band's oldest member. Total cost is O(k log n), where k is
+  the number of distinct priority levels actually populated, not the number
+  of jobs.
+
+    Input:
+      KEYS[1] 'prefix'
+
+    Output:
+      the ready timestamp of the oldest matching job, or false if there are
+      none.
+]]
+local rcall = redis.call
+local prefix = KEYS[1]
+local waitKey = prefix .. 'wait'
+local prioritizedKey = prefix .. 'prioritized'
+local delayedKey = prefix .. 'delayed'
+local priorityScoreBand = 0x100000000
+
+local oldestTimestamp = nil
+
+local function considerJobId(jobId)
+  if not jobId then
+    return
+  end
+  local fields = rcall('HMGET', prefix .. jobId, 'timestamp', 'delay')
+  local timestamp = tonumber(fields[1])
+  if not timestamp then
+    return
+  end
+  local readyTimestamp = timestamp + (tonumber(fields[2]) or 0)
+  if oldestTimestamp == nil or readyTimestamp < oldestTimestamp then
+    oldestTimestamp = readyTimestamp
+  end
+end
+
+-- The 'wait' list is FIFO (new jobs pushed to the head), so the tail is the
+-- oldest. Queues that predate BullMQ's dedicated marker key may still have a
+-- deprecated "0:"-prefixed marker entry at the tail; skip over it if so.
+local function oldestWaitingJobId()
+  local jobId = rcall('LINDEX', waitKey, -1)
+  if jobId and string.sub(jobId, 1, 2) == '0:' then
+    return rcall('LINDEX', waitKey, -2)
+  end
+  return jobId
+end
+
+considerJobId(oldestWaitingJobId())
+
+local nextScore = 0
+while true do
+  local found = rcall('ZRANGEBYSCORE', prioritizedKey, nextScore, '+inf',
+    'WITHSCORES', 'LIMIT', 0, 1)
+  if #found == 0 then
+    break
+  end
+  considerJobId(found[1])
+  local priority = math.floor(tonumber(found[2]) / priorityScoreBand)
+  nextScore = (priority + 1) * priorityScoreBand
+end
+
+-- The 'delayed' zset is scored by ready time ascending, so the head is the
+-- most overdue (or the soonest to become ready).
+local delayedIds = rcall('ZRANGE', delayedKey, 0, 0)
+considerJobId(delayedIds[1])
+
+if oldestTimestamp == nil then
+  return false
+end
+return oldestTimestamp

--- a/src/interfaces/queue-backend.ts
+++ b/src/interfaces/queue-backend.ts
@@ -610,6 +610,16 @@ export interface IQueueBackend {
 
   getCountsPerPriority(priorities: number[]): Promise<number[]>;
 
+  /**
+   * Returns the ready-timestamp (ms since epoch) of the oldest pending job
+   * across the "wait" state, every priority level currently populated in
+   * the "prioritized" state, and any "delayed" job whose delay has already
+   * elapsed.
+   *
+   * @returns the timestamp, or null if there are no matching pending jobs.
+   */
+  getOldestJobTimestamp(): Promise<number | null>;
+
   getRanges(
     types: JobType[],
     start?: number,

--- a/src/postgres/commands/get_oldest_job_timestamp.sql
+++ b/src/postgres/commands/get_oldest_job_timestamp.sql
@@ -1,0 +1,10 @@
+-- Ready-timestamp of the oldest pending job for a queue. Param: $1 queue.
+-- A delayed job's ready-timestamp is process_at_ms (when its delay elapses);
+-- for anything else (including prioritized jobs - priority isn't stored in
+-- a separate structure here the way it is in Redis) it's added_at_ms.
+SELECT MIN(
+  CASE WHEN state = 'delayed' THEN process_at_ms ELSE added_at_ms END
+) AS oldest
+FROM job
+WHERE queue = $1
+  AND (state = 'waiting' OR state = 'delayed');

--- a/src/postgres/postgres-queue-backend.ts
+++ b/src/postgres/postgres-queue-backend.ts
@@ -1652,6 +1652,15 @@ export class PostgresQueueBackend
     return rows.map(r => Number(r.cnt));
   }
 
+  async getOldestJobTimestamp(): Promise<number | null> {
+    const { rows } = await this.run<{ oldest: string | null }>(
+      'get_oldest_job_timestamp',
+      [this.queueName],
+    );
+    const oldest = rows[0]?.oldest;
+    return oldest === null || oldest === undefined ? null : Number(oldest);
+  }
+
   async getRanges(
     types: JobType[],
     start = 0,

--- a/tests/getters.redis.test.ts
+++ b/tests/getters.redis.test.ts
@@ -11,7 +11,10 @@
  * directly. That manipulates Redis connection internals with no portable
  * equivalent, so it is scoped to Redis.
  */
-import { getBlockingRedisClient } from './utils/get-redis-client';
+import {
+  getBlockingRedisClient,
+  getRedisClient,
+} from './utils/get-redis-client';
 import {
   describe,
   beforeEach,
@@ -82,6 +85,25 @@ describe('Jobs getters (redis-only)', () => {
         expect(nextWorkers2).toHaveLength(1);
 
         await worker.close();
+      });
+    });
+  });
+
+  describe('.getOldestJobTimestamp', () => {
+    describe('when a deprecated wait-list marker is present', () => {
+      it('skips it and finds the real oldest waiting job behind it', async () => {
+        await queue.waitUntilReady();
+
+        const oldTimestamp = Date.now() - 60_000;
+        await queue.add('old', {}, { timestamp: oldTimestamp });
+
+        // Queues created with very old BullMQ versions could have a "0:"
+        // marker entry at the tail of the wait list (now superseded by a
+        // dedicated marker key). Simulate that legacy layout directly.
+        const client = await getRedisClient(queue);
+        await client.rpush(queue.toKey('wait'), '0:legacy-marker');
+
+        expect(await queue.getOldestJobTimestamp()).toBe(oldTimestamp);
       });
     });
   });

--- a/tests/getters.test.ts
+++ b/tests/getters.test.ts
@@ -947,6 +947,81 @@ describe('Jobs getters', () => {
     });
   });
 
+  describe('.getOldestJobTimestamp', () => {
+    it('returns null when there are no pending jobs', async () => {
+      await queue.waitUntilReady();
+
+      expect(await queue.getOldestJobTimestamp()).toBeNull();
+    });
+
+    it('returns the timestamp of the oldest waiting job', async () => {
+      await queue.waitUntilReady();
+
+      const oldTimestamp = Date.now() - 60_000;
+      await queue.add('old', {}, { timestamp: oldTimestamp });
+      await queue.add('new', {}, { timestamp: Date.now() });
+
+      expect(await queue.getOldestJobTimestamp()).toBe(oldTimestamp);
+    });
+
+    it('returns the ready-timestamp of an overdue delayed job, not its enqueue time', async () => {
+      await queue.waitUntilReady();
+
+      const enqueuedAt = Date.now() - 60_000;
+      await queue.add('delayed', {}, { timestamp: enqueuedAt, delay: 10_000 });
+
+      expect(await queue.getOldestJobTimestamp()).toBe(enqueuedAt + 10_000);
+    });
+
+    it('returns a future ready-timestamp for a delayed job whose delay has not elapsed yet', async () => {
+      await queue.waitUntilReady();
+
+      const enqueuedAt = Date.now();
+      await queue.add(
+        'delayed',
+        {},
+        { timestamp: enqueuedAt, delay: 60 * 60 * 1000 },
+      );
+
+      // The job is still "pending" even though it isn't due yet, so its real
+      // (future) ready-timestamp is returned as-is, like getDelayed() would
+      // return the job itself. Callers computing an "age" should clamp
+      // Date.now() - timestamp to zero themselves.
+      expect(await queue.getOldestJobTimestamp()).toBe(
+        enqueuedAt + 60 * 60 * 1000,
+      );
+    });
+
+    it('finds the oldest job at a lower priority even behind a fresher higher-priority job', async () => {
+      await queue.waitUntilReady();
+
+      const oldTimestamp = Date.now() - 60_000;
+      await queue.add(
+        'stale-low-priority',
+        {},
+        { priority: 2, timestamp: oldTimestamp },
+      );
+      await queue.add(
+        'fresh-high-priority',
+        {},
+        { priority: 1, timestamp: Date.now() },
+      );
+
+      expect(await queue.getOldestJobTimestamp()).toBe(oldTimestamp);
+    });
+
+    it('finds the oldest job across non-contiguous priority levels', async () => {
+      await queue.waitUntilReady();
+
+      const oldTimestamp = Date.now() - 60_000;
+      await queue.add('stale', {}, { priority: 10, timestamp: oldTimestamp });
+      await queue.add('fresh-1', {}, { priority: 1, timestamp: Date.now() });
+      await queue.add('fresh-5', {}, { priority: 5, timestamp: Date.now() });
+
+      expect(await queue.getOldestJobTimestamp()).toBe(oldTimestamp);
+    });
+  });
+
   describe('.getDependencies', () => {
     it('return unprocessed jobs that are dependencies of a given parent job', async () => {
       const flowProducer = new FlowProducer({ connection, prefix });

--- a/tests/postgres/operations.test.ts
+++ b/tests/postgres/operations.test.ts
@@ -334,4 +334,66 @@ describe('PostgreSQL backend operations', () => {
       await backend.close();
     }
   });
+
+  describe('.getOldestJobTimestamp', () => {
+    it('returns null when there are no pending jobs', async () => {
+      const backend = newBackend();
+      try {
+        await backend.waitUntilReady();
+        expect(await backend.getOldestJobTimestamp()).toBeNull();
+      } finally {
+        await backend.close();
+      }
+    });
+
+    it('returns the timestamp of the oldest waiting job', async () => {
+      const backend = newBackend();
+      try {
+        await backend.waitUntilReady();
+        const oldTimestamp = Date.now() - 60_000;
+        await backend.addJob(makeJob({ timestamp: oldTimestamp }), '');
+        await backend.addJob(makeJob({ timestamp: Date.now() }), '');
+
+        expect(await backend.getOldestJobTimestamp()).toBe(oldTimestamp);
+      } finally {
+        await backend.close();
+      }
+    });
+
+    it('returns the ready-timestamp of an overdue delayed job, not its enqueue time', async () => {
+      const backend = newBackend();
+      try {
+        await backend.waitUntilReady();
+        const enqueuedAt = Date.now() - 60_000;
+        await backend.addJob(
+          makeJob({ timestamp: enqueuedAt, delay: 10_000 }),
+          '',
+        );
+
+        expect(await backend.getOldestJobTimestamp()).toBe(enqueuedAt + 10_000);
+      } finally {
+        await backend.close();
+      }
+    });
+
+    it('finds the oldest job at a lower priority even behind a fresher higher-priority job', async () => {
+      const backend = newBackend();
+      try {
+        await backend.waitUntilReady();
+        const oldTimestamp = Date.now() - 60_000;
+        await backend.addJob(
+          makeJob({ timestamp: oldTimestamp, priority: 2 }),
+          '',
+        );
+        await backend.addJob(
+          makeJob({ timestamp: Date.now(), priority: 1 }),
+          '',
+        );
+
+        expect(await backend.getOldestJobTimestamp()).toBe(oldTimestamp);
+      } finally {
+        await backend.close();
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds `queue.getOldestJobTimestamp(): Promise<number | null>`, which returns the ready-timestamp (`timestamp + delay`) of the oldest pending job across the `wait` list, every populated priority level in the `prioritized` zset, and any `delayed` job whose delay has already elapsed. Returns `null` when there's nothing pending.

This directly addresses #3237 ("Queue age (age of oldest job) metric") — a health/SLO signal that's independent of raw queue depth: a queue can be long right after a bulk enqueue and still be perfectly healthy, but a single job that's been sitting for an hour past its priority/delay usually means something's wrong.

## Why not the workaround already suggested on #3237?

That thread's accepted workaround is:

```ts
const [oldestJob] = await queue.getJobs(
  ['wait', 'waiting-children', 'prioritized', 'paused'],
  0, 0, true,
);
```

This is cheap, but for the `prioritized` type it returns the **highest-priority** job, not the oldest one — `prioritized` is a zset ordered by priority first (see `getPriorityScore.lua`), so index `0` ascending is the head of the priority ordering, not the head of the age ordering. In a queue that keeps receiving high-priority work, a low-priority job can sit indefinitely without ever showing up via this method, which is exactly the failure mode this metric exists to catch.

## Approach

For `prioritized`, this walks the zset one *populated* priority band at a time instead of requiring the caller to enumerate priorities (as `getCountsPerPriority` does) or scanning the whole thing:

```
ZRANGEBYSCORE prioritized <startScore> +inf WITHSCORES LIMIT 0 1
```

jumps straight to the next distinct priority level in use (skipping any unused ones in between), and since scores within a band are ascending by insertion order (`priority * 0x100000000 + counter`), that same result is already that band's oldest member — one `O(log n)` lookup does double duty. Setting `startScore = (foundPriority + 1) * BAND` and repeating visits every populated level in `O(k log n)`, where `k` is the number of *distinct priority levels actually in use*, not the job count or the theoretical priority range.

Also handles a legacy edge case: queues created with very old BullMQ versions can still have a deprecated `"0:"`-prefixed marker at the tail of the `wait` list (superseded by the dedicated marker key); the script detects and skips it. Covered by a dedicated test in `getters.redis.test.ts`.

## Backends

Implemented for both:
- **Redis** — the Lua script above (`src/commands/getOldestJobTimestamp-1.lua`).
- **PostgreSQL** — a single `MIN(...)` query (`src/postgres/commands/get_oldest_job_timestamp.sql`); no band-walking needed since priority isn't a separate structure there.

## Testing

- `tests/getters.test.ts` (cross-backend, runs against Redis in CI): empty queue, plain waiting job, overdue delayed job, not-yet-due delayed job, low-priority job behind a fresher high-priority one, and priorities with gaps between them.
- `tests/getters.redis.test.ts`: the deprecated wait-list marker case.
- `tests/postgres/operations.test.ts`: the same core scenarios against the Postgres backend directly.

All new and existing tests pass on both backends locally (`yarn vitest run tests/getters.test.ts tests/getters.redis.test.ts`, and the full `tests/postgres/**` suite against a local PostgreSQL instance).
