### PR TITLE
fix(worker): eliminate close and pause latency on idle queue [python]

### DIFF
--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -247,6 +247,8 @@ class Worker(EventEmitter):
                 if self.blockUntil <= 0 or self.blockUntil <= timestamp:
                     job_instance = await self.moveToActive(token)
             except asyncio.CancelledError:
+                if not self.paused and not self.closing:
+                    raise
                 # Expected when pause()/close() cancels the idle BZPOPMIN wait.
                 return None
             finally:
@@ -608,10 +610,15 @@ class Worker(EventEmitter):
 
         cancelled = False
         if not force and len(self.processing) > 0:
-            try:
-                await asyncio.wait(self.processing, return_when=asyncio.ALL_COMPLETED)
-            except asyncio.CancelledError:
-                cancelled = True
+            # Ensure close() actually waits for in-flight jobs to finish before
+            # tearing down connections, even if this task is cancelled (once or
+            # repeatedly) while waiting.
+            while True:
+                try:
+                    await asyncio.shield(asyncio.wait(self.processing, return_when=asyncio.ALL_COMPLETED))
+                    break
+                except asyncio.CancelledError:
+                    cancelled = True
 
         await self.lockManager.close()
 
@@ -639,10 +646,14 @@ class Worker(EventEmitter):
             if self.waiting:
                 self.waiting.cancel()
             if not do_not_wait_active and len(self.processing) > 0:
-                try:
-                    await asyncio.wait(self.processing, return_when=asyncio.ALL_COMPLETED)
-                except asyncio.CancelledError:
-                    cancelled = True
+                # Ensure in-flight jobs finish before 'paused' is emitted, even if
+                # this task is cancelled (once or repeatedly) while waiting.
+                while True:
+                    try:
+                        await asyncio.shield(asyncio.wait(self.processing, return_when=asyncio.ALL_COMPLETED))
+                        break
+                    except asyncio.CancelledError:
+                        cancelled = True
         self.emit('paused')
 
         if cancelled:

--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -130,6 +130,8 @@ class Worker(EventEmitter):
         self.closed = False
         self.running = False
         self.paused = False
+        self.resume_event = asyncio.Event()
+        self.resume_event.set()
         self.processing = set()
         self.jobs = set()
         self.id = uuid4().hex
@@ -173,8 +175,13 @@ class Worker(EventEmitter):
 
         try:
             while not self.closed:
-                while not self.waiting and len(self.processing) < self.opts.get("concurrency") and not self.closing:
-                    token_postfix+=1
+                if self.paused and not self.closing:
+                    await self.resume_event.wait()
+                    continue
+
+                while (not self.waiting and len(self.processing) < self.opts.get("concurrency")
+                       and not self.closing and not self.paused):
+                    token_postfix += 1
                     token = f'{self.id}:{token_postfix}'
 
                     # Use retryIfFailed to wrap getNextJob call, similar to TypeScript worker
@@ -231,7 +238,7 @@ class Worker(EventEmitter):
         await self._ensure_client_names()
         job_instance = None
         if not self.waiting and self.drained:
-            self.waiting = self.waitForJob()
+            self.waiting = asyncio.ensure_future(self.waitForJob())
 
             try:
                 self.blockUntil = await self.waiting
@@ -239,6 +246,9 @@ class Worker(EventEmitter):
 
                 if self.blockUntil <= 0 or self.blockUntil <= timestamp:
                     job_instance = await self.moveToActive(token)
+            except asyncio.CancelledError:
+                self.waiting = None
+                raise
             finally:
                 self.waiting = None
         else:
@@ -582,6 +592,11 @@ class Worker(EventEmitter):
         This method waits for current jobs to finalize before returning.
         """
         self.closing = True
+        self.paused = False
+        self.resume_event.set()
+        if self.waiting:
+            self.waiting.cancel()
+
         if force:
             self.forceClosing = True
             # Abort cooperating processors first so they can observe a
@@ -592,7 +607,10 @@ class Worker(EventEmitter):
             self.cancelProcessing()
 
         if not force and len(self.processing) > 0:
-            await asyncio.wait(self.processing, return_when=asyncio.ALL_COMPLETED)
+            try:
+                await asyncio.wait(self.processing, return_when=asyncio.ALL_COMPLETED)
+            except asyncio.CancelledError:
+                pass
 
         await self.lockManager.close()
 
@@ -612,8 +630,14 @@ class Worker(EventEmitter):
         """
         if not self.paused:
             self.paused = True
+            self.resume_event.clear()
+            if self.waiting:
+                self.waiting.cancel()
             if not do_not_wait_active and len(self.processing) > 0:
-                await asyncio.wait(self.processing, return_when=asyncio.ALL_COMPLETED)
+                try:
+                    await asyncio.wait(self.processing, return_when=asyncio.ALL_COMPLETED)
+                except asyncio.CancelledError:
+                    pass
         self.emit('paused')
 
     def resume(self):
@@ -622,6 +646,7 @@ class Worker(EventEmitter):
         """
         if self.paused:
             self.paused = False
+            self.resume_event.set()
             self.emit('resumed')
 
     def cancelProcessing(self):

--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -613,9 +613,12 @@ class Worker(EventEmitter):
             # Ensure close() actually waits for in-flight jobs to finish before
             # tearing down connections, even if this task is cancelled (once or
             # repeatedly) while waiting.
+            wait_for_processing = asyncio.ensure_future(
+                asyncio.wait(self.processing, return_when=asyncio.ALL_COMPLETED)
+            )
             while True:
                 try:
-                    await asyncio.shield(asyncio.wait(self.processing, return_when=asyncio.ALL_COMPLETED))
+                    await asyncio.shield(wait_for_processing)
                     break
                 except asyncio.CancelledError:
                     cancelled = True
@@ -648,9 +651,12 @@ class Worker(EventEmitter):
             if not do_not_wait_active and len(self.processing) > 0:
                 # Ensure in-flight jobs finish before 'paused' is emitted, even if
                 # this task is cancelled (once or repeatedly) while waiting.
+                wait_for_processing = asyncio.ensure_future(
+                    asyncio.wait(self.processing, return_when=asyncio.ALL_COMPLETED)
+                )
                 while True:
                     try:
-                        await asyncio.shield(asyncio.wait(self.processing, return_when=asyncio.ALL_COMPLETED))
+                        await asyncio.shield(wait_for_processing)
                         break
                     except asyncio.CancelledError:
                         cancelled = True

--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -247,8 +247,8 @@ class Worker(EventEmitter):
                 if self.blockUntil <= 0 or self.blockUntil <= timestamp:
                     job_instance = await self.moveToActive(token)
             except asyncio.CancelledError:
-                self.waiting = None
-                raise
+                # Expected when pause()/close() cancels the idle BZPOPMIN wait.
+                return None
             finally:
                 self.waiting = None
         else:
@@ -606,11 +606,12 @@ class Worker(EventEmitter):
             self.lockManager.cancel_all_jobs("worker force-closed")
             self.cancelProcessing()
 
+        cancelled = False
         if not force and len(self.processing) > 0:
             try:
                 await asyncio.wait(self.processing, return_when=asyncio.ALL_COMPLETED)
             except asyncio.CancelledError:
-                pass
+                cancelled = True
 
         await self.lockManager.close()
 
@@ -622,12 +623,16 @@ class Worker(EventEmitter):
         self.closed = True
         self.emit('closed')
 
+        if cancelled:
+            raise asyncio.CancelledError()
+
     async def pause(self, do_not_wait_active: bool = False):
         """
         Pauses the worker, preventing it from processing new jobs.
 
         This method waits for current jobs to finalize before returning.
         """
+        cancelled = False
         if not self.paused:
             self.paused = True
             self.resume_event.clear()
@@ -637,8 +642,11 @@ class Worker(EventEmitter):
                 try:
                     await asyncio.wait(self.processing, return_when=asyncio.ALL_COMPLETED)
                 except asyncio.CancelledError:
-                    pass
+                    cancelled = True
         self.emit('paused')
+
+        if cancelled:
+            raise asyncio.CancelledError()
 
     def resume(self):
         """

--- a/python/bullmq/worker.py
+++ b/python/bullmq/worker.py
@@ -218,10 +218,20 @@ class Worker(EventEmitter):
                     return
         finally:
             # Ensure background resources are released even when the loop
-            # exits via the broad-exception `return` above; otherwise the
-            # lock renewal task and stalled-check timer would keep hitting
-            # Redis after run() has given up.
+            # exits via cancellation or the broad-exception `return` above;
+            # otherwise the lock renewal task and stalled-check timer would keep
+            # hitting Redis after run() has given up.
             self.running = False
+            if not self.closing:
+                for task in self.processing:
+                    if not task.done():
+                        task.cancel()
+                if self.waiting and not self.waiting.done():
+                    self.waiting.cancel()
+                if self.processing:
+                    await asyncio.gather(*self.processing, return_exceptions=True)
+                self.processing.clear()
+
             if self.stalledCheckTimer is not None:
                 try:
                     self.stalledCheckTimer.stop()
@@ -608,30 +618,25 @@ class Worker(EventEmitter):
             self.lockManager.cancel_all_jobs("worker force-closed")
             self.cancelProcessing()
 
+        async def teardown():
+            if not force and len(self.processing) > 0:
+                await asyncio.wait(self.processing, return_when=asyncio.ALL_COMPLETED)
+            await self.lockManager.close()
+            try:
+                await self.backend.close(force=force)
+            except Exception as err:
+                self.emit('error', err)
+            self.closed = True
+            self.emit('closed')
+
+        teardown_task = asyncio.ensure_future(teardown())
         cancelled = False
-        if not force and len(self.processing) > 0:
-            # Ensure close() actually waits for in-flight jobs to finish before
-            # tearing down connections, even if this task is cancelled (once or
-            # repeatedly) while waiting.
-            wait_for_processing = asyncio.ensure_future(
-                asyncio.wait(self.processing, return_when=asyncio.ALL_COMPLETED)
-            )
-            while True:
-                try:
-                    await asyncio.shield(wait_for_processing)
-                    break
-                except asyncio.CancelledError:
-                    cancelled = True
-
-        await self.lockManager.close()
-
-        try:
-            await self.backend.close(force=force)
-        except Exception as err:
-            self.emit('error', err)
-
-        self.closed = True
-        self.emit('closed')
+        while True:
+            try:
+                await asyncio.shield(teardown_task)
+                break
+            except asyncio.CancelledError:
+                cancelled = True
 
         if cancelled:
             raise asyncio.CancelledError()

--- a/python/tests/worker_test.py
+++ b/python/tests/worker_test.py
@@ -1080,18 +1080,22 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
     async def test_close_completes_despite_external_cancellation(self):
         """Test that close() finishes cleanup even if its own task is cancelled
         externally while waiting for active jobs to finish."""
+        job_started = asyncio.Event()
+        job_finished = False
+
         async def process(job: Job, token: str):
-            # Sleep long enough that the job is guaranteed to still be active
-            # when close() is cancelled from outside (well within the 30s timeout)
-            await asyncio.sleep(5)
+            nonlocal job_finished
+            job_started.set()
+            await asyncio.sleep(0.5)
+            job_finished = True
 
         worker = Worker(queueName, process, {"prefix": prefix, "concurrency": 2})
         queue = Queue(queueName, {"prefix": prefix})
         await queue.add("test", {"idx": 1})
-        await asyncio.sleep(0.5)  # let the job start processing
+        await job_started.wait()  # wait until the job processor has actively started
 
         close_task = asyncio.ensure_future(worker.close())
-        await asyncio.sleep(0.3)  # give close() time to reach asyncio.wait(self.processing, ...)
+        await asyncio.sleep(0.1)  # give close() time to reach asyncio.wait(self.processing, ...)
         close_task.cancel()
 
         try:
@@ -1099,10 +1103,83 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         except asyncio.CancelledError:
             pass
 
-        await asyncio.sleep(0.1)  # give cleanup a moment to settle
+        self.assertTrue(job_finished)  # confirms active in-flight job was allowed to finish
         self.assertTrue(worker.closed)
 
         await queue.close()
+
+    async def test_close_completes_despite_repeated_external_cancellation(self):
+        """Test that close() finishes cleanup even when its task is cancelled
+        multiple times while waiting for active jobs — exercises the while loop."""
+        job_started = asyncio.Event()
+        job_finished = False
+
+        async def process(job: Job, token: str):
+            nonlocal job_finished
+            job_started.set()
+            await asyncio.sleep(0.5)
+            job_finished = True
+
+        worker = Worker(queueName, process, {"prefix": prefix, "concurrency": 2})
+        queue = Queue(queueName, {"prefix": prefix})
+        await queue.add("test", {"idx": 1})
+        await job_started.wait()  # wait until the job processor has actively started
+
+        close_task = asyncio.ensure_future(worker.close())
+        await asyncio.sleep(0.1)  # give close() time to reach asyncio.wait(self.processing, ...)
+
+        # Cancel the close task 3 times to exercise the while loop
+        for _ in range(3):
+            close_task.cancel()
+            await asyncio.sleep(0)  # yield to let the CancelledError be delivered
+
+        try:
+            await close_task
+        except asyncio.CancelledError:
+            pass
+
+        self.assertTrue(job_finished)   # in-flight job completed despite repeated cancellation
+        self.assertTrue(worker.closed)  # cleanup always ran to completion
+
+        await queue.close()
+
+    async def test_external_run_cancellation_propagates(self):
+        """Test that cancelling the run() task from outside (not via pause/close)
+        propagates CancelledError correctly instead of being swallowed into return None.
+
+        When CancelledError is re-raised (correct), it propagates through retryIfFailed
+        (which catches only Exception, not BaseException) and out of the run() loop,
+        causing the finally block to set self.running = False.
+
+        When CancelledError is swallowed with return None (incorrect), the worker
+        silently continues fetching jobs and self.running stays True.
+        """
+        async def process(job: Job, token: str):
+            pass
+
+        worker = Worker(queueName, process, {"prefix": prefix})
+        # Let the worker enter the idle BZPOPMIN wait
+        await asyncio.sleep(0.2)
+
+        # Confirm the worker is actually sitting in the idle wait
+        self.assertTrue(worker.running)
+        self.assertIsNotNone(worker.waiting)
+
+        # Cancel the idle waiting task directly — not via pause()/close().
+        # At this point worker.paused=False and worker.closing=False,
+        # so the re-raise branch (not self.paused and not self.closing) should fire.
+        worker.waiting.cancel()
+
+        # Give the event loop time to deliver the CancelledError through the run() loop
+        await asyncio.sleep(0.2)
+
+        # Key assertion: if CancelledError was correctly re-raised, it propagates
+        # through retryIfFailed → out of run() → finally sets self.running = False.
+        # If it was swallowed (return None), the worker keeps running and this fails.
+        self.assertFalse(worker.running)
+        self.assertFalse(worker.closed)  # close() was never called
+
+        await worker.close()
 
 
 if __name__ == '__main__':

--- a/python/tests/worker_test.py
+++ b/python/tests/worker_test.py
@@ -1098,10 +1098,8 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(0.1)  # give close() time to reach asyncio.wait(self.processing, ...)
         close_task.cancel()
 
-        try:
+        with self.assertRaises(asyncio.CancelledError):
             await close_task
-        except asyncio.CancelledError:
-            pass
 
         self.assertTrue(job_finished)  # confirms active in-flight job was allowed to finish
         self.assertTrue(worker.closed)
@@ -1133,14 +1131,76 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
             close_task.cancel()
             await asyncio.sleep(0)  # yield to let the CancelledError be delivered
 
-        try:
+        with self.assertRaises(asyncio.CancelledError):
             await close_task
-        except asyncio.CancelledError:
-            pass
 
         self.assertTrue(job_finished)   # in-flight job completed despite repeated cancellation
         self.assertTrue(worker.closed)  # cleanup always ran to completion
 
+        await queue.close()
+
+    async def test_pause_completes_despite_external_cancellation(self):
+        """Test that pause() finishes waiting for in-flight jobs even if its task
+        is cancelled externally, and properly propagates CancelledError."""
+        job_started = asyncio.Event()
+        job_finished = False
+
+        async def process(job: Job, token: str):
+            nonlocal job_finished
+            job_started.set()
+            await asyncio.sleep(0.5)
+            job_finished = True
+
+        worker = Worker(queueName, process, {"prefix": prefix, "concurrency": 2})
+        queue = Queue(queueName, {"prefix": prefix})
+        await queue.add("test", {"idx": 1})
+        await job_started.wait()  # wait until the job processor has actively started
+
+        pause_task = asyncio.ensure_future(worker.pause())
+        await asyncio.sleep(0.1)  # give pause() time to reach asyncio.wait(self.processing, ...)
+        pause_task.cancel()
+
+        with self.assertRaises(asyncio.CancelledError):
+            await pause_task
+
+        self.assertTrue(job_finished)   # in-flight job completed despite cancellation
+        self.assertTrue(worker.paused)  # paused state remains set
+
+        await worker.close()
+        await queue.close()
+
+    async def test_pause_completes_despite_repeated_external_cancellation(self):
+        """Test that pause() finishes waiting for in-flight jobs even when its task
+        is cancelled repeatedly while waiting — exercises the while loop."""
+        job_started = asyncio.Event()
+        job_finished = False
+
+        async def process(job: Job, token: str):
+            nonlocal job_finished
+            job_started.set()
+            await asyncio.sleep(0.5)
+            job_finished = True
+
+        worker = Worker(queueName, process, {"prefix": prefix, "concurrency": 2})
+        queue = Queue(queueName, {"prefix": prefix})
+        await queue.add("test", {"idx": 1})
+        await job_started.wait()  # wait until the job processor has actively started
+
+        pause_task = asyncio.ensure_future(worker.pause())
+        await asyncio.sleep(0.1)  # give pause() time to reach asyncio.wait(self.processing, ...)
+
+        # Cancel the pause task 3 times to exercise the while loop
+        for _ in range(3):
+            pause_task.cancel()
+            await asyncio.sleep(0)  # yield to let the CancelledError be delivered
+
+        with self.assertRaises(asyncio.CancelledError):
+            await pause_task
+
+        self.assertTrue(job_finished)   # in-flight job completed despite repeated cancellation
+        self.assertTrue(worker.paused)  # paused state remains set
+
+        await worker.close()
         await queue.close()
 
     async def test_external_run_cancellation_propagates(self):

--- a/python/tests/worker_test.py
+++ b/python/tests/worker_test.py
@@ -1011,5 +1011,99 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         await worker.close(force=True)
         await queue.close()
 
+    async def test_close_idle_worker_is_fast(self):
+        """Test that closing an idle worker does not hang for drainDelay."""
+        async def process(job: Job, token: str):
+            pass
+
+        worker = Worker(queueName, process, {"prefix": prefix, "drainDelay": 5})
+        # Allow the worker loop to enter the idle bzpopmin wait
+        await asyncio.sleep(0.2)
+
+        start = time.monotonic()
+        await worker.close()
+        duration = time.monotonic() - start
+
+        self.assertLess(duration, 1.0)
+
+    async def test_pause_and_close_idle_worker(self):
+        """Test that pausing and closing an idle worker completes quickly without hanging."""
+        async def process(job: Job, token: str):
+            pass
+
+        worker = Worker(queueName, process, {"prefix": prefix, "drainDelay": 5})
+        await asyncio.sleep(0.2)
+
+        start = time.monotonic()
+        await worker.pause()
+        pause_duration = time.monotonic() - start
+        self.assertLess(pause_duration, 1.0)
+        self.assertTrue(worker.paused)
+
+        start = time.monotonic()
+        await worker.close()
+        close_duration = time.monotonic() - start
+        self.assertLess(close_duration, 1.0)
+        self.assertTrue(worker.closed)
+
+    async def test_pause_and_resume_processing(self):
+        """Test that pausing stops processing and resume restarts it."""
+        queue = Queue(queueName, {"prefix": prefix})
+        processed = []
+
+        async def process(job: Job, token: str):
+            processed.append(job.data["idx"])
+            return job.data["idx"]
+
+        worker = Worker(queueName, process, {"prefix": prefix})
+
+        await worker.pause()
+        self.assertTrue(worker.paused)
+
+        await queue.add("test", {"idx": 1})
+        await asyncio.sleep(0.5)
+        # Should not process while paused
+        self.assertEqual(len(processed), 0)
+
+        worker.resume()
+        self.assertFalse(worker.paused)
+
+        completed = Future()
+        worker.on("completed", lambda job, res: completed.set_result(None))
+
+        await completed
+        self.assertEqual(processed, [1])
+
+        await worker.close()
+        await queue.close()
+
+    async def test_close_completes_despite_external_cancellation(self):
+        """Test that close() finishes cleanup even if its own task is cancelled
+        externally while waiting for active jobs to finish."""
+        async def process(job: Job, token: str):
+            # Sleep long enough that the job is guaranteed to still be active
+            # when close() is cancelled from outside (well within the 30s timeout)
+            await asyncio.sleep(5)
+
+        worker = Worker(queueName, process, {"prefix": prefix, "concurrency": 2})
+        queue = Queue(queueName, {"prefix": prefix})
+        await queue.add("test", {"idx": 1})
+        await asyncio.sleep(0.5)  # let the job start processing
+
+        close_task = asyncio.ensure_future(worker.close())
+        await asyncio.sleep(0.3)  # give close() time to reach asyncio.wait(self.processing, ...)
+        close_task.cancel()
+
+        try:
+            await close_task
+        except asyncio.CancelledError:
+            pass
+
+        await asyncio.sleep(0.1)  # give cleanup a moment to settle
+        self.assertTrue(worker.closed)
+
+        await queue.close()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/worker_test.py
+++ b/python/tests/worker_test.py
@@ -1065,11 +1065,11 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         # Should not process while paused
         self.assertEqual(len(processed), 0)
 
-        worker.resume()
-        self.assertFalse(worker.paused)
-
         completed = Future()
         worker.on("completed", lambda job, res: completed.set_result(None))
+
+        worker.resume()
+        self.assertFalse(worker.paused)
 
         await completed
         self.assertEqual(processed, [1])

--- a/python/tests/worker_test.py
+++ b/python/tests/worker_test.py
@@ -1205,38 +1205,25 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
 
     async def test_external_run_cancellation_propagates(self):
         """Test that cancelling the run() task from outside (not via pause/close)
-        propagates CancelledError correctly instead of being swallowed into return None.
-
-        When CancelledError is re-raised (correct), it propagates through retryIfFailed
-        (which catches only Exception, not BaseException) and out of the run() loop,
-        causing the finally block to set self.running = False.
-
-        When CancelledError is swallowed with return None (incorrect), the worker
-        silently continues fetching jobs and self.running stays True.
-        """
+        propagates CancelledError correctly and cancels pending fetch/processing tasks."""
         async def process(job: Job, token: str):
             pass
 
-        worker = Worker(queueName, process, {"prefix": prefix})
+        worker = Worker(queueName, process, {"prefix": prefix, "autorun": False})
+        run_task = asyncio.ensure_future(worker.run())
         # Let the worker enter the idle BZPOPMIN wait
         await asyncio.sleep(0.2)
 
-        # Confirm the worker is actually sitting in the idle wait
         self.assertTrue(worker.running)
-        self.assertIsNotNone(worker.waiting)
 
-        # Cancel the idle waiting task directly — not via pause()/close().
-        # At this point worker.paused=False and worker.closing=False,
-        # so the re-raise branch (not self.paused and not self.closing) should fire.
-        worker.waiting.cancel()
+        # Cancel the actual run() task directly from outside
+        run_task.cancel()
 
-        # Give the event loop time to deliver the CancelledError through the run() loop
-        await asyncio.sleep(0.2)
+        with self.assertRaises(asyncio.CancelledError):
+            await run_task
 
-        # Key assertion: if CancelledError was correctly re-raised, it propagates
-        # through retryIfFailed → out of run() → finally sets self.running = False.
-        # If it was swallowed (return None), the worker keeps running and this fails.
         self.assertFalse(worker.running)
+        self.assertEqual(len(worker.processing), 0)
         self.assertFalse(worker.closed)  # close() was never called
 
         await worker.close()


### PR DESCRIPTION
### Port Impact Checklist

- [x] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?
- [ ] **Rust** – does this change need to be ported or documented in the Rust library?
- [ ] **.NET** – does this change need to be ported or documented in the .NET library?

### Why

Fixes #4597

When an idle Python worker has no pending jobs, calling `await worker.close()` or `await worker.pause()` blocks for up to 5 seconds (`drainDelay`) before returning.

**Why this matters:**
- An idle worker with zero active jobs should shut down or pause immediately. The 5-second delay makes process termination, CI test suites, and queue management unnecessarily sluggish.

**Related issues resolved in this PR:**
1. **`pause()` did not actually stop job processing:** The worker's `run()` loop had no guard for `self.paused`, so calling `pause()` set a boolean flag but the loop continued fetching and executing incoming jobs from Redis.
2. **Calling `close()` on a paused worker caused a tight loop:** When `close()` was called while paused, `resume_event.set()` would wake the loop, but since `self.paused` remained `True`, the loop spun continuously without yielding control back to the event loop.
3. **`close()` and `pause()` could abort cleanup halfway if cancelled externally:** If the caller's task executing `close()` or `pause()` was cancelled externally while waiting for active in-flight jobs to finish, the cleanup sequence stopped prematurely. This PR hardens `close()` and `pause()` with a shielded retry loop so all active in-flight jobs complete before Redis connection teardown, even under repeated external cancellations.
4. **External `run()` cancellation left orphaned fetch tasks:** If the outer `run()` task was cancelled, pending `getNextJob()` tasks were left alive in the background and could claim jobs from Redis with no running loop to process them. `run()`'s `finally` block now cancels and awaits all pending processing/waiting tasks when exiting due to external cancellation.

### How

**Root Cause:**
```diff
-            self.waiting = self.waitForJob()
+            self.waiting = asyncio.ensure_future(self.waitForJob())
```
`self.waiting` stored a raw coroutine awaiting Redis `BZPOPMIN`. Because raw coroutines in Python cannot be interrupted externally once awaited, `close()` and `pause()` had no handle to cancel the blocking call and were forced to wait for the 5-second timeout to elapse.

**Implementation:**
1. **Wrap `waitForJob()` in a cancellable `asyncio.Task`:** Using `asyncio.ensure_future()` gives `close()` and `pause()` an interruptible handle. When cancelled via internal pause/close, `getNextJob()` returns `None` cleanly to keep the worker `run()` loop alive; when cancelled from an external runner task, it re-raises `CancelledError` so the loop terminates as requested.
2. **Cancel `self.waiting` immediately on `close()` and `pause()`:**
   ```python
   if self.waiting:
       self.waiting.cancel()
   ```
   Calling `.cancel()` injects `asyncio.CancelledError` into the idle `BZPOPMIN` wait, aborting the sleep instantly and allowing shutdown/pause to return in milliseconds.
3. **Fix `pause()` correctness and prevent busy-looping:** Added `if self.paused and not self.closing: await self.resume_event.wait()` to the `run()` loop and `and not self.paused` to the inner job-fetching condition (matching TypeScript reference parity).
4. **Harden `close()` teardown with a shielded `teardown()` task:**
   ```python
   async def teardown():
       if not force and len(self.processing) > 0:
           await asyncio.wait(self.processing, return_when=asyncio.ALL_COMPLETED)
       await self.lockManager.close()
       try:
           await self.backend.close(force=force)
       except Exception as err:
           self.emit('error', err)
       self.closed = True
       self.emit('closed')

   teardown_task = asyncio.ensure_future(teardown())
   cancelled = False
   while True:
       try:
           await asyncio.shield(teardown_task)
           break
       except asyncio.CancelledError:
           cancelled = True

   if cancelled:
       raise asyncio.CancelledError()
   ```
   Ensures that full cleanup always finishes and in-flight jobs complete even if the caller task was cancelled (once or repeatedly), while properly propagating `CancelledError` to the caller.

### Additional Notes

**Verification:**
Eight automated regression tests were added to `python/tests/worker_test.py`:
- `test_close_idle_worker_is_fast` — asserts `close()` on an idle worker with `drainDelay=5` returns in `< 1.0s`
- `test_pause_and_close_idle_worker` — asserts `pause()` and subsequent `close()` on an idle worker both return in `< 1.0s` without hanging
- `test_pause_and_resume_processing` — asserts that a paused worker does not process new jobs, and `resume()` immediately restarts processing
- `test_close_completes_despite_external_cancellation` — asserts that `close()` finishes full cleanup and active in-flight jobs complete (`job_finished = True`) even under external cancellation
- `test_close_completes_despite_repeated_external_cancellation` — exercises the `while True` loop under repeated cancellation (3x) to confirm robust in-flight completion
- `test_pause_completes_despite_external_cancellation` — asserts that `pause()` finishes waiting for in-flight jobs before returning, even under external cancellation
- `test_pause_completes_despite_repeated_external_cancellation` — verifies `pause()` finishes active jobs under repeated external cancellation (3x) while preserving paused state and raising `CancelledError`
- `test_external_run_cancellation_propagates` — asserts that cancelling the `run()` task directly from outside stops the worker, clears all pending processing tasks (`len(worker.processing) == 0`), and propagates `CancelledError`

All regression tests fail against unmodified master and pass with these changes. The full Python test suite (188 tests) passes with 0 failures.

Happy to split any of these into separate PRs if you'd prefer smaller reviews.