### PR TITLE
fix(worker): close when Redis is unreachable

### DIFF
--- a/src/classes/bun-redis-client.ts
+++ b/src/classes/bun-redis-client.ts
@@ -337,7 +337,17 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
     // A duplicate created with a `rawFactory` builds its raw client lazily on
     // the first connect (Bun's native `duplicate()` is async).
     if (!this.raw && this.rawFactory) {
-      this.raw = await this.rawFactory();
+      const raw = await this.rawFactory();
+
+      // disconnect()/quit() cannot cancel the factory promise itself. If it
+      // resolved after final shutdown started, discard the late client before
+      // it can be wired up or open a socket after close() has resolved.
+      if (this.closing) {
+        this._closeRawClient(raw);
+        return;
+      }
+
+      this.raw = raw;
       this.rawFactory = undefined;
       this._setupCallbacks();
     }
@@ -417,20 +427,7 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
     }
   }
 
-  private _closeRaw(): void {
-    // Cancel any pending reconnect
-    if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
-    }
-    this.reconnecting = false;
-
-    // A duplicate closed before it ever connected has no raw client yet.
-    this.rawFactory = undefined;
-    const raw = this.raw;
-    if (!raw) {
-      return;
-    }
+  private _closeRawClient(raw: TClient): void {
     raw.onconnect = () => {};
     raw.onclose = () => {};
     raw.onerror = () => {};
@@ -447,6 +444,22 @@ class BunRedisAdapter<TClient extends BunRedisRawClient>
           // swallow
         }
       });
+    }
+  }
+
+  private _closeRaw(): void {
+    // Cancel any pending reconnect
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.reconnecting = false;
+
+    // A duplicate closed before it ever connected has no raw client yet.
+    this.rawFactory = undefined;
+    const raw = this.raw;
+    if (raw) {
+      this._closeRawClient(raw);
     }
   }
 

--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -191,6 +191,8 @@ export class RedisConnection extends EventEmitter {
 
   private readonly opts: RedisOptions;
   private readonly initializing: Promise<RedisClient>;
+  private readonly closingSignal: Promise<void>;
+  private resolveClosingSignal: () => void;
 
   private version: string;
   protected packageVersion = packageVersion;
@@ -277,6 +279,10 @@ export class RedisConnection extends EventEmitter {
       this.emit('ready');
     };
 
+    this.closingSignal = new Promise(resolve => {
+      this.resolveClosingSignal = resolve;
+    });
+
     this.initializing = this.init();
     this.initializing.catch(err => {
       // Only emit if there is an `error` listener attached. `EventEmitter.emit`
@@ -309,7 +315,10 @@ export class RedisConnection extends EventEmitter {
    * Waits for a redis client to be ready.
    * @param redis - client
    */
-  static async waitUntilReady(client: RedisClient): Promise<void> {
+  static async waitUntilReady(
+    client: RedisClient,
+    closing?: Promise<void>,
+  ): Promise<void> {
     if (client.status === 'ready') {
       return;
     }
@@ -323,7 +332,8 @@ export class RedisConnection extends EventEmitter {
     }
 
     if (client.status === 'wait') {
-      return client.connect();
+      const connecting = client.connect();
+      return closing ? Promise.race([connecting, closing]) : connecting;
     }
 
     if (client.status === 'end') {
@@ -334,7 +344,7 @@ export class RedisConnection extends EventEmitter {
     let handleEnd: () => void;
     let handleError: (e: Error) => void;
     try {
-      await new Promise<void>((resolve, reject) => {
+      const ready = new Promise<void>((resolve, reject) => {
         let lastError: Error;
 
         handleError = (err: Error) => {
@@ -367,6 +377,7 @@ export class RedisConnection extends EventEmitter {
         client.on('end', handleEnd);
         client.once('error', handleError);
       });
+      await (closing ? Promise.race([ready, closing]) : ready);
     } finally {
       client.removeListener('end', handleEnd);
       client.removeListener('error', handleError);
@@ -423,7 +434,11 @@ export class RedisConnection extends EventEmitter {
     this.patchBlockingClusterClient();
 
     if (!this.extraOptions.skipWaitingForReady) {
-      await RedisConnection.waitUntilReady(this._client);
+      await RedisConnection.waitUntilReady(this._client, this.closingSignal);
+    }
+
+    if (this.closing) {
+      return this._client;
     }
 
     this.loadCommands(this.packageVersion);
@@ -758,6 +773,7 @@ export class RedisConnection extends EventEmitter {
       const status = this.status;
       this.status = 'closing';
       this.closing = true;
+      this.resolveClosingSignal();
       this.disableBlockingClusterReconnect();
 
       try {
@@ -766,7 +782,11 @@ export class RedisConnection extends EventEmitter {
           await this.initializing;
         }
         if (!this.extraOptions.shared) {
-          if (status == 'initializing' || force) {
+          const clientIsReady =
+            this._client.status === 'ready' ||
+            (this._client.status === 'connect' && isRedisCluster(this._client));
+
+          if (status == 'initializing' || force || !clientIsReady) {
             // If we have not still connected to Redis, we need to disconnect.
             this._client.disconnect();
             // Suppress any rejection from the in-flight init() so it doesn't

--- a/src/classes/redis-queue-backend.ts
+++ b/src/classes/redis-queue-backend.ts
@@ -409,7 +409,20 @@ export class RedisQueueBackend extends EventEmitter implements IQueueBackend {
    */
   async disconnectBlocking(wait = true): Promise<void> {
     if (this.blockingConnection) {
-      await this.blockingConnection.disconnect(wait);
+      if (wait) {
+        await this.blockingConnection.disconnect(true);
+      } else {
+        // Final worker shutdown must cancel connection initialization and must
+        // not wait for an event from a socketless reconnecting client.
+        await this.blockingConnection.close(true);
+      }
+    }
+
+    if (!wait && this.connection.status === 'initializing') {
+      // A worker that never reached Redis can have its main loop parked on the
+      // regular connection's initialization as well. There cannot be an active
+      // job before that connection becomes ready, so it is safe to close early.
+      await this.connection.close(true);
     }
   }
 

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -1395,11 +1395,12 @@ export class Worker<
    */
   private async whenCurrentJobsFinished(reconnect = true) {
     // The blocking connection is dedicated to bzpopmin, so it is safe to
-    // always disconnect it whenever the main loop is running. Waiting for the
-    // actual disconnect ('end' event) is required to avoid a race where the
-    // bzpopmin call is still in flight when the main loop awaits its result.
+    // always disconnect it whenever the main loop is running. Pause waits for
+    // the actual disconnect ('end' event) before reconnecting to avoid racing
+    // an in-flight bzpopmin. Final shutdown does not reconnect, and must not
+    // wait for an event that a socketless reconnecting client cannot emit.
     if (this.mainLoopRunning) {
-      await this.backend.disconnectBlocking(true);
+      await this.backend.disconnectBlocking(reconnect);
       await this.mainLoopRunning;
     } else {
       reconnect = false;

--- a/tests/bun-redis-client.test.ts
+++ b/tests/bun-redis-client.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { createBunRedisClient } from '../src/classes/bun-redis-client';
+
+describe('BunRedisAdapter', () => {
+  it('discards a duplicate whose factory resolves after final disconnect', async () => {
+    let releaseDuplicate!: () => void;
+    let markDuplicateStarted!: () => void;
+    const duplicateStarted = new Promise<void>(resolve => {
+      markDuplicateStarted = resolve;
+    });
+    const duplicateReleased = new Promise<void>(resolve => {
+      releaseDuplicate = resolve;
+    });
+
+    class FakeRaw {
+      connected = false;
+      connectCalls = 0;
+      onconnect: (() => void) | null = null;
+      onclose: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      async connect() {
+        this.connectCalls++;
+        this.connected = true;
+        this.onconnect?.();
+      }
+
+      close() {
+        this.connected = false;
+      }
+
+      async duplicate() {
+        markDuplicateStarted();
+        await duplicateReleased;
+        return lateRaw;
+      }
+
+      async send() {
+        return null;
+      }
+
+      async get() {
+        return null;
+      }
+
+      async smembers() {
+        return [];
+      }
+
+      async incr() {
+        return 0;
+      }
+    }
+
+    const lateRaw = new FakeRaw();
+    const primary = createBunRedisClient(new FakeRaw() as any);
+    await primary.connect();
+
+    const duplicate = primary.duplicate();
+    await duplicateStarted;
+    duplicate.disconnect();
+    releaseDuplicate();
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(duplicate.status).toBe('end');
+    expect(lateRaw.connectCalls).toBe(0);
+    expect(lateRaw.connected).toBe(false);
+
+    await primary.quit();
+  });
+});

--- a/tests/connection.test.ts
+++ b/tests/connection.test.ts
@@ -577,6 +577,37 @@ describe('RedisConnection', () => {
     });
   });
 
+  describe('close()', () => {
+    it('quits a healthy client orderly', async () => {
+      const client = createMockClusterClient();
+      const connection = new RedisConnection(client as any, {
+        skipVersionCheck: true,
+        skipWaitingForReady: true,
+      });
+      await connection.client;
+
+      await connection.close();
+
+      expect(client.quit.calledOnce).toBe(true);
+      expect(client.disconnect.called).toBe(false);
+    });
+
+    it('disconnects a reconnecting client instead of queuing quit', async () => {
+      const client = createMockClusterClient();
+      const connection = new RedisConnection(client as any, {
+        skipVersionCheck: true,
+        skipWaitingForReady: true,
+      });
+      await connection.client;
+      client.status = 'reconnecting';
+
+      await connection.close();
+
+      expect(client.disconnect.calledOnce).toBe(true);
+      expect(client.quit.called).toBe(false);
+    });
+  });
+
   describe('Queue', () => {
     it('propagates skipWaitingForReady to RedisConnection', () => {
       const queue = new Queue('test', {

--- a/tests/worker-close.test.ts
+++ b/tests/worker-close.test.ts
@@ -1,0 +1,99 @@
+import { AddressInfo, createServer } from 'net';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Worker } from '../src/classes';
+import {
+  getBlockingRedisConnection,
+  getRedisConnection,
+} from './utils/get-redis-client';
+
+describe('Worker close with unreachable Redis', () => {
+  const workers: Worker[] = [];
+
+  afterEach(async () => {
+    await Promise.allSettled(
+      workers.flatMap(worker => {
+        const connection = getRedisConnection(worker);
+        const blockingConnection = getBlockingRedisConnection(worker);
+
+        return [connection.close(true), blockingConnection.close(true)];
+      }),
+    );
+    workers.length = 0;
+  });
+
+  async function getUnusedPort(): Promise<number> {
+    const server = createServer();
+
+    return new Promise((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => {
+        const { port } = server.address() as AddressInfo;
+        server.close(error => (error ? reject(error) : resolve(port)));
+      });
+    });
+  }
+
+  async function createWorkerWithUnreachableRedis(): Promise<Worker> {
+    const port = await getUnusedPort();
+    const worker = new Worker('test-unreachable-redis', async () => {}, {
+      connection: {
+        host: '127.0.0.1',
+        port,
+        maxRetriesPerRequest: 0,
+      },
+    });
+    worker.on('error', () => {});
+    workers.push(worker);
+
+    return worker;
+  }
+
+  async function expectToCloseWithin(
+    worker: Worker,
+    force = false,
+  ): Promise<void> {
+    let timeout: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        worker.close(force),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error('Worker.close() timed out')),
+            2000,
+          );
+        }),
+      ]);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  it.each([
+    { force: false, label: 'gracefully' },
+    { force: true, label: 'forcefully' },
+  ])('closes $label when Redis is unreachable', async ({ force }) => {
+    const worker = await createWorkerWithUnreachableRedis();
+
+    await new Promise(resolve => setTimeout(resolve, 300));
+    await expectToCloseWithin(worker, force);
+
+    expect(getRedisConnection(worker).status).toBe('closed');
+    expect(getBlockingRedisConnection(worker).status).toBe('closed');
+    if (!force) {
+      expect(worker.isRunning()).toBe(false);
+    }
+  });
+
+  it('closes idempotently before the initial connection', async () => {
+    const worker = await createWorkerWithUnreachableRedis();
+
+    await Promise.all([
+      expectToCloseWithin(worker),
+      expectToCloseWithin(worker),
+    ]);
+
+    expect(getRedisConnection(worker).status).toBe('closed');
+    expect(getBlockingRedisConnection(worker).status).toBe('closed');
+  });
+});


### PR DESCRIPTION
### Port Impact Checklist

- [ ] **Python** – does this change need to be ported or documented in the Python library?
- [ ] **Elixir** – does this change need to be ported or documented in the Elixir library?
- [ ] **PHP** – does this change need to be ported or documented in the PHP library?
- [ ] **Rust** – does this change need to be ported or documented in the Rust library?
- [ ] **.NET** – does this change need to be ported or documented in the .NET library?

### Why

When Redis has never been reachable, a worker's blocking client can remain in the `reconnecting` state. Graceful shutdown interrupts the blocking command with `disconnect(true)`, which waits for an `end` or `error` event. A socketless reconnecting client may emit neither event, leaving `Worker.close()` pending indefinitely and keeping the process alive through retry timers.

Fixes #4656.

### How

- Pass the worker's reconnect intent through `whenCurrentJobsFinished()`, preserving the wait-and-reconnect behavior used by `pause()` while using final teardown during `close()`.
- Add a closing signal to `RedisConnection` so shutdown can cancel an in-flight readiness wait.
- Use an immediate disconnect when the underlying client is not actually ready, while preserving orderly `quit()` for healthy connections.
- Close the regular connection early when initial connection setup is also blocking the worker loop.
- Add adapter-agnostic regression coverage for graceful close, forced close, and repeated close before the initial connection, plus unit coverage for healthy and reconnecting client teardown.

### Additional Notes (Optional)

Local verification:

- `corepack yarn build`
- `corepack yarn lint`
- Worker shutdown regression tests with ioredis: 3 passed
- The same regression tests with node-redis: 3 passed
- Bun 1.4.0 regression tests: 3 passed
- RedisConnection healthy/reconnecting close unit tests: 2 passed
- The issue reproduction now resolves `close()` in a few milliseconds and the process exits on its own

Valkey GLIDE 2.5.0 could not be run natively on Windows because the package does not publish a Windows native binding. The dedicated Ubuntu CI job covers that adapter. The full Redis-backed suite is also left to CI because a local Redis service was unavailable.