### PR TITLE
docs: clarify working with batches and real-time updates (#126)

### DIFF
--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -18,6 +18,7 @@
 - [Queues](guide/queues/README.md)
   - [Auto-removal of jobs](guide/queues/auto-removal-of-jobs.md)
   - [Adding jobs in bulk](guide/queues/adding-bulks.md)
+  - [Working with batches](guide/queues/batches.md)
   - [Global Concurrency](guide/queues/global-concurrency.md)
   - [Global Rate Limit](guide/queues/global-rate-limit.md)
   - [Meta](guide/queues/meta.md)

--- a/docs/gitbook/guide/events/README.md
+++ b/docs/gitbook/guide/events/README.md
@@ -57,6 +57,54 @@ The `QueueEvents` class is implemented using [Redis streams](https://redis.io/to
 The event stream is auto-trimmed so that its size does not grow too much, by default it is \~10.000 events, but this can be configured with the `streams.events.maxLen` option.
 {% endhint %}
 
+## Real-time updates
+
+Local `Worker` / `Queue` listeners only see events in the current process.
+`QueueEvents` is the usual building block for **real-time updates** across
+workers: dashboards, websockets, SSE, or another service that must react while
+jobs run.
+
+```typescript
+import { QueueEvents } from 'bullmq';
+
+const queueEvents = new QueueEvents('Paint', { connection });
+
+queueEvents.on('completed', ({ jobId, returnvalue }) => {
+  sendToDashboard({ type: 'completed', jobId, returnvalue });
+});
+
+queueEvents.on('failed', ({ jobId, failedReason }) => {
+  sendToDashboard({ type: 'failed', jobId, failedReason });
+});
+
+queueEvents.on(
+  'progress',
+  ({ jobId, data }: { jobId: string; data: number | object }) => {
+    sendToDashboard({ type: 'progress', jobId, data });
+  },
+);
+```
+
+Publish progress from the worker with `job.updateProgress(...)` (number or
+object). That pairs well with [working with batches](../queues/batches.md)
+when one job represents many items, or when you want a live bar for a long job:
+
+```typescript
+await job.updateProgress({ completed: 3, total: 10 });
+```
+
+Close `QueueEvents` on shutdown so its Redis connection is released:
+
+```typescript
+await queueEvents.close();
+```
+
+{% hint style="info" %}
+For jobs processed with [BullMQ Pro batches](../../bullmq-pro/batches.md),
+worker-local `completed` / `failed` listeners see the wrapper batch job. Use
+`QueueEvents` / `QueueEventsPro` when you need per-job lifecycle events.
+{% endhint %}
+
 ### Manual trim events
 
 In case you need to trim your events manually, you can use **`trimEvents`** method:

--- a/docs/gitbook/guide/queues/batches.md
+++ b/docs/gitbook/guide/queues/batches.md
@@ -1,0 +1,164 @@
+# Working with batches
+
+"Batches" in BullMQ can mean three different things. Pick the API that matches
+the problem you are solving:
+
+| Goal                                                   | Where       | API                                                |
+| ------------------------------------------------------ | ----------- | -------------------------------------------------- |
+| Enqueue many independent jobs efficiently / atomically | Open source | [`Queue.addBulk`](adding-bulks.md)                 |
+| Enqueue many parent/child trees at once                | Open source | [`FlowProducer.addBulk`](../flows/adding-bulks.md) |
+| Process many waiting jobs in **one** worker callback   | BullMQ Pro  | [Pro batches](../../bullmq-pro/batches.md)         |
+
+{% hint style="info" %}
+Worker `concurrency` runs several jobs in parallel, but each processor call still
+receives **one** job. That is not the same as Pro batch processing, where
+`job.getBatch()` returns up to `batch.size` jobs together.
+{% endhint %}
+
+## Add many jobs (`Queue.addBulk`)
+
+Use this when you already have a list of work items and each item should remain
+its own job (own retries, own events, own completion):
+
+```typescript
+import { Queue } from 'bullmq';
+
+const queue = new Queue('invoices', { connection });
+
+const jobs = await queue.addBulk([
+  { name: 'send', data: { invoiceId: 'A-100' } },
+  { name: 'send', data: { invoiceId: 'A-101' } },
+  { name: 'send', data: { invoiceId: 'A-102' } },
+]);
+```
+
+`addBulk` reduces Redis round-trips compared with calling `add` in a loop. See
+[Adding jobs in bulk](adding-bulks.md) for language examples and atomicity notes.
+
+## Add many flows (`FlowProducer.addBulk`)
+
+Use this when each unit of work is a flow (parent + children) and you want to
+create several trees in one call:
+
+```typescript
+import { FlowProducer } from 'bullmq';
+
+const flowProducer = new FlowProducer({ connection });
+
+await flowProducer.addBulk([
+  {
+    name: 'import-file',
+    queueName: 'imports',
+    data: { fileId: 'first.csv' },
+    children: [
+      {
+        name: 'parse',
+        queueName: 'import-steps',
+        data: { fileId: 'first.csv' },
+      },
+      {
+        name: 'index',
+        queueName: 'import-steps',
+        data: { fileId: 'first.csv' },
+      },
+    ],
+  },
+  {
+    name: 'import-file',
+    queueName: 'imports',
+    data: { fileId: 'second.csv' },
+    children: [
+      {
+        name: 'parse',
+        queueName: 'import-steps',
+        data: { fileId: 'second.csv' },
+      },
+      {
+        name: 'index',
+        queueName: 'import-steps',
+        data: { fileId: 'second.csv' },
+      },
+    ],
+  },
+]);
+```
+
+Details: [Adding flows in bulk](../flows/adding-bulks.md).
+
+## Model a batch as a single job
+
+When the items must share one retry / timeout / completion outcome, put them in
+one job payload instead of inventing a custom worker-side batcher:
+
+```typescript
+await queue.add('send-batch', {
+  invoiceIds: ['A-100', 'A-101', 'A-102'],
+});
+```
+
+```typescript
+import { Worker } from 'bullmq';
+
+const worker = new Worker(
+  'invoices',
+  async job => {
+    const invoiceIds: string[] = job.data.invoiceIds;
+
+    for (const [index, invoiceId] of invoiceIds.entries()) {
+      await sendInvoice(invoiceId);
+      await job.updateProgress({
+        completed: index + 1,
+        total: invoiceIds.length,
+      });
+    }
+
+    return { sent: invoiceIds.length };
+  },
+  { connection },
+);
+```
+
+Prefer `addBulk` (or flows) when each item needs independent retries or
+per-item failure tracking.
+
+## Process several jobs in one worker callback (Pro)
+
+Open-source workers always invoke the processor with a single job. Native
+worker-side batches are a [BullMQ Pro](../../bullmq-pro/introduction.md)
+feature:
+
+```typescript
+import { WorkerPro } from '@taskforcesh/bullmq-pro';
+
+const worker = new WorkerPro(
+  'invoices',
+  async job => {
+    const batch = job.getBatch();
+
+    // Example: one bulk DB/API call for the whole batch
+    await sendInvoices(batch.map(batchedJob => batchedJob.data));
+  },
+  {
+    connection,
+    batch: { size: 10 },
+  },
+);
+```
+
+Pro batches have different failure and event semantics (a dummy wrapper job,
+`setAsFailed`, `QueueEventsPro`, `minSize` / `timeout`, group affinity). Read
+[BullMQ Pro: Batches](../../bullmq-pro/batches.md) before enabling them.
+
+## Real-time updates for batched work
+
+Whether you used `addBulk`, a single batch job, or Pro batches, live UIs should
+listen with [`QueueEvents`](../events/README.md#real-time-updates) so one
+process can observe completions and `progress` from every worker.
+
+## Read more
+
+- [Adding jobs in bulk](adding-bulks.md)
+- [Adding flows in bulk](../flows/adding-bulks.md)
+- [Events / real-time updates](../events/README.md#real-time-updates)
+- [Workers: concurrency](../workers/concurrency.md)
+- [BullMQ Pro: Batches](../../bullmq-pro/batches.md)


### PR DESCRIPTION
## Summary

Fixes the long-standing docs gap for IssueHunt-funded [#126](https://github.com/taskforcesh/bullmq/issues/126) ($20): “working with batches” and “real time updates”.

Adds a maintainer-friendly **Queues → Working with batches** page that clearly separates:

1. **OSS producer bulk APIs** — `Queue.addBulk` and `FlowProducer.addBulk` (links to existing guides; does not re-document them)
2. **OSS pattern** — model a logical batch as **one job** payload (shared retry/completion), with `job.updateProgress`
3. **BullMQ Pro** — native worker-side batches via `WorkerPro` + `job.getBatch()` (links to the existing Pro batches guide for failure/event semantics)

Also expands **Events** with a **Real-time updates** section: `QueueEvents` for cross-process dashboards + `updateProgress`, plus a short Pro note that worker-local listeners see the wrapper batch job.

Docs-only. No changelog churn, no invented custom batchers that call `moveToCompleted`/`moveToFailed` with fake tokens.

## Why another PR

Surveyed open competition for #126:

| PR | Gap |
| --- | --- |
| [#3776](https://github.com/taskforcesh/bullmq/pull/3776) | Link-only stub; little guidance |
| [#3863](https://github.com/taskforcesh/bullmq/pull/3863) | Very large AI-style pages; unsafe fake-token batch pattern; deletes changelog / SUMMARY entries |
| [#4602](https://github.com/taskforcesh/bullmq/pull/4602) | Wrong SUMMARY path (`guide/patterns/...` under Patterns); duplicates bulk guides; weak Pro/realtime accuracy |

This PR stays concise, matches current APIs (`@taskforcesh/bullmq-pro`, Pro batches options), and keeps existing v6 API links / Rust examples intact.

## IssueHunt

- Issue: https://github.com/taskforcesh/bullmq/issues/126
- Funded: $20 — https://issuehunt.io/r/taskforcesh/bullmq/issues/126

Closes #126

## Test plan

- [x] `npx prettier@3.8.3 --check` on the three touched/new docs files
- [x] `git diff --check`
- [ ] Spot-check GitBook nav: Queues → Working with batches; Events → Real-time updates anchors