### PR TITLE
fix(worker): backport blocking client recovery to v5.x

### DIFF
--- a/src/classes/redis-connection.ts
+++ b/src/classes/redis-connection.ts
@@ -632,6 +632,9 @@ export class RedisConnection extends EventEmitter {
   async reconnect(): Promise<void> {
     const client = await this.client;
     for (;;) {
+      if (this.closing) {
+        throw new ConnectionClosedError(CONNECTION_CLOSED_ERROR_MSG);
+      }
       if (
         client.status === 'ready' ||
         (client.status === 'connect' && isRedisCluster(client))

--- a/src/classes/worker.ts
+++ b/src/classes/worker.ts
@@ -20,6 +20,7 @@ import {
   DELAY_TIME_1,
   forwardConnectionError,
   isNotConnectionError,
+  isRedisCluster,
   isRedisInstance,
   randomUUID,
 } from '../utils';
@@ -45,6 +46,13 @@ import { LockManager } from './lock-manager';
 
 // 10 seconds is the maximum time a BZPOPMIN can block.
 const maximumBlockTimeout = 10;
+
+function isClientLive(client: RedisClient): boolean {
+  return (
+    client.status === 'ready' ||
+    (client.status === 'connect' && isRedisCluster(client))
+  );
+}
 
 // note: sandboxed processors would also like to define concurrency per process
 // for better resource utilization.
@@ -821,18 +829,39 @@ will never work with more accuracy than 1ms. */
           // We cannot trust that the blocking connection stays blocking forever
           // due to issues in Redis and IORedis, so we will reconnect if we
           // don't get a response in the expected time.
-          timeout = setTimeout(
-            async () => {
-              bclient.disconnect(!this.closing);
-            },
-            blockTimeout * 1000 + 1000,
-          );
+          let timedOut = false;
+          const watchdog = new Promise<null>(resolve => {
+            timeout = setTimeout(
+              () => {
+                timedOut = true;
+                resolve(null);
+              },
+              blockTimeout * 1000 + 1000,
+            );
+          });
 
           this.updateDelays(); // reset delays to avoid reusing same values in next iteration
 
           // Markers should only be used for un-blocking, so we will handle them in this
           // function only.
-          const result = await bclient.bzpopmin(this.keys.marker, blockTimeout);
+          const result = await Promise.race([
+            bclient.bzpopmin(this.keys.marker, blockTimeout),
+            watchdog,
+          ]);
+          if (timedOut && !this.closing) {
+            // Disconnecting a socketless ioredis client cancels its retry timer.
+            // Let it reconnect first, then drop the auto-resent blocking command.
+            if (!isClientLive(bclient)) {
+              await this.blockingConnection.reconnect();
+            }
+            if (isClientLive(bclient) && !this.closing) {
+              // Await the socket close so reconnect cannot observe stale "ready".
+              await this.blockingConnection.disconnect(true);
+              if (!this.closing) {
+                await this.blockingConnection.reconnect();
+              }
+            }
+          }
           if (result) {
             const [, member, score] = result;
 
@@ -854,8 +883,7 @@ will never work with more accuracy than 1ms. */
       if (isNotConnectionError(<Error>error)) {
         this.emit('error', <Error>error);
       }
-      // The watchdog must abort every overdue blocking command, but doing so
-      // during socketless Sentinel resolution can leave ioredis terminally ended.
+      // Recover terminal clients, including failed Sentinel resolution.
       if (!this.closing && bclient.status === 'end') {
         try {
           await bclient.connect();

--- a/tests/connection.test.ts
+++ b/tests/connection.test.ts
@@ -17,6 +17,7 @@ import {
   QueueBase,
   FlowProducer,
   RedisConnection,
+  ConnectionClosedError,
 } from '../src/classes';
 import { randomUUID, removeAllQueueData } from '../src/utils';
 
@@ -494,6 +495,33 @@ describe('RedisConnection', () => {
       await connection.reconnect();
 
       expect(client.connect.calledOnce).toBe(true);
+    });
+
+    it('does not reconnect a closed connection', async () => {
+      const client = createClient('end');
+      const connection = createConnection(client);
+      connection.closing = true;
+
+      await expect(connection.reconnect()).rejects.toBeInstanceOf(
+        ConnectionClosedError,
+      );
+      expect(client.connect.called).toBe(false);
+    });
+
+    it('stops reconnecting when the connection closes while waiting', async () => {
+      const client = createClient('reconnecting');
+      const connection = createConnection(client);
+      const reconnecting = connection.reconnect();
+      const rejected = expect(reconnecting).rejects.toBeInstanceOf(
+        ConnectionClosedError,
+      );
+      await Promise.resolve();
+      connection.closing = true;
+      client.status = 'end';
+      client.emit('end');
+
+      await rejected;
+      expect(client.connect.called).toBe(false);
     });
 
     it.each(['connecting', 'connect', 'reconnecting'])(
@@ -976,6 +1004,110 @@ describe('connection', () => {
     await processing;
     await worker.close();
   });
+
+  it('does not reopen a force-closed worker during blocking watchdog recovery', async () => {
+    const sandbox = sinon.createSandbox();
+    const worker = new Worker(queueName, async () => {}, {
+      autorun: false,
+      connection: {
+        host: redisHost,
+        maxRetriesPerRequest: null,
+        retryStrategy: () => 10000,
+      },
+      prefix,
+      drainDelay: 1,
+    });
+    await worker.waitUntilReady();
+    const blockingConnection = worker['blockingConnection'];
+    const bclient = await blockingConnection.client;
+    const bzpopmin = sandbox.spy(bclient, 'bzpopmin');
+    const reconnect = sandbox.spy(blockingConnection, 'reconnect');
+    const connect = sandbox.spy(bclient, 'connect');
+
+    try {
+      const running = worker.run();
+      await expect.poll(() => bzpopmin.called).toBe(true);
+      bclient.disconnect(true);
+      await expect.poll(() => reconnect.called, { timeout: 5000 }).toBe(true);
+      expect(bclient.status).toBe('reconnecting');
+
+      await worker.close(true);
+      // A socketless disconnect may not emit end; model a late socket-close
+      // event to ensure the pending reconnect cannot reopen the closed client.
+      bclient.emit('end');
+      await running;
+      expect(connect.called).toBe(false);
+      expect(bclient.status).toBe('end');
+      expect(blockingConnection.status).toBe('closed');
+    } finally {
+      sandbox.restore();
+      await worker.close(true);
+    }
+  });
+
+  it.each(['reconnecting', 'ready'])(
+    'keeps processing after the blocking watchdog fires while %s (#4707)',
+    async status => {
+      const sandbox = sinon.createSandbox();
+      let processed = 0;
+      const worker = new Worker(
+        queueName,
+        async () => {
+          processed++;
+        },
+        {
+          autorun: false,
+          connection: {
+            host: redisHost,
+            maxRetriesPerRequest: null,
+            retryStrategy: () => 2500,
+          },
+          prefix,
+          drainDelay: 1,
+        },
+      );
+      const errors: Error[] = [];
+      worker.on('error', error => errors.push(error));
+      await worker.waitUntilReady();
+      const blockingConnection = worker['blockingConnection'];
+      const bclient = await blockingConnection.client;
+      const reconnect = sandbox.spy(blockingConnection, 'reconnect');
+      const bzpopmin = sandbox.stub(bclient, 'bzpopmin').callThrough();
+      if (status === 'ready') {
+        // Model an interrupted command that ioredis silently re-sends forever.
+        bzpopmin.onFirstCall().returns(new Promise(() => {}));
+      }
+
+      try {
+        await queue.add('before', {});
+        const running = worker.run();
+        await expect.poll(() => processed).toBe(1);
+        await expect.poll(() => bzpopmin.called).toBe(true);
+
+        if (status === 'reconnecting') {
+          // Keep ioredis socketless longer than the watchdog's two-second limit.
+          bclient.disconnect(true);
+          await expect.poll(() => bclient.status).toBe('reconnecting');
+        }
+
+        await expect.poll(() => reconnect.called, { timeout: 5000 }).toBe(true);
+        await expect
+          .poll(() => bclient.status, { timeout: 5000 })
+          .toBe('ready');
+        await queue.add('after', {});
+        await expect.poll(() => processed, { timeout: 5000 }).toBe(2);
+        await queue.add('still-processing', {});
+        await expect.poll(() => processed, { timeout: 5000 }).toBe(3);
+        expect(errors).toEqual([]);
+        await worker.close();
+        await running;
+      } finally {
+        sandbox.restore();
+        await worker.close(true);
+      }
+    },
+    20000,
+  );
 
   it('should handle jobs added before and after a redis disconnect', async () => {
     let count = 0;

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1236,7 +1236,10 @@ describe('workers', () => {
   });
 
   describe('when waiting for a job', () => {
-    async function runBlockingConnectionWatchdog(status: string) {
+    async function runBlockingConnectionWatchdog(
+      status: string,
+      isCluster = false,
+    ) {
       const worker = new Worker(queueName, NoopProc, {
         autorun: false,
         connection,
@@ -1244,40 +1247,107 @@ describe('workers', () => {
       });
       await worker.waitUntilReady();
 
-      const disconnect = sandbox.stub();
-      const bclient = {
-        bzpopmin: sandbox.stub().resolves(null),
-        disconnect,
-        status,
-      } as unknown as IRedisClient;
-      const setTimeoutStub = sandbox
-        .stub(global, 'setTimeout')
-        .callsFake(callback => {
-          callback();
-          return 0 as unknown as NodeJS.Timeout;
+      const blockingConnection = worker['blockingConnection'];
+      const bclient = new Proxy(await blockingConnection.client, {
+        get(target, property, receiver) {
+          return property === 'isCluster'
+            ? isCluster
+            : Reflect.get(target, property, receiver);
+        },
+      });
+      const calls: string[] = [];
+      sandbox.stub(bclient, 'status').get(() => status);
+      sandbox.stub(bclient, 'bzpopmin').returns(new Promise(() => {}));
+      const clientDisconnect = sandbox.stub(bclient, 'disconnect');
+      const disconnect = sandbox
+        .stub(blockingConnection, 'disconnect')
+        .callsFake(async wait => {
+          expect(wait).toBe(true);
+          calls.push(`disconnect:${status}`);
+          // A real socket closes asynchronously; reconnect must await it.
+          await new Promise(resolve => setTimeout(resolve, 1));
+          status = 'end';
         });
+      sandbox.stub(blockingConnection, 'reconnect').callsFake(async () => {
+        calls.push(`reconnect:${status}`);
+        status = 'ready';
+      });
+      const clock = sandbox.useFakeTimers({
+        toFake: ['setTimeout', 'clearTimeout'],
+      });
 
       try {
-        await worker['waitForJob'](bclient, 0);
-        return disconnect;
+        let settled = false;
+        const waiting = worker['waitForJob'](bclient, 0).then(result => {
+          settled = true;
+          return result;
+        });
+        await clock.tickAsync(6001);
+        expect(clientDisconnect.called).toBe(false);
+        expect(settled).toBe(true);
+        expect(await waiting).toBe(0);
+        expect(disconnect.calledOnce).toBe(true);
+        expect(status).toBe('ready');
+        return calls;
       } finally {
-        setTimeoutStub.restore();
+        sandbox.restore();
         await worker.close();
       }
     }
 
+    it.each(['wait', 'connecting', 'connect', 'close', 'reconnecting', 'end'])(
+      'waits for a %s blocking client before resetting it',
+      async status => {
+        const calls = await runBlockingConnectionWatchdog(status);
+        expect(calls).toEqual([
+          `reconnect:${status}`,
+          'disconnect:ready',
+          'reconnect:end',
+        ]);
+      },
+    );
+
     it.each([
-      'wait',
-      'connecting',
-      'connect',
-      'ready',
-      'close',
-      'reconnecting',
-      'end',
-      'custom',
-    ])('disconnects a blocking client with status %s', async status => {
-      const disconnect = await runBlockingConnectionWatchdog(status);
-      expect(disconnect.calledOnceWith(true)).toBe(true);
+      ['ready', false],
+      ['connect', true],
+    ] as const)(
+      'awaits socket close before reconnecting a live client (%s, cluster: %s)',
+      async (status, isCluster) => {
+        const calls = await runBlockingConnectionWatchdog(status, isCluster);
+        expect(calls).toEqual([`disconnect:${status}`, 'reconnect:end']);
+      },
+    );
+
+    it('surfaces watchdog recovery errors and retries', async () => {
+      const worker = new Worker(queueName, NoopProc, {
+        autorun: false,
+        connection,
+        prefix,
+      });
+      await worker.waitUntilReady();
+
+      const bclient = await worker['blockingConnection'].client;
+      const error = new Error('watchdog recovery failed');
+      const onError = sandbox.spy();
+      worker.on('error', onError);
+      sandbox.stub(bclient, 'status').value('reconnecting');
+      sandbox.stub(bclient, 'bzpopmin').returns(new Promise(() => {}));
+      sandbox.stub(worker['blockingConnection'], 'reconnect').rejects(error);
+      const workerDelay = sandbox.stub(worker, 'delay').resolves();
+      const clock = sandbox.useFakeTimers({
+        toFake: ['setTimeout', 'clearTimeout'],
+      });
+
+      try {
+        const waiting = worker['waitForJob'](bclient, 0);
+        await clock.tickAsync(6000);
+        expect(await waiting).toBe(Infinity);
+        expect(onError.calledOnceWith(error)).toBe(true);
+        expect(workerDelay.calledOnce).toBe(true);
+      } finally {
+        sandbox.restore();
+        await worker.close();
+      }
     });
 
     it('reconnects a terminal blocking client after a connection error', async () => {


### PR DESCRIPTION
Backport #4586, preserving reconnect timers and awaiting socket
closure before reconnecting. Prevent recovery from reopening closed
connections and add regression coverage.

Fixes #4707
