### PR TITLE
fix(postgres): serialize addLog to prevent duplicate job_log index

### DIFF
--- a/src/postgres/postgres-queue-backend.ts
+++ b/src/postgres/postgres-queue-backend.ts
@@ -73,6 +73,9 @@ function bigintOrUndefined(value: string | null): number | undefined {
 /** Max events fetched per readEvents round-trip. */
 const EVENT_READ_BATCH = 100;
 
+/** Namespaces the `addLog` advisory lock away from the migrator's own lock key. */
+const ADD_LOG_ADVISORY_LOCK_KEY = 0x4c4f4747; // 'LOGG'
+
 /** Strips `undefined` properties so the JSON shape matches the Redis backend. */
 function removeUndefined<T extends Record<string, any>>(obj: T): T {
   for (const key of Object.keys(obj)) {
@@ -1244,13 +1247,9 @@ export class PostgresQueueBackend
     logRow: string,
     keepLogs?: number,
   ): Promise<number> {
-    let rows: { idx: string }[];
+    let idx: number;
     try {
-      ({ rows } = await this.run<{ idx: string }>('add_log', [
-        this.queueName,
-        jobId,
-        logRow,
-      ]));
+      idx = await this.insertLogAtomically(jobId, logRow);
     } catch (err: any) {
       // 23503 = foreign_key_violation: the job no longer exists.
       if (err && err.code === '23503') {
@@ -1258,7 +1257,7 @@ export class PostgresQueueBackend
       }
       throw err;
     }
-    const count = Number(rows[0].idx) + 1;
+    const count = idx + 1;
 
     if (keepLogs && count > keepLogs) {
       await this.run('trim_logs', [this.queueName, jobId, count - keepLogs]);
@@ -1266,6 +1265,42 @@ export class PostgresQueueBackend
     }
 
     return count;
+  }
+
+  // A lock taken inside the same statement as the MAX(idx) read wouldn't help:
+  // under READ COMMITTED, a statement's snapshot is fixed when it starts, before
+  // the lock wait resolves, so a blocked caller can still read stale data. The
+  // lock and the read need to be separate statements on one connection instead.
+  private async insertLogAtomically(
+    jobId: string,
+    logRow: string,
+  ): Promise<number> {
+    const client = await this.connection.pool.connect();
+    try {
+      await client.query('BEGIN');
+      try {
+        await client.query(
+          "SELECT pg_advisory_xact_lock($1, hashtext($2 || ':' || $3))",
+          [ADD_LOG_ADVISORY_LOCK_KEY, this.queueName, jobId],
+        );
+        const { rows } = await client.query<{ idx: string }>(
+          'SELECT COALESCE(MAX(idx) + 1, 0) AS idx FROM job_log WHERE queue = $1 AND job_id = $2',
+          [this.queueName, jobId],
+        );
+        const idx = Number(rows[0].idx);
+        await client.query(
+          'INSERT INTO job_log (queue, job_id, idx, row) VALUES ($1, $2, $3, $4)',
+          [this.queueName, jobId, idx, logRow],
+        );
+        await client.query('COMMIT');
+        return idx;
+      } catch (err) {
+        await client.query('ROLLBACK');
+        throw err;
+      }
+    } finally {
+      client.release();
+    }
   }
 
   async clearLogs(jobId: string, keepLogs?: number): Promise<void> {

--- a/tests/postgres/operations.test.ts
+++ b/tests/postgres/operations.test.ts
@@ -195,6 +195,29 @@ describe('PostgreSQL backend operations', () => {
     }
   });
 
+  it('assigns a unique idx to every log line under concurrent addLog calls', async () => {
+    const backend = newBackend();
+    try {
+      await backend.waitUntilReady();
+      const id = await backend.addJob(makeJob(), '');
+
+      const n = 20;
+      const counts = await Promise.all(
+        Array.from({ length: n }, (_, i) => backend.addLog(id, `line ${i}`)),
+      );
+
+      expect(new Set(counts).size).toBe(n);
+      expect([...counts].sort((a, b) => a - b)).toEqual(
+        Array.from({ length: n }, (_, i) => i + 1),
+      );
+
+      const { count } = await backend.getJobLogs(id, 0, -1, true);
+      expect(count).toBe(n);
+    } finally {
+      await backend.close();
+    }
+  });
+
   it('stores and reads queue metadata', async () => {
     const backend = newBackend();
     try {


### PR DESCRIPTION
Fixes #4682.

I had a job calling `job.log()` several times in a row against the Postgres backend, and it kept failing with `duplicate key value violates unique constraint "job_log_pkey"` partway through - losing log lines with no way to avoid it, since even a fully sequential, awaited caller can still race (the sandbox forwards log messages to the parent without waiting for the previous write, so overlapping inserts happen regardless of how the processor itself is written).

`add_log.sql` picks the next index with a plain `COALESCE((SELECT MAX(idx)+1 ...), 0)` - no lock, so two overlapping inserts for the same job can read the same max and collide. An advisory lock taken earlier in the *same* statement doesn't fix this: under READ COMMITTED, a statement's snapshot is fixed when it starts, before the lock wait resolves, so a caller that was blocked still reads stale data once it's unblocked. I moved `addLog` off the single `.sql` file onto a dedicated connection running an explicit transaction - lock, then a fresh read, then the insert - mirroring the advisory-lock pattern the migrator already uses. Verified with a real 20-way concurrent `addLog` test against a local Postgres, which reproduces the exact reported error on unpatched code and passes cleanly with the fix.

One thing worth flagging: `add_log.sql` itself is unchanged and still has the described race - it's also copied verbatim to the Python/Elixir/.NET ports (per the `copy:sql:*` scripts), so those likely have the same bug and would need their own equivalent fix; I didn't touch it here since the Node backend no longer uses it for this operation and I don't have a way to verify a fix against the other ports.